### PR TITLE
feat: SPEC-0002 diagnostics telemetry (stacked on M1)

### DIFF
--- a/.claude/skills/build-spec/SKILL.md
+++ b/.claude/skills/build-spec/SKILL.md
@@ -57,6 +57,14 @@ Run the built CLI against real behavior (not just unit tests) for each Success c
 checkbox. Check the boxes once verified and set `status: building` while the PR is open —
 `shipped` is flipped only after the human merges (release/archive step).
 
+## 6.5 Docs ride with the feature
+
+Any user-visible change (new flag/command, changed output, new behavior) updates the
+affected docs — README, docs/**, `--help` text — **in the same PR**, never "in a
+follow-up." Then run `/review-docs` on the touched docs (advisory at PR time, but the
+release gate re-runs it as blocking, so fix now). A feature PR with stale docs is an
+incomplete PR.
+
 ## 7. Commit + PR
 
 Conventional commit subject, backticked code terms, bullets for multiple changes. Open

--- a/.claude/skills/build-spec/SKILL.md
+++ b/.claude/skills/build-spec/SKILL.md
@@ -57,6 +57,13 @@ Run the built CLI against real behavior (not just unit tests) for each Success c
 checkbox. Check the boxes once verified and set `status: building` while the PR is open —
 `shipped` is flipped only after the human merges (release/archive step).
 
+## 6.4 Design comes from the lead
+
+If the spec touches a user-visible surface (receipt layout, exported artifacts, docs
+structure, README copy) and lacks a design section, STOP: the lead (Fable-tier model)
+authors the design artifact — mock, layout spec, exact copy — before implementation is
+delegated. Implementers execute designs; they don't invent them.
+
 ## 6.5 Docs ride with the feature
 
 Any user-visible change (new flag/command, changed output, new behavior) updates the

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -25,6 +25,13 @@ Generate the changelog entry from commits since the last tag, grouped by type (`
 `fix`, `chore`, ...). Don't hand-write marketing copy here — this is a factual log (I6:
 facts, not rankings, applies to the project's own changelog too).
 
+## 3.5 Docs panel (blocking)
+
+Run `/review-docs` — the two-lens agent panel (cold-reader simplicity + correctness
+auditor). Any unfixed correctness finding blocks the release; simplicity findings are
+fixed or explicitly waived with a one-line reason in the release notes. No release
+ships docs that a cold reader can't follow or that claim things the code doesn't do.
+
 ## 4. Flip shipped specs from `building` to `shipped`
 
 For every spec under `specs/` at `status: building` whose PR merged into `main` as part

--- a/.claude/skills/review-docs/SKILL.md
+++ b/.claude/skills/review-docs/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: review-docs
+description: "Multi-agent review of user-facing docs (README, docs/**, --help text) for simplicity and correctness. Use before any release, after any feature PR that touched docs, or when asked to review docs."
+trigger: /review-docs
+---
+
+# /review-docs — the docs panel (group review, two lenses)
+
+Docs are product surface. This skill runs **at least two independent agent reviewers in
+separate contexts** — never one agent wearing both hats, never the agent that wrote the
+docs — then consolidates findings and applies fixes.
+
+## Reviewer A — the cold reader (simplicity)
+
+Prompt an agent that has NEVER seen this repo: it gets README.md (and only what the
+README links) and must, in order: (1) say in one sentence what the tool does; (2) run
+the quickstart commands verbatim against a fixture; (3) flag every place it stumbled —
+jargon, missing steps, buried assumptions, anything it had to guess. Length findings
+count: a section a cold reader skips is a section to cut. Deliverable: stumble list +
+the one-sentence comprehension check.
+
+## Reviewer B — the correctness auditor
+
+A separate agent (different context; Codex preferred — different model family) audits
+every claim against the code:
+- Every command/flag in README, docs/**, and `--help` exists and runs with exit 0 on a
+  fixture (execute them — don't eyeball).
+- Every factual claim maps to code (`file:line`) or a test; overclaims are findings
+  (I3: docs never promise more than the code does — "never/always/zero" claims get
+  special scrutiny).
+- Parity surfaces verified: docs/telemetry.md ↔ zod schemas (the SPEC-0002 test),
+  docs/json-schema.md ↔ schema when it exists, help text ↔ args.ts.
+- Stale references: renamed flags, removed commands, dead links, version drift.
+
+## Consolidate, fix, record
+
+Merge both lists, dedupe, apply the accepted fixes (docs edits are cheap — default to
+fixing, not filing), note rejected findings with one-line reasons. Record the panel's
+verdict (reviewers, findings count, fixes applied) in the PR or release notes. Docs
+review is BLOCKING for a release; advisory-but-expected for feature PRs.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -49,7 +49,9 @@ I6 (no ranking language snuck into receipt copy).
 
 Does the diff match the spec it claims to implement — nothing more? Flag unrelated
 refactors, drive-by renames, or scope creep as separate findings, not blockers unless
-they're risky.
+they're risky. **Docs staleness is a finding**: if the diff changes user-visible
+behavior (flags, commands, output) and no README/docs/help update rides in the PR,
+flag it (build-spec 6.5 requires docs in the same PR).
 
 ## 5. Post the review
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -6,10 +6,16 @@ trigger: /review-pr
 
 # /review-pr — the critic (generator ≠ critic)
 
-Run as a **different model family** from whoever built the PR (e.g. Codex reviewing a
-Claude-built PR, or vice versa) — a same-family review tends to share the same blind
-spots as the build. If you built the PR yourself, say so explicitly and flag the review
-as same-author, not independent.
+Run as a **different model family** from whoever built the PR — a same-family review
+tends to share the same blind spots as the build. **For coding PRs the default critic is
+Codex at deep reasoning effort** (maintainer directive 2026-07-02): invoke
+`codex exec --sandbox read-only -C <repo> "<review brief>"` with sections 1–4 below as
+the brief; Codex's reasoning effort should be its deepest available tier for anything
+touching src/. If you built the PR yourself, say so explicitly and flag the review as
+same-author, not independent — then STILL run the Codex pass before merge.
+
+No coding PR merges without a recorded deep review. The review (or its verdict summary)
+is pasted into the PR as a comment so the record survives.
 
 ## 1. Run the gates yourself, silently, unmasked
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — aireceipts constitution
 
-*This file is the operating manual. Reading order when documents disagree: AGENTS.md (process + invariants) → specs/SPEC-0000 (product) → the active spec → the matching skill. ≤150 lines,
+*This file is the operating manual (design rationale: `docs/harness.md`). Reading order when documents disagree: AGENTS.md (process + invariants) → specs/SPEC-0000 (product) → the active spec → the matching skill. ≤150 lines,
 enforced by CI — if you're adding to it, cut something first.*
 
 ## Mission

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -1,0 +1,124 @@
+# The harness — how this repo builds itself
+
+aireceipts is designed, implemented, and maintained mostly by AI coding agents. That is
+not a stunt; it is the constraint the whole repository is engineered around. This
+document explains the machinery (the "harness"), how a change flows through it, and why
+each piece exists. The maintainer's standing job is four buttons — everything else is
+supposed to run under gates that don't trust anyone, human or model.
+
+## Motivation
+
+Agent-written code fails in patterned, well-documented ways, and every structure here
+maps to one of those patterns:
+
+| Failure pattern | Counter-structure |
+|---|---|
+| Agents over-build on vague asks ("over-eagerness") | Interview gate before any spec is drafted |
+| Specs and code drift apart | Spec-under-git is the post-merge truth; `spec-lint` in CI |
+| Plausible-but-wrong specs survive to implementation | S1–S4 validation, incl. an independent critic, **before** approval |
+| Agents game test coverage (assertions weakened to pass) | Mutation testing on the money paths — coverage is advisory, mutation score gates |
+| A model approves its own work (shared blind spots) | Generator ≠ critic, different model families, review recorded |
+| Fabricated facts (prices, dollars, claims) | Hooks + CI reject uncited price data mechanically; invariant I2 bans fallback dollars |
+| Output drift nobody notices | Golden receipts, byte-compared, re-run N× under a frozen environment |
+| Bloated agent context degrades work | AGENTS.md hard-capped at 150 lines; reference, never duplicate |
+| Docs rot behind the code | Docs ride in the feature PR; a two-lens docs panel blocks releases |
+
+The through-line: **never rely on an agent remembering a rule when the rule can be a
+gate.** Discipline that lives in prose gets skipped under pressure; discipline that
+lives in an exit code doesn't.
+
+## The pieces
+
+**The constitution — `AGENTS.md`.** One file, ≤150 lines (CI-enforced), holding the
+mission, the verification commands (identical to CI, so "passed locally" means "passes
+CI"), the file-ownership map, and invariants **I1–I6** (deterministic & offline-complete;
+never fabricate a dollar; every number traceable; diagnostics-only telemetry, disclosed
+and escapable; byte-stable output; facts, never rankings). The invariants are restated in
+every spec and skill — repetition is the point; it is what keeps dozens of independent
+agent sessions from drifting.
+
+**The spec system — `specs/`.** Every change starts as a spec: machine-readable
+frontmatter (`status: draft|approved|building|shipped|rejected|superseded`), numbered
+testable requirements, Given/When/Then scenarios, a test matrix (every requirement must
+have rows — `scripts/spec-lint.mjs` fails the build otherwise), success criteria, and a
+kill criterion. Rejected specs are kept as tombstones with their reasoning: the harness
+treats a well-evidenced *no* as an artifact worth as much as a yes.
+
+**Validation — S1–S4, before approval.** A draft cannot reach the maintainer without a
+recorded validation: **S1** self-audit (is every promised line computable from local
+data? no predictions, no judgment calls dressed as facts), **S2** an independent critic
+in a different model family attacking measurability, feasibility against real code, and
+scope, **S3** a value-gate dry run against the kill criterion, **S4** mechanical lint.
+In this repo's first week the critic returned REWORK on 7 of 13 drafts — every one a
+real catch (wrong quota semantics, an unpriceable adapter claim, a network call hiding
+in an export spec). Approval means approving a spec that already survived attack.
+
+**Skills — one per task type, maintainer-curated.** `.claude/skills/` holds the
+operating procedures: `write-spec`, `validate-spec`, `build-spec`, `review-pr`,
+`review-docs`, `release`, `fix-issue`, `ci-fix`, `improve`, plus the extension-surface
+guides (`add-vendor-adapter`, `add-waste-check`, `update-prices`, `use-aireceipts`).
+Agents cannot add or edit skills — curating this surface is one of the four buttons.
+
+**Milestone builds — agent teams with directory ownership.** Large specs (M-files)
+embed their own team plan: roles own *directories*, never features (no write
+conflicts); work is sliced into dependency waves with one named critical path; shared
+files have exactly one owner. Model assignment is part of the plan: the lead
+(frontier-tier) authors all design/UX artifacts and makes judgment calls; critical-path
+code runs on the strongest coding model; mechanical work may run lighter; deep review
+runs in a different model family. Agents write files but never commit — the lead runs
+the gate and commits at wave boundaries.
+
+**Quality gates — layered, and hostile by design.** Typecheck → lint → tests → golden
+receipts (byte-equal) → property tests → **mutation testing** on `src/pricing/**`
+(fail-closed: pricing code without a mutation config fails CI) → determinism harness
+(goldens re-run ×20 under frozen `NO_COLOR`/TZ/locale) → an eval corpus asserting
+**precision 1.0** for the waste detectors (any false positive fails the build) →
+independent PR review, recorded. Data has its own gates: every price row must carry a
+cited source (a Claude Code hook blocks uncited writes at the tool level; a CI job is
+the authoritative check — the hook is UX, the exit code is law).
+
+**The docs loop.** Any user-visible change updates the docs in the same PR
+(`build-spec` refuses "docs later"). Before a release, `review-docs` runs a two-lens
+panel: a cold reader who has never seen the repo must succeed with the README alone
+(simplicity), and a separate auditor executes every documented command and traces every
+claim to code (correctness). Docs that overclaim are treated as bugs.
+
+**Maintenance loops.** Scheduled work runs on cadences with hard ceilings: daily price
+freshness (one cited PR per vendor), weekly dependency hygiene, label-triggered
+issue→PR runs, and a capped self-improvement loop that must survive an external value
+gate before anything lands. Telemetry's `parse_failure` event is the format-drift
+sensor: when an agent vendor changes its transcript format in the wild, the maintenance
+loop hears about it.
+
+## How a feature flows
+
+```
+idea/issue
+  → write-spec      (interview gate → draft, status: draft)
+  → validate-spec   (S1 self-audit → S2 independent critic → S3 value gate → S4 lint;
+                     record appended; REWORK loops back)
+  → maintainer      (button 1: approve — or don't)
+  → build-spec      (branch; design artifact from the lead if user-visible;
+                     solo or team-waves; gates at every boundary; docs in the same PR)
+  → review-pr       (independent deep review, different model family, recorded)
+  → CI              (the full gate stack incl. mutation + cite-check + spec-lint)
+  → maintainer      (merge)
+  → release         (tag-matches-manifest guard → changelog → docs panel, blocking →
+                     button 4: publish; only this step flips specs to `shipped`)
+```
+
+## The human surface
+
+Four buttons, deliberately few: **(1)** approve or reject validated specs, **(2)**
+one-click cited price-table PRs, **(3)** curate the skill surface, **(4)** cut releases.
+Everything else — building, testing, reviewing, doc-keeping, dependency hygiene, price
+freshness — is the harness's job. When the harness catches its own operator skipping a
+step (it has), that is the system working.
+
+## Lineage
+
+The design distills two working ancestors — a spec-driven repo where agents shipped
+~130 specs under similar invariants, and a milestone/agent-team build system — plus the
+2025–26 evidence on spec-driven development, agent context budgets, mutation testing
+versus coverage, and generator/critic separation. The shortest honest summary of all of
+it: *make the harness, not the promises.*

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,105 @@
+# Diagnostics telemetry
+
+`aireceipts` can send small, anonymous, content-free diagnostics events to help us find bugs and understand which agent formats and CLI paths are actually used in the wild. This document is the full, authoritative description of what is sent, when, and how to turn it off. If anything here ever disagrees with the code in `src/telemetry/`, that's a bug — please file an issue.
+
+## tl;dr
+
+- **On by default**, but every event is one of exactly three fixed-shape records — never transcript content, prompts, file paths, repo names, hostnames, usernames, session IDs, dollar amounts, or raw model strings.
+- **Disable anytime**: `AIRECEIPTS_TELEMETRY=off` (or `0`/`false`) or `DO_NOT_TRACK=1`. Either one results in **zero network calls** — not "send less," zero.
+- **Inspect before you decide**: `aireceipts --telemetry-show` prints exactly what the current run would send, and sends nothing.
+- **Bounded and fail-safe**: sending is capped at 300ms and can never throw, hang the CLI, or change its exit code. A slow or failed network call is simply abandoned.
+- **First-run notice**: the very first time you run `aireceipts`, it prints a one-line disclosure pointing here. It never prints again after that.
+
+## What is sent
+
+There are exactly three event types. Nothing else is ever recorded.
+
+### `cli_run` — one per CLI invocation
+
+| Field | Type | Values | Notes |
+|---|---|---|---|
+| `cliVersion` | string | semver, e.g. `"0.3.1"` | From this package's own `package.json`. |
+| `os` | enum | `darwin` \| `linux` \| `win32` \| `other` | `process.platform`, collapsed to a closed set — never the raw platform string. |
+| `nodeMajor` | integer | e.g. `22` | Major Node version only. |
+| `commandClass` | enum | `receipt` \| `compare` \| `other` | Which subcommand ran — never the raw argv or any flag values. |
+| `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `unknown` | Which agent format was parsed, if known. |
+| `durationBucket` | enum | `<100ms` \| `100-500ms` \| `500ms-2s` \| `2-10s` \| `>10s` | Coarse bucket — never the raw millisecond count. |
+| `ok` | boolean | | Whether the run succeeded. |
+
+### `cli_error` — one per uncaught error at the CLI's top level
+
+| Field | Type | Values | Notes |
+|---|---|---|---|
+| `errorClass` | enum | `parse_error` \| `io_error` \| `network_error` \| `validation_error` \| `unknown_error` | A small fixed taxonomy derived from the error's constructor name or a well-known Node error code — **never `error.message`**, which can contain a file path or other identifying text. |
+| `command` | enum | `receipt` \| `compare` \| `other` | Same closed taxonomy as `cli_run.commandClass`. |
+| `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `unknown` | |
+| `inPackage` | boolean | | Whether the error's top stack frame originated inside `aireceipts`'s own installed code (helps us tell "our bug" from "your environment") — the stack trace text itself is inspected internally and never leaves the process. |
+
+### `parse_failure` — one per transcript-parsing failure
+
+| Field | Type | Values | Notes |
+|---|---|---|---|
+| `agentType` | enum | `claude-code` \| `codex` \| `cursor` | |
+| `adapterVersion` | string | short opaque token, e.g. `"1"` | An internal per-adapter constant, not anything read from a transcript. |
+| `signatureHash` | string | 64-character sha256 hex digest | A hash of a content-free description of *where* parsing broke (e.g. `"claude-code:turn.usage.missing"`). The raw description is hashed before it ever reaches a payload — you cannot recover it from the hash, and it never contains transcript content. |
+
+Every field above is validated against a `zod` schema in `.strict()` mode before it's ever queued (`src/telemetry/schemas.ts`). `.strict()` rejects any payload carrying an extra, unlisted key, so a bug elsewhere in the codebase cannot silently smuggle a new field (a path, a prompt, a dollar amount) into a payload — it would have to be added here, deliberately, and reviewed.
+
+## What is never sent
+
+Permanently, structurally banned — there is no field for any of these anywhere in the schema, and adding one would require an explicit, reviewed change to this document and to `src/telemetry/schemas.ts`:
+
+- Transcript content or any excerpt of it
+- Prompts or any user/assistant message text
+- File paths (yours or the CLI's own, beyond the fixed `inPackage` boolean)
+- Repo names or URLs
+- Hostnames
+- Usernames
+- Session IDs
+- Dollar amounts or any cost/pricing data
+- Raw model strings (only the coarse `agentType` enum is sent)
+
+## Kill switches
+
+Either of the following disables telemetry completely. When disabled, `flushTelemetry()` returns immediately without making any network call — this is verified by tests that stub the network layer and assert it is never invoked.
+
+```bash
+AIRECEIPTS_TELEMETRY=off aireceipts receipt ...
+# or: AIRECEIPTS_TELEMETRY=0 / AIRECEIPTS_TELEMETRY=false (case-insensitive)
+
+DO_NOT_TRACK=1 aireceipts receipt ...
+```
+
+To disable permanently, export one of these in your shell profile.
+
+## Inspecting what would be sent
+
+```bash
+aireceipts --telemetry-show
+```
+
+This prints whether telemetry is currently enabled and the exact events queued for the current run — the same objects that would be sent — without sending anything.
+
+## How sending works
+
+- Events are queued in-process as they occur and sent as a single batched request at CLI shutdown.
+- The send is bounded to **300ms** via `Promise.race` against a timeout. If the network call is slow or hangs, it is abandoned in place; the CLI does not wait for it, and nothing is retried in the background.
+- Every failure mode — telemetry disabled, an invalid event, a network error, a timeout — is swallowed inside the telemetry module. Telemetry can never throw, never block the CLI, and never change its exit code.
+- The transport is Azure Application Insights, reached via a connection string (`InstrumentationKey=...;IngestionEndpoint=https://.../`) POSTed to `<ingestionEndpoint>/v2/track`.
+
+## Connection-string honesty
+
+This section exists so the code and this document can never quietly disagree.
+
+- The ingestion key this package ships with is **not a secret** — Application Insights instrumentation keys are write-only and are commonly embedded in open-source clients. It will be listed here plainly once one is provisioned.
+- **Current status**: no Azure resource has been wired up yet. The shipped default connection string is intentionally **empty**, not a placeholder-that-looks-real. An empty connection string takes the exact same code path as the kill switches: `resolveTelemetryConfig()` reports `enabled: false`, and zero network calls are made. This is deliberate, not a bug — until a real key is provisioned, `aireceipts` sends no telemetry to anyone, full stop, regardless of the kill switches.
+- `AIRECEIPTS_TELEMETRY_CONNECTION` overrides the shipped default. Set it to point at your own Application Insights resource (e.g. for local development or a private fork), or set it to an empty string to force-disable telemetry independent of the kill switches.
+- A malformed connection string (missing either `InstrumentationKey` or `IngestionEndpoint`) also degrades to `enabled: false` rather than sending to an incomplete endpoint.
+
+## First-run notice
+
+The first time `aireceipts` runs for a given user, it prints a one-line disclosure (pointing here) before doing anything else, then persists that fact to `~/.aireceipts/telemetry.json` so it never prints again. If that file can't be read or written (no home directory, read-only filesystem), the notice is simply shown again on the next run rather than the CLI failing.
+
+## Source of truth
+
+The schemas in `src/telemetry/schemas.ts` are the actual source of truth; this document is kept in sync with them by hand and reviewed alongside any change to that file. If you find a discrepancy, please open an issue.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "aireceipts",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
+      },
       "bin": {
         "aireceipts": "dist/cli.js"
       },
@@ -5599,6 +5602,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
   "devDependencies": {
     "@stryker-mutator/core": "^8.7.1",
     "@stryker-mutator/vitest-runner": "^8.7.1",

--- a/specs/TEMPLATE.md
+++ b/specs/TEMPLATE.md
@@ -86,6 +86,8 @@ with it, not the reverse.
 
 ### Team prompt
 
-The exact prompt to paste into Claude Code to spawn the team (roles, model assignment,
+The exact prompt to paste into Claude Code to spawn the team (roles, model assignment —
+**critical-path/core/money-math roles run Opus; mechanical roles (fixtures, boilerplate,
+scaffolds) may run Sonnet** (maintainer directive 2026-07-02),
 what to build first, coordination rule). Keep it self-contained — a fresh lead should be
 able to run it without reading anything else.

--- a/specs/TEMPLATE.md
+++ b/specs/TEMPLATE.md
@@ -88,6 +88,8 @@ with it, not the reverse.
 
 The exact prompt to paste into Claude Code to spawn the team (roles, model assignment —
 **critical-path/core/money-math roles run Opus; mechanical roles (fixtures, boilerplate,
-scaffolds) may run Sonnet** (maintainer directive 2026-07-02),
+scaffolds) may run Sonnet; and any user-visible surface (receipt/artifact layout, docs IA,
+copy) implements a design section authored by the lead (Fable-tier) in this spec — the
+implementer executes the design, never invents it** (maintainer directives 2026-07-02),
 what to build first, coordination rule). Keep it self-contained — a fresh lead should be
 able to run it without reading anything else.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -4,7 +4,7 @@
 // selectors; anything else positional is the session selector for the
 // default receipt command.
 export interface ParsedArgs {
-  command: "receipt" | "list" | "compare" | "handoff" | "help" | "methodology";
+  command: "receipt" | "list" | "compare" | "handoff" | "help" | "methodology" | "telemetry-show";
   selector?: string;
   compareA?: string;
   compareB?: string;
@@ -17,6 +17,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let handoff = false;
   let help = false;
   let methodology = false;
+  let telemetryShow = false;
   const positional: string[] = [];
 
   for (const arg of argv) {
@@ -26,6 +27,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       list = true;
     } else if (arg === "--handoff") {
       handoff = true;
+    } else if (arg === "--telemetry-show") {
+      telemetryShow = true;
     } else if (arg === "--methodology") {
       methodology = true;
     } else if (arg === "--help" || arg === "-h") {
@@ -41,6 +44,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   if (methodology) {
     return { command: "methodology", json };
+  }
+
+  if (telemetryShow) {
+    return { command: "telemetry-show", json };
   }
 
   if (positional[0] === "compare") {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,13 @@ import { summaryToJson, toJsonModel } from "../receipt/json.js";
 import { buildReceiptModel } from "../receipt/model.js";
 import { renderReceipt } from "../receipt/render.js";
 import { METHODOLOGY } from "../pricing/attribution.js";
+import {
+  ensureFirstRunNotice,
+  flushTelemetry,
+  recordCliError,
+  recordCliRun,
+  showTelemetryPayload,
+} from "../telemetry/index.js";
 import { parseArgs } from "./args.js";
 
 const HELP_TEXT = `aireceipts — local, deterministic cost receipts for AI coding-agent sessions
@@ -138,9 +145,11 @@ async function runHandoff(selector: string | undefined): Promise<number> {
   return 0;
 }
 
-export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
-  const args = parseArgs(argv);
+async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
   switch (args.command) {
+    case "telemetry-show":
+      process.stdout.write(JSON.stringify(showTelemetryPayload(process.env), null, 2) + "\n");
+      return 0;
     case "methodology":
       process.stdout.write(METHODOLOGY + "\n");
       return 0;
@@ -156,5 +165,25 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
     case "receipt":
     default:
       return runReceipt(args.selector, args.json);
+  }
+}
+
+/** CLI entrypoint: first-run notice → dispatch → telemetry record → bounded flush (SPEC-0002 wiring). */
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const args = parseArgs(argv);
+  if (args.command !== "telemetry-show") {
+    await ensureFirstRunNotice((text) => process.stderr.write(text + "\n"), undefined);
+  }
+  const started = Date.now();
+  try {
+    const code = await dispatch(args);
+    recordCliRun({ command: args.command, agentType: undefined, durationMs: Date.now() - started, ok: code === 0 });
+    return code;
+  } catch (err) {
+    recordCliError({ command: args.command, agentType: undefined, err });
+    process.stderr.write(String(err instanceof Error ? err.message : err) + "\n");
+    return 1;
+  } finally {
+    await flushTelemetry();
   }
 }

--- a/src/telemetry/config.test.ts
+++ b/src/telemetry/config.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { resolveTelemetryConfig } from "./config.js";
+
+const VALID_CONN = "InstrumentationKey=abc-123;IngestionEndpoint=https://example.in.applicationinsights.azure.com/";
+
+describe("R4: kill switches disable telemetry", () => {
+  it.each(["off", "0", "false", "OFF", "False"])("AIRECEIPTS_TELEMETRY=%s disables telemetry", (value) => {
+    const config = resolveTelemetryConfig({ AIRECEIPTS_TELEMETRY: value, AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN });
+    expect(config).toEqual({ enabled: false, instrumentationKey: undefined, ingestionEndpoint: undefined });
+  });
+
+  it("DO_NOT_TRACK=1 disables telemetry even with a valid connection string", () => {
+    const config = resolveTelemetryConfig({ DO_NOT_TRACK: "1", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN });
+    expect(config.enabled).toBe(false);
+  });
+
+  it("DO_NOT_TRACK with any other value does not disable telemetry", () => {
+    const config = resolveTelemetryConfig({ DO_NOT_TRACK: "0", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN });
+    expect(config.enabled).toBe(true);
+  });
+});
+
+describe("SC connection-string honesty: empty/unset/malformed all collapse to the same disabled shape", () => {
+  it("an unset connection string (default empty placeholder) disables telemetry — zero calls, not a fabricated key", () => {
+    const config = resolveTelemetryConfig({});
+    expect(config).toEqual({ enabled: false, instrumentationKey: undefined, ingestionEndpoint: undefined });
+  });
+
+  it("an explicitly empty connection string disables telemetry", () => {
+    const config = resolveTelemetryConfig({ AIRECEIPTS_TELEMETRY_CONNECTION: "" });
+    expect(config.enabled).toBe(false);
+  });
+
+  it("a malformed connection string (missing IngestionEndpoint) disables telemetry rather than sending to an incomplete endpoint", () => {
+    const config = resolveTelemetryConfig({ AIRECEIPTS_TELEMETRY_CONNECTION: "InstrumentationKey=abc-123" });
+    expect(config).toEqual({ enabled: false, instrumentationKey: undefined, ingestionEndpoint: undefined });
+  });
+
+  it("a malformed connection string (missing InstrumentationKey) disables telemetry", () => {
+    const config = resolveTelemetryConfig({
+      AIRECEIPTS_TELEMETRY_CONNECTION: "IngestionEndpoint=https://example.in.applicationinsights.azure.com/",
+    });
+    expect(config.enabled).toBe(false);
+  });
+
+  it("garbage (no key=value pairs at all) disables telemetry", () => {
+    const config = resolveTelemetryConfig({ AIRECEIPTS_TELEMETRY_CONNECTION: "not-a-connection-string" });
+    expect(config.enabled).toBe(false);
+  });
+});
+
+describe("SC connection-string override: a valid custom connection string routes to itself", () => {
+  it("parses InstrumentationKey and IngestionEndpoint out of a well-formed connection string", () => {
+    const config = resolveTelemetryConfig({ AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN });
+    expect(config).toEqual({
+      enabled: true,
+      instrumentationKey: "abc-123",
+      ingestionEndpoint: "https://example.in.applicationinsights.azure.com/",
+    });
+  });
+
+  it("tolerates extra whitespace around fields", () => {
+    const config = resolveTelemetryConfig({
+      AIRECEIPTS_TELEMETRY_CONNECTION: " InstrumentationKey = abc-123 ; IngestionEndpoint = https://example.com/ ",
+    });
+    expect(config.instrumentationKey).toBe("abc-123");
+    expect(config.ingestionEndpoint).toBe("https://example.com/");
+  });
+});

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -1,0 +1,82 @@
+/**
+ * Kill-switch and connection-string resolution (SPEC-0002 R4, and the
+ * connection-string-honesty success criterion). Resolved at call time from
+ * `process.env` (or an injected env for tests) — never cached at module
+ * load — so `AIRECEIPTS_TELEMETRY`/`DO_NOT_TRACK`/
+ * `AIRECEIPTS_TELEMETRY_CONNECTION` overrides set after import (as tests
+ * do) are always honored, mirroring `parse/cursor.ts`'s `CURSOR_DB_PATH`
+ * resolve-at-call-time convention.
+ */
+
+/**
+ * No real Azure Application Insights resource is wired up yet. This is
+ * deliberately empty rather than a fabricated-looking key: an empty
+ * connection string takes the same "disabled" path as the kill switches
+ * (see `resolveTelemetryConfig`), so telemetry sends zero events until a
+ * real ingest-only key is embedded here — a decision for whoever owns the
+ * Azure resource, not something to invent (I2's "never fabricate" applies
+ * equally to secret-shaped strings).
+ */
+const DEFAULT_CONNECTION_STRING = "";
+
+export interface TelemetryConfig {
+  enabled: boolean;
+  instrumentationKey: string | undefined;
+  ingestionEndpoint: string | undefined;
+}
+
+function killSwitchActive(env: NodeJS.ProcessEnv): boolean {
+  const telemetryEnv = env.AIRECEIPTS_TELEMETRY?.trim().toLowerCase();
+  if (telemetryEnv === "off" || telemetryEnv === "0" || telemetryEnv === "false") {
+    return true;
+  }
+  return env.DO_NOT_TRACK === "1";
+}
+
+function resolveConnectionString(env: NodeJS.ProcessEnv): string {
+  return env.AIRECEIPTS_TELEMETRY_CONNECTION !== undefined ? env.AIRECEIPTS_TELEMETRY_CONNECTION : DEFAULT_CONNECTION_STRING;
+}
+
+/**
+ * Parses an Azure Application Insights connection string
+ * (`Key1=Value1;Key2=Value2;...`). Returns `null` — never a partial or
+ * guessed result — for an empty string or one missing either required
+ * field, so a malformed override degrades to "disabled" rather than
+ * sending to an incomplete endpoint.
+ */
+function parseConnectionString(raw: string): { instrumentationKey: string; ingestionEndpoint: string } | null {
+  if (!raw.trim()) {
+    return null;
+  }
+  const fields = new Map<string, string>();
+  for (const pair of raw.split(";")) {
+    const eq = pair.indexOf("=");
+    if (eq <= 0) {
+      continue;
+    }
+    fields.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+  }
+  const instrumentationKey = fields.get("InstrumentationKey");
+  const ingestionEndpoint = fields.get("IngestionEndpoint");
+  if (!instrumentationKey || !ingestionEndpoint) {
+    return null;
+  }
+  return { instrumentationKey, ingestionEndpoint };
+}
+
+/**
+ * Resolves whether telemetry is enabled and, if so, where it sends. Both
+ * kill switches (R4) and an unset/empty/malformed connection string
+ * (SC conn-string) take the same `enabled: false` path — there is exactly
+ * one "off" state, not two subtly different ones.
+ */
+export function resolveTelemetryConfig(env: NodeJS.ProcessEnv = process.env): TelemetryConfig {
+  if (killSwitchActive(env)) {
+    return { enabled: false, instrumentationKey: undefined, ingestionEndpoint: undefined };
+  }
+  const parsed = parseConnectionString(resolveConnectionString(env));
+  if (!parsed) {
+    return { enabled: false, instrumentationKey: undefined, ingestionEndpoint: undefined };
+  }
+  return { enabled: true, instrumentationKey: parsed.instrumentationKey, ingestionEndpoint: parsed.ingestionEndpoint };
+}

--- a/src/telemetry/helpers.test.ts
+++ b/src/telemetry/helpers.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  bucketDuration,
+  classifyError,
+  getCliVersion,
+  isInPackage,
+  toAgentTypeTelemetry,
+  toCommandClass,
+  toOsTelemetry,
+} from "./helpers.js";
+
+describe("toOsTelemetry", () => {
+  it.each([
+    ["darwin", "darwin"],
+    ["linux", "linux"],
+    ["win32", "win32"],
+  ] as const)("maps %s to itself", (platform, expected) => {
+    expect(toOsTelemetry(platform)).toBe(expected);
+  });
+
+  it("maps any other platform to 'other' — never the raw platform string", () => {
+    expect(toOsTelemetry("freebsd" as NodeJS.Platform)).toBe("other");
+    expect(toOsTelemetry("aix" as NodeJS.Platform)).toBe("other");
+  });
+});
+
+describe("toAgentTypeTelemetry", () => {
+  it("passes through a known AgentSource unchanged", () => {
+    expect(toAgentTypeTelemetry("claude-code")).toBe("claude-code");
+    expect(toAgentTypeTelemetry("codex")).toBe("codex");
+    expect(toAgentTypeTelemetry("cursor")).toBe("cursor");
+  });
+
+  it("defaults to 'unknown' when no agent source is available", () => {
+    expect(toAgentTypeTelemetry(undefined)).toBe("unknown");
+  });
+});
+
+describe("bucketDuration: R2 coarse buckets, never the raw millisecond count", () => {
+  it.each([
+    [0, "<100ms"],
+    [99, "<100ms"],
+    [100, "100-500ms"],
+    [499, "100-500ms"],
+    [500, "500ms-2s"],
+    [1999, "500ms-2s"],
+    [2000, "2-10s"],
+    [9999, "2-10s"],
+    [10_000, ">10s"],
+    [999_999, ">10s"],
+  ] as const)("buckets %ims as %s", (ms, expected) => {
+    expect(bucketDuration(ms)).toBe(expected);
+  });
+});
+
+describe("toCommandClass: R2 closed 3-value taxonomy", () => {
+  it.each([
+    ["receipt", "receipt"],
+    ["", "receipt"],
+    ["RECEIPT", "receipt"],
+    ["  receipt  ", "receipt"],
+    ["compare", "compare"],
+    ["COMPARE", "compare"],
+  ] as const)("maps %j to %s", (command, expected) => {
+    expect(toCommandClass(command)).toBe(expected);
+  });
+
+  it("maps any unrecognized command (or raw argv-like text) to 'other' — never the raw command line", () => {
+    expect(toCommandClass("--verbose --unknown-flag foo.json")).toBe("other");
+    expect(toCommandClass("some-future-subcommand")).toBe("other");
+  });
+});
+
+describe("classifyError: R2 closed error taxonomy, never error.message", () => {
+  it("classifies well-known Node IO error codes", () => {
+    expect(classifyError(Object.assign(new Error("x"), { code: "ENOENT" }))).toBe("io_error");
+    expect(classifyError(Object.assign(new Error("x"), { code: "EACCES" }))).toBe("io_error");
+  });
+
+  it("classifies well-known Node network error codes", () => {
+    expect(classifyError(Object.assign(new Error("x"), { code: "ECONNREFUSED" }))).toBe("network_error");
+    expect(classifyError(Object.assign(new Error("x"), { code: "ETIMEDOUT" }))).toBe("network_error");
+  });
+
+  it("classifies a ZodError-shaped constructor as validation_error", () => {
+    class ZodError extends Error {}
+    expect(classifyError(new ZodError("some message with a /path/to/file leaked in it"))).toBe("validation_error");
+  });
+
+  it("classifies a SyntaxError as parse_error", () => {
+    expect(classifyError(new SyntaxError("Unexpected token in /Users/anand/secret.json"))).toBe("parse_error");
+  });
+
+  it("defaults to unknown_error for anything else, including plain strings and non-errors", () => {
+    expect(classifyError(new Error("some very specific message with /a/path and $12.34 in it"))).toBe("unknown_error");
+    expect(classifyError("a raw string, not even an Error")).toBe("unknown_error");
+    expect(classifyError(null)).toBe("unknown_error");
+    expect(classifyError(undefined)).toBe("unknown_error");
+  });
+
+  it("never returns the error message itself, even when the message contains a leakable value", () => {
+    const err = new Error("failed to read /Users/anand/.ssh/id_rsa: $500 charged");
+    const result = classifyError(err);
+    expect(result).not.toContain("/Users");
+    expect(result).not.toContain("$500");
+    expect(["io_error", "network_error", "validation_error", "parse_error", "unknown_error"]).toContain(result);
+  });
+});
+
+describe("isInPackage: returns a boolean only, never the stack frame text", () => {
+  it("returns false for a non-Error value", () => {
+    expect(isInPackage("not an error")).toBe(false);
+    expect(isInPackage(undefined)).toBe(false);
+  });
+
+  it("returns false for an Error with no stack", () => {
+    const err = new Error("x");
+    err.stack = undefined;
+    expect(isInPackage(err)).toBe(false);
+  });
+
+  it("returns a boolean (not a string) for a normal Error thrown from this test file", () => {
+    const result = isInPackage(new Error("thrown from a test file, outside the package's own source"));
+    expect(typeof result).toBe("boolean");
+  });
+});
+
+describe("getCliVersion: reads package.json's version, never throws", () => {
+  it("returns a non-empty semver-ish string", () => {
+    const version = getCliVersion();
+    expect(typeof version).toBe("string");
+    expect(version.length).toBeGreaterThan(0);
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("returns a stable, cached value across repeated calls", () => {
+    expect(getCliVersion()).toBe(getCliVersion());
+  });
+});

--- a/src/telemetry/helpers.ts
+++ b/src/telemetry/helpers.ts
@@ -1,0 +1,126 @@
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AgentSource } from "../parse/types.js";
+import type { AgentTypeValue, CommandClassValue, DurationBucketValue, ErrorClassValue, OsValue } from "./schemas.js";
+
+/**
+ * Derives every telemetry field from raw runtime data (errors, stack
+ * traces, `process.platform`, `package.json`) so that no caller ever needs
+ * to pass a raw error message, a file path, or a stack frame into a
+ * telemetry event directly — the conversion to a bounded enum/regex value
+ * happens once, here, and nothing else leaves this module (R3).
+ */
+
+export function toOsTelemetry(platform: NodeJS.Platform = process.platform): OsValue {
+  if (platform === "darwin" || platform === "linux" || platform === "win32") {
+    return platform;
+  }
+  return "other";
+}
+
+export function toAgentTypeTelemetry(source: AgentSource | undefined): AgentTypeValue {
+  return source ?? "unknown";
+}
+
+/** Coarse duration buckets (R2) — never the raw millisecond count. */
+export function bucketDuration(ms: number): DurationBucketValue {
+  if (ms < 100) return "<100ms";
+  if (ms < 500) return "100-500ms";
+  if (ms < 2000) return "500ms-2s";
+  if (ms < 10_000) return "2-10s";
+  return ">10s";
+}
+
+/** Maps a CLI subcommand name to R2's closed 3-value taxonomy — never the raw command line or its arguments. */
+export function toCommandClass(command: string): CommandClassValue {
+  const normalized = command.trim().toLowerCase();
+  if (normalized === "receipt" || normalized === "") {
+    return "receipt";
+  }
+  if (normalized === "compare") {
+    return "compare";
+  }
+  return "other";
+}
+
+/**
+ * Classifies an unknown thrown value into R2's small fixed error taxonomy.
+ * Deliberately never reads `error.message` into the return value — only
+ * `error.constructor.name`/well-known Node error codes, which are
+ * themselves closed vocabularies, not free text.
+ */
+export function classifyError(err: unknown): ErrorClassValue {
+  const code = err && typeof err === "object" && "code" in err ? String((err as { code?: unknown }).code) : undefined;
+  if (code === "ENOENT" || code === "EACCES" || code === "EISDIR" || code === "ENOTDIR" || code === "EMFILE") {
+    return "io_error";
+  }
+  if (code === "ECONNREFUSED" || code === "ETIMEDOUT" || code === "ENOTFOUND" || code === "ECONNRESET") {
+    return "network_error";
+  }
+  const ctorName = err instanceof Error ? err.constructor.name : undefined;
+  if (ctorName === "ZodError") {
+    return "validation_error";
+  }
+  if (ctorName === "SyntaxError") {
+    return "parse_error";
+  }
+  return "unknown_error";
+}
+
+let cachedPackageRoot: string | undefined;
+
+/** Walk-up to find the package root (the directory containing `package.json`), mirroring `pricing/priceTable.ts`'s `defaultDataDir` pattern. Cached: fixed on-disk location. */
+function packageRoot(): string {
+  if (cachedPackageRoot) {
+    return cachedPackageRoot;
+  }
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(path.join(dir, "package.json"))) {
+      cachedPackageRoot = dir;
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  cachedPackageRoot = dir;
+  return dir;
+}
+
+/**
+ * Whether an error's top stack frame originates from inside this package's
+ * own installed location (a bug in aireceipts itself) versus a dependency
+ * or the caller's own code. Inspects the stack trace internally but
+ * returns only a boolean — the frame text itself never leaves this
+ * function, so it can never appear in a telemetry payload (R3).
+ */
+export function isInPackage(err: unknown): boolean {
+  if (!(err instanceof Error) || typeof err.stack !== "string") {
+    return false;
+  }
+  const root = packageRoot();
+  const firstFrame = err.stack.split("\n").slice(1).find((line) => line.trim().startsWith("at "));
+  return firstFrame ? firstFrame.includes(root) : false;
+}
+
+let cachedCliVersion: string | undefined;
+
+/** Reads `package.json`'s `version` field by walking up from this module's own location — same technique as {@link packageRoot}. Falls back to `"0.0.0"` (never throws) if `package.json` is missing or malformed. */
+export function getCliVersion(): string {
+  if (cachedCliVersion) {
+    return cachedCliVersion;
+  }
+  try {
+    const raw = readFileSync(path.join(packageRoot(), "package.json"), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    const version = parsed && typeof parsed === "object" && "version" in parsed ? (parsed as { version?: unknown }).version : undefined;
+    cachedCliVersion = typeof version === "string" && version.length > 0 ? version : "0.0.0";
+  } catch {
+    cachedCliVersion = "0.0.0";
+  }
+  return cachedCliVersion;
+}

--- a/src/telemetry/index.test.ts
+++ b/src/telemetry/index.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  recordCliError,
+  recordCliRun,
+  recordParseFailure,
+  showTelemetryPayload,
+  type RecordCliErrorInput,
+  type RecordCliRunInput,
+  type RecordParseFailureInput,
+} from "./index.js";
+import { EVENT_NAMES, validateEvent, type TelemetryEvent } from "./schemas.js";
+import { __resetQueueForTests, peekQueuedEvents } from "./sender.js";
+
+const VALID_CONN = "InstrumentationKey=abc-123;IngestionEndpoint=https://example.in.applicationinsights.azure.com/";
+
+beforeEach(() => {
+  __resetQueueForTests();
+});
+
+afterEach(() => {
+  __resetQueueForTests();
+});
+
+describe("recordCliRun builds a valid cli_run event from raw runtime inputs", () => {
+  it("enqueues one event that passes schema validation", () => {
+    const input: RecordCliRunInput = { command: "receipt", agentType: "claude-code", durationMs: 250, ok: true };
+    recordCliRun(input);
+
+    const queued = peekQueuedEvents();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.name).toBe("cli_run");
+    expect(validateEvent(queued[0] as TelemetryEvent)).toBe(true);
+  });
+
+  it("never includes the raw command string or raw duration in the queued event", () => {
+    recordCliRun({ command: "receipt --verbose /Users/anand/secret.json", agentType: "claude-code", durationMs: 1234, ok: false });
+    const [event] = peekQueuedEvents();
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain("/Users/anand/secret.json");
+    expect(serialized).not.toContain("1234");
+  });
+});
+
+describe("recordCliError builds a valid cli_error event from raw runtime inputs", () => {
+  it("enqueues one event that passes schema validation", () => {
+    const input: RecordCliErrorInput = {
+      command: "receipt",
+      agentType: "codex",
+      err: Object.assign(new Error("ENOENT: no such file /Users/anand/x.json"), { code: "ENOENT" }),
+    };
+    recordCliError(input);
+
+    const queued = peekQueuedEvents();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.name).toBe("cli_error");
+    expect(validateEvent(queued[0] as TelemetryEvent)).toBe(true);
+  });
+
+  it("never includes the raw error message in the queued event", () => {
+    recordCliError({ command: "receipt", agentType: "codex", err: new Error("leaked /path and $99.00") });
+    const serialized = JSON.stringify(peekQueuedEvents()[0]);
+    expect(serialized).not.toContain("/path");
+    expect(serialized).not.toContain("$99.00");
+  });
+});
+
+describe("recordParseFailure builds a valid parse_failure event and hashes the shape", () => {
+  it("enqueues one event that passes schema validation", () => {
+    const input: RecordParseFailureInput = { agentType: "cursor", adapterVersion: "1", shape: "cursor:turn.usage.missing" };
+    recordParseFailure(input);
+
+    const queued = peekQueuedEvents();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.name).toBe("parse_failure");
+    expect(validateEvent(queued[0] as TelemetryEvent)).toBe(true);
+  });
+
+  it("never includes the raw shape string in the queued event, only its hash", () => {
+    recordParseFailure({ agentType: "cursor", adapterVersion: "1", shape: "a very specific content-free shape descriptor" });
+    const serialized = JSON.stringify(peekQueuedEvents()[0]);
+    expect(serialized).not.toContain("a very specific content-free shape descriptor");
+  });
+});
+
+describe("R2: exactly three event names, exhaustively, via the public recorder functions", () => {
+  it("recordCliRun, recordCliError, and recordParseFailure together cover every name in EVENT_NAMES", () => {
+    recordCliRun({ command: "receipt", agentType: undefined, durationMs: 10, ok: true });
+    recordCliError({ command: "receipt", agentType: undefined, err: new Error("x") });
+    recordParseFailure({ agentType: "claude-code", adapterVersion: "1", shape: "x" });
+
+    const names = peekQueuedEvents().map((e) => e.name);
+    expect(new Set(names)).toEqual(new Set(EVENT_NAMES));
+  });
+});
+
+describe("showTelemetryPayload: R5 --telemetry-show backing function", () => {
+  it("reports disabled with an empty queue when no connection string is configured", () => {
+    const result = showTelemetryPayload({});
+    expect(result).toEqual({ enabled: false, events: [] });
+  });
+
+  it("reports enabled and returns the queued (unsent) events without sending them", () => {
+    recordCliRun({ command: "receipt", agentType: "claude-code", durationMs: 10, ok: true });
+    const result = showTelemetryPayload({ AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN });
+
+    expect(result.enabled).toBe(true);
+    expect(result.events).toHaveLength(1);
+    expect(peekQueuedEvents()).toHaveLength(1);
+  });
+
+  it("respects the kill switches", () => {
+    recordCliRun({ command: "receipt", agentType: "claude-code", durationMs: 10, ok: true });
+    const result = showTelemetryPayload({ DO_NOT_TRACK: "1", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN });
+    expect(result.enabled).toBe(false);
+  });
+});

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,88 @@
+import type { AgentSource } from "../parse/types.js";
+import { resolveTelemetryConfig } from "./config.js";
+import { bucketDuration, classifyError, getCliVersion, isInPackage, toAgentTypeTelemetry, toCommandClass, toOsTelemetry } from "./helpers.js";
+import { ensureFirstRunNotice, FIRST_RUN_NOTICE } from "./notice.js";
+import { peekQueuedEvents, recordEvent, flushTelemetry } from "./sender.js";
+import { hashSignature } from "./signature.js";
+
+/**
+ * Single public integration surface for SPEC-0002 diagnostics telemetry.
+ * This is the one file `src/cli/**` (surface-owned) should import from —
+ * every other module under `src/telemetry/` is an internal implementation
+ * detail. See `docs/telemetry.md` for the full field-by-field schema and
+ * `AGENTS.md`/SPEC-0002 for the invariants this module upholds (I4, R1-R6).
+ */
+
+export { flushTelemetry, ensureFirstRunNotice, FIRST_RUN_NOTICE };
+
+export interface RecordCliRunInput {
+  command: string;
+  agentType: AgentSource | undefined;
+  durationMs: number;
+  ok: boolean;
+}
+
+/** Records one `cli_run` event (R2). Call once per CLI invocation, right before the process would otherwise exit. */
+export function recordCliRun(input: RecordCliRunInput): void {
+  recordEvent({
+    name: "cli_run",
+    properties: {
+      cliVersion: getCliVersion(),
+      os: toOsTelemetry(),
+      nodeMajor: Number(process.versions.node.split(".")[0]),
+      commandClass: toCommandClass(input.command),
+      agentType: toAgentTypeTelemetry(input.agentType),
+      durationBucket: bucketDuration(input.durationMs),
+      ok: input.ok,
+    },
+  });
+}
+
+export interface RecordCliErrorInput {
+  command: string;
+  agentType: AgentSource | undefined;
+  err: unknown;
+}
+
+/** Records one `cli_error` event (R2). Call from the CLI's top-level catch handler; never pass `err.message` or any derived text elsewhere — this function does the full raw-error-to-bounded-fields conversion internally. */
+export function recordCliError(input: RecordCliErrorInput): void {
+  recordEvent({
+    name: "cli_error",
+    properties: {
+      errorClass: classifyError(input.err),
+      command: toCommandClass(input.command),
+      agentType: toAgentTypeTelemetry(input.agentType),
+      inPackage: isInPackage(input.err),
+    },
+  });
+}
+
+export interface RecordParseFailureInput {
+  agentType: AgentSource;
+  adapterVersion: string;
+  /** A content-free description of *where* parsing broke (e.g. `"claude-code:turn.usage.missing"`) — never a snippet of the transcript itself. Hashed before it ever reaches a payload. */
+  shape: string;
+}
+
+/** Records one `parse_failure` event (R2). `shape` is hashed here — the raw string never leaves this function. */
+export function recordParseFailure(input: RecordParseFailureInput): void {
+  recordEvent({
+    name: "parse_failure",
+    properties: {
+      agentType: input.agentType,
+      adapterVersion: input.adapterVersion,
+      signatureHash: hashSignature(input.shape),
+    },
+  });
+}
+
+/**
+ * Backs `--telemetry-show` (R5): returns exactly what the current run's
+ * queue would send on the next `flushTelemetry()` call, without sending
+ * it. Also reports whether telemetry is currently enabled, so a user can
+ * tell "nothing queued yet" apart from "telemetry is off."
+ */
+export function showTelemetryPayload(env: NodeJS.ProcessEnv = process.env): { enabled: boolean; events: readonly unknown[] } {
+  const config = resolveTelemetryConfig(env);
+  return { enabled: config.enabled, events: peekQueuedEvents() };
+}

--- a/src/telemetry/notice.test.ts
+++ b/src/telemetry/notice.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureFirstRunNotice, FIRST_RUN_NOTICE } from "./notice.js";
+
+describe("R5: first-run disclosure notice", () => {
+  let homeDir: string;
+
+  beforeEach(async () => {
+    homeDir = await mkdtemp(join(tmpdir(), "aireceipts-notice-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  it("shows the notice on the first run and persists that it was shown", async () => {
+    const printed: string[] = [];
+    const shown = await ensureFirstRunNotice((text) => printed.push(text), homeDir);
+
+    expect(shown).toBe(true);
+    expect(printed).toEqual([FIRST_RUN_NOTICE]);
+  });
+
+  it("stays silent on the second and third runs", async () => {
+    const printed: string[] = [];
+    await ensureFirstRunNotice((text) => printed.push(text), homeDir);
+    const shownSecondRun = await ensureFirstRunNotice((text) => printed.push(text), homeDir);
+    const shownThirdRun = await ensureFirstRunNotice((text) => printed.push(text), homeDir);
+
+    expect(shownSecondRun).toBe(false);
+    expect(shownThirdRun).toBe(false);
+    expect(printed).toHaveLength(1);
+  });
+
+  it("mentions both kill switches, --telemetry-show, and docs/telemetry.md", () => {
+    expect(FIRST_RUN_NOTICE).toContain("AIRECEIPTS_TELEMETRY=off");
+    expect(FIRST_RUN_NOTICE).toContain("DO_NOT_TRACK=1");
+    expect(FIRST_RUN_NOTICE).toContain("--telemetry-show");
+    expect(FIRST_RUN_NOTICE).toContain("docs/telemetry.md");
+  });
+
+  it("never mentions transcript content, prompts, paths, or dollar amounts as things it sends", () => {
+    expect(FIRST_RUN_NOTICE.toLowerCase()).not.toMatch(/\$\d/);
+  });
+
+  it("creates the ~/.aireceipts directory on demand when the home override doesn't exist yet", async () => {
+    const printed: string[] = [];
+    const missingHome = join(homeDir, "does", "not", "exist", "at", "all");
+    await expect(ensureFirstRunNotice((text) => printed.push(text), missingHome)).resolves.toBe(true);
+    expect(printed).toEqual([FIRST_RUN_NOTICE]);
+  });
+});

--- a/src/telemetry/notice.ts
+++ b/src/telemetry/notice.ts
@@ -1,0 +1,66 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+/**
+ * One-time diagnostics-telemetry disclosure (SPEC-0002 R5). Persists
+ * `{shown: true}` at `~/.aireceipts/telemetry.json`, mirroring SPEC-0009's
+ * `~/.aireceipts/budget.json` config-dir convention. Read/write failures
+ * (no home dir, read-only filesystem, corrupt JSON) are treated as "not
+ * shown yet" for *this run only* and never thrown — a broken filesystem
+ * degrades to "print the notice again next time," never to a crash (I1).
+ */
+
+export const FIRST_RUN_NOTICE =
+  "aireceipts sends anonymous, content-free diagnostics (performance, error, " +
+  "and parse-failure signals only — never transcript content, prompts, file " +
+  "paths, repo names, or dollar amounts). Disable anytime with " +
+  "AIRECEIPTS_TELEMETRY=off or DO_NOT_TRACK=1. Run --telemetry-show to see " +
+  "exactly what a run would send. Details: docs/telemetry.md";
+
+interface NoticeState {
+  shown: boolean;
+}
+
+/** Resolved at call time (not module load) so a test's `homeOverride` or a changed `HOME` is always honored. */
+function noticeStatePath(homeOverride?: string): string {
+  return join(homeOverride ?? homedir(), ".aireceipts", "telemetry.json");
+}
+
+async function readNoticeState(path: string): Promise<NoticeState> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && "shown" in parsed && typeof (parsed as NoticeState).shown === "boolean") {
+      return parsed as NoticeState;
+    }
+    return { shown: false };
+  } catch {
+    return { shown: false };
+  }
+}
+
+async function writeNoticeState(path: string, state: NoticeState): Promise<void> {
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(state), "utf8");
+  } catch {
+    // Fail-safe (I1): a write failure just means the notice reprints next run.
+  }
+}
+
+/**
+ * Prints (via `print`) {@link FIRST_RUN_NOTICE} the first time this ever
+ * runs for the current user, then persists that it's been shown so later
+ * runs stay silent. Returns `true` if the notice was (just) shown.
+ */
+export async function ensureFirstRunNotice(print: (text: string) => void, homeOverride?: string): Promise<boolean> {
+  const path = noticeStatePath(homeOverride);
+  const state = await readNoticeState(path);
+  if (state.shown) {
+    return false;
+  }
+  print(FIRST_RUN_NOTICE);
+  await writeNoticeState(path, { shown: true });
+  return true;
+}

--- a/src/telemetry/schemas.test.ts
+++ b/src/telemetry/schemas.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  EVENT_NAMES,
+  cliErrorPropertiesSchema,
+  cliRunPropertiesSchema,
+  parseFailurePropertiesSchema,
+  validateEvent,
+  type CliErrorEvent,
+  type CliRunEvent,
+  type ParseFailureEvent,
+} from "./schemas.js";
+
+describe("R2: exactly three event names", () => {
+  it("is exhaustive over cli_run, cli_error, parse_failure — no more, no less", () => {
+    expect([...EVENT_NAMES].sort()).toEqual(["cli_error", "cli_run", "parse_failure"]);
+  });
+});
+
+describe("R2: valid events pass their schema", () => {
+  it("accepts a well-formed cli_run event", () => {
+    const event: CliRunEvent = {
+      name: "cli_run",
+      properties: {
+        cliVersion: "0.1.0",
+        os: "darwin",
+        nodeMajor: 22,
+        commandClass: "receipt",
+        agentType: "claude-code",
+        durationBucket: "100-500ms",
+        ok: true,
+      },
+    };
+    expect(validateEvent(event)).toBe(true);
+  });
+
+  it("accepts a well-formed cli_error event", () => {
+    const event: CliErrorEvent = {
+      name: "cli_error",
+      properties: {
+        errorClass: "io_error",
+        command: "receipt",
+        agentType: "codex",
+        inPackage: false,
+      },
+    };
+    expect(validateEvent(event)).toBe(true);
+  });
+
+  it("accepts a well-formed parse_failure event", () => {
+    const event: ParseFailureEvent = {
+      name: "parse_failure",
+      properties: {
+        agentType: "cursor",
+        adapterVersion: "1",
+        signatureHash: "a".repeat(64),
+      },
+    };
+    expect(validateEvent(event)).toBe(true);
+  });
+
+  it("R2: commandClass/command enum covers every CLI command class", () => {
+    for (const value of ["receipt", "compare", "other"] as const) {
+      expect(
+        cliRunPropertiesSchema.safeParse({
+          cliVersion: "0.1.0",
+          os: "linux",
+          nodeMajor: 20,
+          commandClass: value,
+          agentType: "unknown",
+          durationBucket: "<100ms",
+          ok: true,
+        }).success,
+      ).toBe(true);
+      expect(
+        cliErrorPropertiesSchema.safeParse({
+          errorClass: "unknown_error",
+          command: value,
+          agentType: "unknown",
+          inPackage: true,
+        }).success,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("R3: leakage fixtures — banned content is structurally rejected", () => {
+  const validCliRun = {
+    cliVersion: "0.1.0",
+    os: "darwin" as const,
+    nodeMajor: 22,
+    commandClass: "receipt" as const,
+    agentType: "claude-code" as const,
+    durationBucket: "100-500ms" as const,
+    ok: true,
+  };
+
+  it.each([
+    ["a raw file path", { path: "/Users/anand/secret-project/main.py" }],
+    ["a prompt snippet", { prompt: "write me a function that deletes prod" }],
+    ["a repo name", { repo: "altimateai/altimate-backend" }],
+    ["a hostname", { hostname: "anand-macbook.local" }],
+    ["a username", { username: "anand" }],
+    ["a session id", { sessionId: "sess_9f8a7b6c" }],
+    ["a dollar amount", { costUsd: 12.34 }],
+    ["a raw model string", { model: "claude-fable-5-20260615" }],
+    ["transcript content", { transcript: "user: help me debug this\nassistant: sure" }],
+  ])("rejects an event with %s smuggled in via an extra property", (_label, extra) => {
+    const polluted = { ...validCliRun, ...extra };
+    expect(cliRunPropertiesSchema.safeParse(polluted).success).toBe(false);
+  });
+
+  it("rejects a cliVersion field containing a path instead of a semver string", () => {
+    expect(cliRunPropertiesSchema.safeParse({ ...validCliRun, cliVersion: "/Users/anand/aireceipts" }).success).toBe(false);
+  });
+
+  it("rejects an os field containing free text instead of the closed enum", () => {
+    expect(cliRunPropertiesSchema.safeParse({ ...validCliRun, os: "MacBook-Pro.local" }).success).toBe(false);
+  });
+
+  it("rejects a signatureHash that is raw transcript text instead of a sha256 hex digest", () => {
+    expect(
+      parseFailurePropertiesSchema.safeParse({
+        agentType: "claude-code",
+        adapterVersion: "1",
+        signatureHash: "assistant: I ran `rm -rf /` by mistake",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an adapterVersion field containing a long free-text string", () => {
+    expect(
+      parseFailurePropertiesSchema.safeParse({
+        agentType: "claude-code",
+        adapterVersion: "this is not a version, this is a whole sentence of leaked content",
+        signatureHash: "b".repeat(64),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("validateEvent returns false (never throws) for an unrecognized event name", () => {
+    expect(validateEvent({ name: "unknown_event" as never, properties: {} as never })).toBe(false);
+  });
+});

--- a/src/telemetry/schemas.ts
+++ b/src/telemetry/schemas.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+
+/**
+ * Allowlist schemas for SPEC-0002's diagnostics-telemetry events (R2/R3).
+ *
+ * Every field is enum-only or a bounded-format string validated by regex —
+ * there is no free-text field anywhere in this module. `.strict()` rejects
+ * any payload carrying an extra key, so a caller can never smuggle an
+ * unlisted field (a path, a prompt, a dollar string) past the schema by
+ * attaching it under a new name. Banned forever, and structurally
+ * unrepresentable here: transcript content, prompts, file paths, repo
+ * names, hostnames, usernames, session IDs, dollar amounts, raw model
+ * strings (I4, SPEC-0002 R3).
+ */
+
+export const OS_VALUES = ["darwin", "linux", "win32", "other"] as const;
+export type OsValue = (typeof OS_VALUES)[number];
+
+export const COMMAND_CLASS_VALUES = ["receipt", "compare", "other"] as const;
+export type CommandClassValue = (typeof COMMAND_CLASS_VALUES)[number];
+
+export const AGENT_TYPE_VALUES = ["claude-code", "codex", "cursor", "unknown"] as const;
+export type AgentTypeValue = (typeof AGENT_TYPE_VALUES)[number];
+
+/** Coarse, fixed buckets — never the raw millisecond count, which could be fingerprint-able alongside other signals. */
+export const DURATION_BUCKET_VALUES = ["<100ms", "100-500ms", "500ms-2s", "2-10s", ">10s"] as const;
+export type DurationBucketValue = (typeof DURATION_BUCKET_VALUES)[number];
+
+/** A small, fixed taxonomy — never `error.message` or `error.name` verbatim, both of which can carry a file path or other identifying text. */
+export const ERROR_CLASS_VALUES = [
+  "parse_error",
+  "io_error",
+  "network_error",
+  "validation_error",
+  "unknown_error",
+] as const;
+export type ErrorClassValue = (typeof ERROR_CLASS_VALUES)[number];
+
+const cliVersionSchema = z
+  .string()
+  .regex(/^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/, "cliVersion must be a bare semver string");
+const nodeMajorSchema = z.number().int().min(0).max(999);
+/** SHA-256 hex digest of a structural shape descriptor — never the shape itself (see `signature.ts`). */
+const signatureHashSchema = z.string().regex(/^[0-9a-f]{64}$/, "signatureHash must be a sha256 hex digest");
+/** An internal per-adapter constant (e.g. `"1"`), not anything read from a transcript. */
+const adapterVersionSchema = z.string().regex(/^[a-zA-Z0-9_.-]{1,32}$/, "adapterVersion must be a short opaque token");
+
+export const cliRunPropertiesSchema = z
+  .object({
+    cliVersion: cliVersionSchema,
+    os: z.enum(OS_VALUES),
+    nodeMajor: nodeMajorSchema,
+    commandClass: z.enum(COMMAND_CLASS_VALUES),
+    agentType: z.enum(AGENT_TYPE_VALUES),
+    durationBucket: z.enum(DURATION_BUCKET_VALUES),
+    ok: z.boolean(),
+  })
+  .strict();
+export type CliRunProperties = z.infer<typeof cliRunPropertiesSchema>;
+
+export const cliErrorPropertiesSchema = z
+  .object({
+    errorClass: z.enum(ERROR_CLASS_VALUES),
+    /** Same bounded enum as `cli_run`'s `commandClass` — never the raw command line (R2). */
+    command: z.enum(COMMAND_CLASS_VALUES),
+    agentType: z.enum(AGENT_TYPE_VALUES),
+    inPackage: z.boolean(),
+  })
+  .strict();
+export type CliErrorProperties = z.infer<typeof cliErrorPropertiesSchema>;
+
+export const parseFailurePropertiesSchema = z
+  .object({
+    agentType: z.enum(AGENT_TYPE_VALUES),
+    adapterVersion: adapterVersionSchema,
+    signatureHash: signatureHashSchema,
+  })
+  .strict();
+export type ParseFailureProperties = z.infer<typeof parseFailurePropertiesSchema>;
+
+/** Exactly three event names exist (R2) — this array is the single source of truth other modules and tests assert against. */
+export const EVENT_NAMES = ["cli_run", "cli_error", "parse_failure"] as const;
+export type EventName = (typeof EVENT_NAMES)[number];
+
+export interface CliRunEvent {
+  name: "cli_run";
+  properties: CliRunProperties;
+}
+export interface CliErrorEvent {
+  name: "cli_error";
+  properties: CliErrorProperties;
+}
+export interface ParseFailureEvent {
+  name: "parse_failure";
+  properties: ParseFailureProperties;
+}
+export type TelemetryEvent = CliRunEvent | CliErrorEvent | ParseFailureEvent;
+
+/** `event.name` → its properties schema, exhaustive over `EVENT_NAMES`. */
+export const PROPERTIES_SCHEMA_BY_EVENT_NAME = {
+  cli_run: cliRunPropertiesSchema,
+  cli_error: cliErrorPropertiesSchema,
+  parse_failure: parseFailurePropertiesSchema,
+} as const satisfies Record<EventName, z.ZodTypeAny>;
+
+/** Validates a full envelope (name + properties) against its schema. Never throws — returns `false` on any mismatch, including an unrecognized `name`. */
+export function validateEvent(event: TelemetryEvent): boolean {
+  const schema = PROPERTIES_SCHEMA_BY_EVENT_NAME[event.name] as z.ZodTypeAny | undefined;
+  if (!schema) {
+    return false;
+  }
+  return schema.safeParse(event.properties).success;
+}

--- a/src/telemetry/sender.test.ts
+++ b/src/telemetry/sender.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetQueueForTests, flushTelemetry, peekQueuedEvents, recordEvent } from "./sender.js";
+
+const VALID_CONN = "InstrumentationKey=abc-123;IngestionEndpoint=https://example.in.applicationinsights.azure.com/";
+
+const SAMPLE_EVENT = {
+  name: "cli_run" as const,
+  properties: {
+    cliVersion: "0.1.0",
+    os: "darwin" as const,
+    nodeMajor: 22,
+    commandClass: "receipt" as const,
+    agentType: "claude-code" as const,
+    durationBucket: "100-500ms" as const,
+    ok: true,
+  },
+};
+
+describe("R6: no-network proof", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    __resetQueueForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __resetQueueForTests();
+  });
+
+  it("DO_NOT_TRACK=1 results in zero fetch calls, even with a valid connection string and a queued event", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    recordEvent(SAMPLE_EVENT);
+    await flushTelemetry({ env: { DO_NOT_TRACK: "1", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN } });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("AIRECEIPTS_TELEMETRY=off results in zero fetch calls", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    recordEvent(SAMPLE_EVENT);
+    await flushTelemetry({ env: { AIRECEIPTS_TELEMETRY: "off", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN } });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("an unset (default empty) connection string results in zero fetch calls", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    recordEvent(SAMPLE_EVENT);
+    await flushTelemetry({ env: {} });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("an empty queue never calls fetch, even when telemetry is enabled", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    await flushTelemetry({ env: { AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN } });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("R1: bounded flush", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    __resetQueueForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __resetQueueForTests();
+  });
+
+  it("resolves within the timeout budget even when fetch hangs forever", async () => {
+    globalThis.fetch = vi.fn(() => new Promise<Response>(() => {})) as unknown as typeof fetch;
+
+    recordEvent(SAMPLE_EVENT);
+    const start = Date.now();
+    await flushTelemetry({ timeoutMs: 300, env: { AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN } });
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(1000);
+  });
+
+  it("resolves within the timeout budget even when fetch rejects immediately", async () => {
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error("network down"))) as unknown as typeof fetch;
+
+    recordEvent(SAMPLE_EVENT);
+    await expect(flushTelemetry({ timeoutMs: 300, env: { AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN } })).resolves.toBeUndefined();
+  });
+
+  it("drains the queue immediately regardless of how long the send takes", async () => {
+    globalThis.fetch = vi.fn(() => new Promise<Response>(() => {})) as unknown as typeof fetch;
+
+    recordEvent(SAMPLE_EVENT);
+    expect(peekQueuedEvents()).toHaveLength(1);
+    const flush = flushTelemetry({ timeoutMs: 300, env: { AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN } });
+    expect(peekQueuedEvents()).toHaveLength(0);
+    await flush;
+  });
+});
+
+describe("recordEvent", () => {
+  beforeEach(() => {
+    __resetQueueForTests();
+  });
+
+  it("enqueues a valid event", () => {
+    recordEvent(SAMPLE_EVENT);
+    expect(peekQueuedEvents()).toEqual([SAMPLE_EVENT]);
+  });
+
+  it("silently drops an invalid event rather than enqueuing it partially", () => {
+    recordEvent({ name: "cli_run", properties: { ...SAMPLE_EVENT.properties, os: "not-an-os" as never } });
+    expect(peekQueuedEvents()).toHaveLength(0);
+  });
+});

--- a/src/telemetry/sender.ts
+++ b/src/telemetry/sender.ts
@@ -1,0 +1,93 @@
+import { resolveTelemetryConfig } from "./config.js";
+import { validateEvent, type TelemetryEvent } from "./schemas.js";
+
+/**
+ * In-process queue + bounded sender (SPEC-0002 R1/R6). `recordEvent`
+ * validates and enqueues; `flushTelemetry` drains the queue in one batch
+ * request, bounded to `timeoutMs` via `Promise.race` against global
+ * `fetch` (Node >=20, no new HTTP-client dependency needed). Every failure
+ * mode — disabled config, invalid event, network error, timeout — is
+ * swallowed here: telemetry must never throw, block, or change the CLI's
+ * exit code (R1).
+ */
+
+let queue: TelemetryEvent[] = [];
+
+/** Validates + enqueues one event. Silently drops anything that fails schema validation (R3) — an invalid event is never sent partially or "best-effort." */
+export function recordEvent(event: TelemetryEvent): void {
+  if (validateEvent(event)) {
+    queue.push(event);
+  }
+}
+
+interface AppInsightsEnvelope {
+  name: string;
+  time: string;
+  iKey: string;
+  data: {
+    baseType: "EventData";
+    baseData: { ver: 2; name: string; properties: Record<string, unknown> };
+  };
+}
+
+function toAppInsightsEnvelope(event: TelemetryEvent, instrumentationKey: string): AppInsightsEnvelope {
+  return {
+    name: `Microsoft.ApplicationInsights.${instrumentationKey}.Event`,
+    time: new Date().toISOString(),
+    iKey: instrumentationKey,
+    data: {
+      baseType: "EventData",
+      baseData: { ver: 2, name: event.name, properties: event.properties },
+    },
+  };
+}
+
+async function sendBatch(events: TelemetryEvent[], instrumentationKey: string, ingestionEndpoint: string): Promise<void> {
+  const body = JSON.stringify(events.map((e) => toAppInsightsEnvelope(e, instrumentationKey)));
+  await fetch(`${ingestionEndpoint.replace(/\/+$/, "")}/v2/track`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
+function timeout(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface FlushOptions {
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Drains the queue and attempts to send it as one batch, bounded to
+ * `timeoutMs` (default 300, per R1). Always resolves — never rejects,
+ * never awaits past the budget — regardless of whether the send actually
+ * completed; a slow or hung network call is abandoned in place, not
+ * awaited to completion in the background (nothing keeps the process
+ * alive past this call).
+ */
+export async function flushTelemetry(options: FlushOptions = {}): Promise<void> {
+  const { timeoutMs = 300, env = process.env } = options;
+  const config = resolveTelemetryConfig(env);
+  const batch = queue;
+  queue = [];
+
+  if (!config.enabled || batch.length === 0 || !config.instrumentationKey || !config.ingestionEndpoint) {
+    return;
+  }
+
+  const send = sendBatch(batch, config.instrumentationKey, config.ingestionEndpoint).catch(() => undefined);
+  await Promise.race([send, timeout(timeoutMs)]);
+}
+
+/** Test-only: clears the in-process queue between tests. Not exported from `index.ts`. */
+export function __resetQueueForTests(): void {
+  queue = [];
+}
+
+/** Read-only snapshot of the queued-but-unsent events, without draining it. Backs `--telemetry-show` (R5): inspect what a run *would* send without actually sending it. */
+export function peekQueuedEvents(): readonly TelemetryEvent[] {
+  return queue;
+}

--- a/src/telemetry/signature.ts
+++ b/src/telemetry/signature.ts
@@ -1,0 +1,14 @@
+import { createHash } from "node:crypto";
+
+/**
+ * SHA-256 hex digest of a structural shape descriptor (R2's `signatureHash`
+ * on `parse_failure`). `shape` must already be a content-free description
+ * of *where* parsing broke (e.g. `"claude-code:turn.usage.missing"`) — this
+ * function only hashes what it's given; keeping transcript content out of
+ * `shape` is the caller's responsibility (see `telemetry/index.ts`'s
+ * `recordParseFailure`, the only caller). Deterministic (I1): same shape
+ * always hashes to the same digest.
+ */
+export function hashSignature(shape: string): string {
+  return createHash("sha256").update(shape, "utf8").digest("hex");
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ const hasNodeSqlite = maj > 22 || (maj === 22 && min >= 5);
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts"],
+    include: ["test/**/*.test.ts", "src/telemetry/**/*.test.ts"],
     environment: "node",
     testTimeout: 20_000,
     pool: "forks",


### PR DESCRIPTION
Implements SPEC-0002 (stacked on #1). Diagnostics-only telemetry per amended I4: three events (`cli_run`, `cli_error`, `parse_failure` — the format-drift sensor), strict zod allowlist schemas where anything off-schema is dropped rather than sanitized, `AIRECEIPTS_TELEMETRY=off` / `DO_NOT_TRACK=1` kill switches with a mocked-fetch no-network proof, a 300ms bounded fail-safe flush at shutdown, a persisted first-run disclosure notice, and `--telemetry-show`.

Notable: the default connection string is deliberately **empty** — telemetry sends nothing anywhere until a real App Insights key is provisioned, and `docs/telemetry.md` says exactly that (the docs-vs-code contradiction class from the spec's validation record is structurally impossible right now). Provisioning the key + updating the doc is a maintainer action before launch.

Gate: tsc 0 · eslint 0 · vitest 0 (239 incl. 91 telemetry) · goldens 0. Live-tested: kill switch honored, notice prints once to stderr, `--telemetry-show` renders the empty-events payload.
