### PR TITLE
chore: wire Azure App Insights telemetry connection

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -91,8 +91,8 @@ This prints whether telemetry is currently enabled and the exact events queued f
 
 This section exists so the code and this document can never quietly disagree.
 
-- The ingestion key this package ships with is **not a secret** — Application Insights instrumentation keys are write-only and are commonly embedded in open-source clients. It will be listed here plainly once one is provisioned.
-- **Current status**: no Azure resource has been wired up yet. The shipped default connection string is intentionally **empty**, not a placeholder-that-looks-real. An empty connection string takes the exact same code path as the kill switches: `resolveTelemetryConfig()` reports `enabled: false`, and zero network calls are made. This is deliberate, not a bug — until a real key is provisioned, `aireceipts` sends no telemetry to anyone, full stop, regardless of the kill switches.
+- The ingestion key this package ships with is **not a secret** — Application Insights instrumentation keys are write-only and are commonly embedded in open-source clients. The shipped key, plainly: `InstrumentationKey=34293e98-bc05-47c7-bab3-5dd0535ac315` (ingestion endpoint `eastus-8.in.applicationinsights.azure.com`).
+- **Current status**: a real Azure Application Insights resource is wired up as of 2026-07-02, so the diagnostics events documented above are sent by default (subject to the kill switches and the 300 ms bounded flush). Run `aireceipts --telemetry-show` to see exactly what a run would send before it sends anything.
 - `AIRECEIPTS_TELEMETRY_CONNECTION` overrides the shipped default. Set it to point at your own Application Insights resource (e.g. for local development or a private fork), or set it to an empty string to force-disable telemetry independent of the kill switches.
 - A malformed connection string (missing either `InstrumentationKey` or `IngestionEndpoint`) also degrades to `enabled: false` rather than sending to an incomplete endpoint.
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -91,7 +91,7 @@ This prints whether telemetry is currently enabled and the exact events queued f
 
 This section exists so the code and this document can never quietly disagree.
 
-- The ingestion key this package ships with is **not a secret** — Application Insights instrumentation keys are write-only and are commonly embedded in open-source clients. The shipped key, plainly: `InstrumentationKey=34293e98-bc05-47c7-bab3-5dd0535ac315` (ingestion endpoint `eastus-8.in.applicationinsights.azure.com`).
+- The ingestion key this package ships with is **not a secret** — Application Insights instrumentation keys are write-only and are commonly embedded in open-source clients. The shipped key, plainly: `InstrumentationKey=394da360-a50c-4700-bcf9-87b8d9d6e0ee` (ingestion endpoint `eastus-8.in.applicationinsights.azure.com`).
 - **Current status**: a real Azure Application Insights resource is wired up as of 2026-07-02, so the diagnostics events documented above are sent by default (subject to the kill switches and the 300 ms bounded flush). Run `aireceipts --telemetry-show` to see exactly what a run would send before it sends anything.
 - `AIRECEIPTS_TELEMETRY_CONNECTION` overrides the shipped default. Set it to point at your own Application Insights resource (e.g. for local development or a private fork), or set it to an empty string to force-disable telemetry independent of the kill switches.
 - A malformed connection string (missing either `InstrumentationKey` or `IngestionEndpoint`) also degrades to `enabled: false` rather than sending to an incomplete endpoint.

--- a/src/telemetry/config.test.ts
+++ b/src/telemetry/config.test.ts
@@ -24,7 +24,7 @@ describe("SC connection-string honesty: empty/unset/malformed all collapse to th
   it("an unset connection string uses the shipped default key — enabled (docs/telemetry.md states the key openly)", () => {
     const config = resolveTelemetryConfig({});
     expect(config.enabled).toBe(true);
-    expect(config.instrumentationKey).toBe("34293e98-bc05-47c7-bab3-5dd0535ac315");
+    expect(config.instrumentationKey).toBe("394da360-a50c-4700-bcf9-87b8d9d6e0ee");
     expect(config.ingestionEndpoint).toContain("eastus-8.in.applicationinsights.azure.com");
   });
 

--- a/src/telemetry/config.test.ts
+++ b/src/telemetry/config.test.ts
@@ -21,9 +21,11 @@ describe("R4: kill switches disable telemetry", () => {
 });
 
 describe("SC connection-string honesty: empty/unset/malformed all collapse to the same disabled shape", () => {
-  it("an unset connection string (default empty placeholder) disables telemetry — zero calls, not a fabricated key", () => {
+  it("an unset connection string uses the shipped default key — enabled (docs/telemetry.md states the key openly)", () => {
     const config = resolveTelemetryConfig({});
-    expect(config).toEqual({ enabled: false, instrumentationKey: undefined, ingestionEndpoint: undefined });
+    expect(config.enabled).toBe(true);
+    expect(config.instrumentationKey).toBe("34293e98-bc05-47c7-bab3-5dd0535ac315");
+    expect(config.ingestionEndpoint).toContain("eastus-8.in.applicationinsights.azure.com");
   });
 
   it("an explicitly empty connection string disables telemetry", () => {

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -21,7 +21,7 @@
 // App Insights ingestion key is a write-only address, not a secret; override or
 // disable via AIRECEIPTS_TELEMETRY_CONNECTION / the kill switches).
 const DEFAULT_CONNECTION_STRING =
-  "InstrumentationKey=34293e98-bc05-47c7-bab3-5dd0535ac315;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=5ce2840c-b895-46d4-8085-291c7740581d";
+  "InstrumentationKey=394da360-a50c-4700-bcf9-87b8d9d6e0ee;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=27aef4ec-bd68-44e1-968b-913ddc5ed538";
 
 export interface TelemetryConfig {
   enabled: boolean;

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -17,7 +17,11 @@
  * Azure resource, not something to invent (I2's "never fabricate" applies
  * equally to secret-shaped strings).
  */
-const DEFAULT_CONNECTION_STRING = "";
+// Openly-embedded ingest-only connection string (see docs/telemetry.md — an
+// App Insights ingestion key is a write-only address, not a secret; override or
+// disable via AIRECEIPTS_TELEMETRY_CONNECTION / the kill switches).
+const DEFAULT_CONNECTION_STRING =
+  "InstrumentationKey=34293e98-bc05-47c7-bab3-5dd0535ac315;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=5ce2840c-b895-46d4-8085-291c7740581d";
 
 export interface TelemetryConfig {
   enabled: boolean;

--- a/src/telemetry/index.test.ts
+++ b/src/telemetry/index.test.ts
@@ -94,8 +94,8 @@ describe("R2: exactly three event names, exhaustively, via the public recorder f
 });
 
 describe("showTelemetryPayload: R5 --telemetry-show backing function", () => {
-  it("reports disabled with an empty queue when no connection string is configured", () => {
-    const result = showTelemetryPayload({});
+  it("reports disabled with an empty queue when the connection string is explicitly empty", () => {
+    const result = showTelemetryPayload({ AIRECEIPTS_TELEMETRY_CONNECTION: "" });
     expect(result).toEqual({ enabled: false, events: [] });
   });
 

--- a/src/telemetry/sender.test.ts
+++ b/src/telemetry/sender.test.ts
@@ -48,12 +48,12 @@ describe("R6: no-network proof", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("an unset (default empty) connection string results in zero fetch calls", async () => {
+  it("an explicitly empty connection string results in zero fetch calls", async () => {
     const fetchSpy = vi.fn();
     globalThis.fetch = fetchSpy as unknown as typeof fetch;
 
     recordEvent(SAMPLE_EVENT);
-    await flushTelemetry({ env: {} });
+    await flushTelemetry({ env: { AIRECEIPTS_TELEMETRY_CONNECTION: "" } });
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Embeds the ingest-only App Insights connection string (write-only key, documented openly per docs/telemetry.md — not a secret) and updates the docs' connection-string-honesty section to match reality, closing the SPEC-0002 success criterion. Kill switches and --telemetry-show unchanged and re-verified (tsc + full vitest green). Note: this is the same App Insights resource the private repo's CI action reports to — event names don't collide (cli_run/cli_error/parse_failure vs receipts_usage/receipts_pr), but a dedicated resource for aireceipts would be cleaner before heavy public traffic.