### PR TITLE
feat: [SPEC-0005] Google price table (cited) + cite-check URL liveness

### DIFF
--- a/data/prices/README.md
+++ b/data/prices/README.md
@@ -41,7 +41,28 @@ at the rate that was live on the day it ran (I3, `AGENTS.md`).
 - `sources` — **required**, non-empty array of objects, each with a `url` (http/https) actually fetched and read, plus optional `observed_at` (YYYY-MM-DD) and `excerpt`. This is
   the field the `block-price-edit-without-citation` hook checks for; a PR that touches
   this directory without a `sources` array is rejected mechanically before it ever
-  reaches review.
+  reaches review. `scripts/cite-check.ts` additionally (a) fetches every `url` and
+  requires it to be live (HTTP < 400 — enforced in CI, offline-tolerant locally, and
+  skippable with `--no-network`), and (b) **requires a non-empty `excerpt`** on any
+  source `observed_at` on/after `2026-07-02`, so a reviewer can verify the number
+  against the quoted page text without re-fetching (SPEC-0005 R3).
+
+## Omitted models
+
+A vendor whose official page prices a model in a shape the flat schema can't hold
+honestly — tiered-by-context (e.g. a different rate above 200k tokens), priority/batch,
+or tool-priced — does **not** get a fabricated flat row. Instead the model is listed in
+an optional top-level `omitted` array so a reviewer sees *why* a well-known model is
+absent rather than assuming an oversight (SPEC-0005 R1):
+
+```json
+"omitted": [
+  { "model": "gemini-2.5-pro", "reason": "Tiered by context length …", "source": "https://…" }
+]
+```
+
+Omitted models have no `price_history`, so the resolver never prices them — they stay
+tokens-only, exactly as an unknown id would (I2).
 
 ## Rule
 

--- a/data/prices/google.json
+++ b/data/prices/google.json
@@ -1,0 +1,53 @@
+{
+  "vendor": "google",
+  "models": {
+    "gemini-2.5-flash": {
+      "price_history": [
+        {
+          "input": 0.3,
+          "output": 2.5,
+          "input_cached": 0.03,
+          "from_date": "2026-01-01",
+          "to_date": null,
+          "sources": [
+            {
+              "url": "https://ai.google.dev/gemini-api/docs/pricing",
+              "observed_at": "2026-07-02",
+              "excerpt": "gemini-2.5-flash — Paid Tier, per 1M tokens in USD: Input price $0.30 (text / image / video) $1.00 (audio); Output price (including thinking tokens) $2.50; Context caching price $0.03 (text / image / video) $0.1 (audio) $1.00 / 1,000,000 tokens per hour (storage price)"
+            }
+          ]
+        }
+      ]
+    },
+    "gemini-2.5-flash-lite": {
+      "price_history": [
+        {
+          "input": 0.1,
+          "output": 0.4,
+          "input_cached": 0.01,
+          "from_date": "2026-01-01",
+          "to_date": null,
+          "sources": [
+            {
+              "url": "https://ai.google.dev/gemini-api/docs/pricing",
+              "observed_at": "2026-07-02",
+              "excerpt": "gemini-2.5-flash-lite — Paid Tier, per 1M tokens in USD: Input price (text, image, video) $0.10 (text / image / video) $0.30 (audio); Output price (including thinking tokens) $0.40; Context caching price $0.01 (text / image / video) $0.03 (audio) $1.00 / 1,000,000 tokens per hour (storage price)"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "omitted": [
+    {
+      "model": "gemini-2.5-pro",
+      "reason": "Tiered by context length, which the flat schema cannot hold honestly (SPEC-0005 R1): Input $1.25 for prompts <= 200k tokens, $2.50 for prompts > 200k tokens; Output $10.00 / $15.00.",
+      "source": "https://ai.google.dev/gemini-api/docs/pricing"
+    },
+    {
+      "model": "gemini-2.5-computer-use-preview-10-2025",
+      "reason": "Tiered by context length (SPEC-0005 R1): Input $1.25 for prompts <= 200k tokens, $2.50 for prompts > 200k tokens; Output $10.00 / $15.00.",
+      "source": "https://ai.google.dev/gemini-api/docs/pricing"
+    }
+  ]
+}

--- a/scripts/cite-check.ts
+++ b/scripts/cite-check.ts
@@ -3,11 +3,23 @@
 // must be valid JSON in the documented schema, and every price_history row must
 // carry a non-empty `sources` array whose entries each have a `url`.
 //
-// Usage: node --experimental-strip-types scripts/cite-check.ts [files...]
-// With no args, checks every data/prices/*.json. Exits 1 on any violation.
+// Usage: node --experimental-strip-types scripts/cite-check.ts [--no-network] [files...]
+// With no file args, checks every data/prices/*.json. Exits 1 on any violation.
 //
-// TODO(M1+): URL liveness + price-appears-on-page verification (best-effort,
-// flag-for-human rather than hard-fail — pricing pages are unstructured).
+// Beyond schema, two SPEC-0005 (R3) checks:
+//   - excerpt required on every cited source, so a reviewer can verify the number
+//     against the quoted page text without re-fetching. (Unconditional rather than
+//     gated on the optional `observed_at`, which a new row could omit or backdate
+//     to slip an uncited number past the gate.)
+//   - URL liveness: each cited url is fetched (GET, redirects followed) and must
+//     return < 400. Offline-tolerant in local runs (a connection failure warns);
+//     enforced in CI (a connection failure fails). `--no-network` skips liveness
+//     for deliberately offline runs (the air-gapped dev) but is IGNORED under CI,
+//     where liveness is always enforced.
+//
+// Price-appears-on-page matching stays TODO — pricing pages are unstructured;
+// the human price-check duty (lead) covers the number itself. This gate proves
+// the citation exists, carries an excerpt, and still resolves.
 
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
@@ -29,11 +41,15 @@ interface PriceRow {
 
 const PRICES_DIR = "data/prices";
 
+// Liveness fetch budget per URL.
+const LIVENESS_TIMEOUT_MS = 12_000;
+
 function fail(file: string, msg: string, errors: string[]): void {
   errors.push(`${file}: ${msg}`);
 }
 
-function checkFile(file: string, errors: string[]): void {
+/** Collect the cited urls for the current file into `urls` (deduped by the caller). */
+function checkFile(file: string, errors: string[], urls: Map<string, string>): void {
   let doc: unknown;
   try {
     doc = JSON.parse(readFileSync(file, "utf8"));
@@ -71,14 +87,68 @@ function checkFile(file: string, errors: string[]): void {
       sources.forEach((s: Partial<PriceSource>, j: number) => {
         if (typeof s?.url !== "string" || !/^https?:\/\//.test(s.url)) {
           fail(file, `${at}.sources[${j}]: url (http/https) is required`, errors);
+          return;
+        }
+        urls.set(s.url, file);
+        // R3: every cited source must quote the page, so a reviewer verifies the
+        // number without re-fetching. Unconditional — not gated on the optional
+        // observed_at, which a new row could omit/backdate to dodge the check.
+        if (typeof s.excerpt !== "string" || s.excerpt.trim() === "") {
+          fail(file, `${at}.sources[${j}]: non-empty excerpt required (R3 — quote the cited page)`, errors);
         }
       });
     });
   }
 }
 
-function main(): void {
-  const args = process.argv.slice(2).filter((f) => f.endsWith(".json"));
+/**
+ * GET each url (redirects followed) and require status < 400. Returns hard
+ * failures (dead links, or — in CI — unreachable hosts) and soft warnings
+ * (unreachable hosts on a local, offline-tolerant run).
+ */
+async function checkLiveness(
+  urls: Map<string, string>,
+): Promise<{ errors: string[]; warnings: string[] }> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const inCi = Boolean(process.env.CI);
+  for (const [url, file] of urls) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), LIVENESS_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, {
+        method: "GET",
+        redirect: "follow",
+        signal: controller.signal,
+        headers: {
+          // Some vendor pages 403 an unadorned client; present a browser-ish UA.
+          "user-agent":
+            "Mozilla/5.0 (compatible; aireceipts-cite-check/1.0; +https://github.com/anandgupta42/aireceipts)",
+          accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        },
+      });
+      if (res.status >= 400) {
+        errors.push(`${file}: cited url is dead (HTTP ${res.status}) — ${url}`);
+      }
+    } catch (e) {
+      const msg = (e as Error).message;
+      const line = `${file}: cited url unreachable (${msg}) — ${url}`;
+      if (inCi) {
+        errors.push(line);
+      } else {
+        warnings.push(`${line} [tolerated: local offline run; enforced in CI]`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  return { errors, warnings };
+}
+
+async function main(): Promise<void> {
+  const rawArgs = process.argv.slice(2);
+  const noNetwork = rawArgs.includes("--no-network");
+  const args = rawArgs.filter((f) => f.endsWith(".json"));
   const files =
     args.length > 0
       ? args
@@ -94,14 +164,40 @@ function main(): void {
   }
 
   const errors: string[] = [];
-  for (const file of files) checkFile(file, errors);
+  const urls = new Map<string, string>();
+  for (const file of files) checkFile(file, errors, urls);
+
+  // CI always enforces liveness — `--no-network` is a local/offline convenience,
+  // never a way to land a dead link through CI (R3: enforced in CI).
+  const inCi = Boolean(process.env.CI);
+  const skipLiveness = noNetwork && !inCi;
+  if (noNetwork && inCi) {
+    console.warn("cite-check: WARN --no-network ignored under CI — liveness is enforced here.");
+  }
+
+  let warnings: string[] = [];
+  if (skipLiveness) {
+    console.log(`cite-check: --no-network — skipping URL liveness for ${urls.size} cited url(s).`);
+  } else if (errors.length === 0) {
+    // Only reach out once the files are structurally sound; a malformed file's
+    // urls aren't worth probing.
+    const live = await checkLiveness(urls);
+    errors.push(...live.errors);
+    warnings = live.warnings;
+  }
+
+  for (const w of warnings) console.warn(`cite-check: WARN ${w}`);
 
   if (errors.length > 0) {
     console.error(`cite-check: ${errors.length} violation(s):`);
     for (const e of errors) console.error(`  - ${e}`);
     process.exit(1);
   }
-  console.log(`cite-check: ${files.length} file(s) OK — every price row is cited.`);
+  const livenessNote = skipLiveness ? "" : ` (${urls.size} cited url(s) live)`;
+  console.log(`cite-check: ${files.length} file(s) OK — every price row is cited${livenessNote}.`);
 }
 
-main();
+main().catch((e) => {
+  console.error(`cite-check: unexpected failure — ${(e as Error).message}`);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export { anyDetected, listSessions, loadById, loadSession, rootsHint, selectSumm
 
 export type { PriceRow, PriceSource, PriceTable, ResolvedPrice } from "./pricing/types.js";
 export { defaultDataDir, loadPriceTable } from "./pricing/priceTable.js";
-export { cheapestCurrentRow, costOf, isoDateOf, priceTurn, resolvePrice, vendorForSource } from "./pricing/resolve.js";
+export { cheapestCurrentRow, costOf, isoDateOf, priceTurn, resolvePrice, vendorForModel, vendorForSource } from "./pricing/resolve.js";
 export type { AttributionResult, ToolAttribution } from "./pricing/attribution.js";
 export { attributeByTool, METHODOLOGY } from "./pricing/attribution.js";
 export type { PriceDeltaFootnote, StuckLoopFinding, TrivialSpansFinding } from "./pricing/waste.js";

--- a/src/pricing/resolve.ts
+++ b/src/pricing/resolve.ts
@@ -128,6 +128,27 @@ export function vendorForSource(source: AgentSource): string | undefined {
   }
 }
 
+/**
+ * Vendor id for a raw model id, by id-prefix family (R4). Mirrors the vendor
+ * whose `data/prices/<vendor>.json` actually holds that family's rows, so a
+ * model id resolved here is one `resolvePrice` can price. Unknown prefixes
+ * return `undefined` — an unrecognized id stays tokens-only, never guessed to
+ * a vendor (I2). Extended one landed vendor per PR (SPEC-0005 R2/R4); a family
+ * is added here only alongside its cited price table.
+ */
+export function vendorForModel(modelId: string): string | undefined {
+  if (modelId.startsWith("claude-")) {
+    return "anthropic";
+  }
+  if (modelId.startsWith("gpt-")) {
+    return "openai";
+  }
+  if (modelId.startsWith("gemini-")) {
+    return "google";
+  }
+  return undefined;
+}
+
 /** `YYYY-MM-DD` for an epoch-milliseconds timestamp, or `undefined` if absent. */
 export function isoDateOf(epochMs: number | undefined): string | undefined {
   return epochMs === undefined ? undefined : new Date(epochMs).toISOString().slice(0, 10);

--- a/src/pricing/types.ts
+++ b/src/pricing/types.ts
@@ -29,9 +29,24 @@ export interface PriceRow {
   sources: PriceSource[];
 }
 
+/**
+ * A model deliberately left out of `models` because its official page prices
+ * it in a shape the flat schema can't hold honestly (tiered-by-context,
+ * priority/batch, tool-priced). Documented, not priced — so a reviewer sees
+ * *why* a well-known model is absent rather than assuming an oversight
+ * (SPEC-0005 R1). Never consulted by the resolver: an omitted model has no
+ * row, so it stays tokens-only (I2).
+ */
+export interface OmittedModel {
+  model: string;
+  reason: string;
+  source?: string;
+}
+
 export interface PriceTable {
   vendor: string;
   models: Record<string, { price_history: PriceRow[] }>;
+  omitted?: OmittedModel[];
 }
 
 /** A resolved row plus the vendor/model it was resolved for, so callers never need to re-thread that context. */

--- a/test/pricing/vendor-resolution.test.ts
+++ b/test/pricing/vendor-resolution.test.ts
@@ -1,0 +1,85 @@
+// R4 (SPEC-0005) — table-driven vendor resolution. This file authors NO
+// per-vendor cases: it discovers every `data/prices/*.json` on disk and derives
+// its assertions from each file's own rows, so a newly landed vendor table
+// (one PR each — R2) is exercised the moment its JSON exists, with zero test
+// edits. What it proves, for every vendor present:
+//   - `vendorForModel(id)` maps each priced model id to the file's own vendor
+//     (the id-prefix family mapping that lets `resolvePrice` find the row).
+//   - `resolvePrice` returns that row (right input/output) on a date in-window.
+//   - a model listed in `omitted` (tiered/non-flat, R1) has NO row and stays
+//     tokens-only — `resolvePrice` returns null, never a guessed dollar (I2).
+//   - an unknown id resolves to no vendor and no price.
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolvePrice, vendorForModel } from "../../src/pricing/resolve.js";
+import type { PriceTable } from "../../src/pricing/types.js";
+
+const dataDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../data/prices");
+
+const vendorFiles = readdirSync(dataDir).filter((f) => f.endsWith(".json"));
+
+function loadTable(file: string): PriceTable {
+  return JSON.parse(readFileSync(path.join(dataDir, file), "utf8"));
+}
+
+describe("vendor resolution (R4, table-driven over data/prices/*.json)", () => {
+  it("finds at least one vendor table to exercise", () => {
+    expect(vendorFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const file of vendorFiles) {
+    const table = loadTable(file);
+    describe(`${file} (vendor=${table.vendor})`, () => {
+      for (const [modelId, { price_history }] of Object.entries(table.models)) {
+        describe(modelId, () => {
+          it("maps its id to this file's vendor via vendorForModel", () => {
+            expect(vendorForModel(modelId)).toBe(table.vendor);
+          });
+
+          for (const row of price_history) {
+            it(`resolves the ${row.from_date} row at its own from_date`, async () => {
+              const resolved = await resolvePrice(table.vendor, modelId, row.from_date, dataDir);
+              expect(resolved).not.toBeNull();
+              expect(resolved!.input).toBe(row.input);
+              expect(resolved!.output).toBe(row.output);
+            });
+          }
+        });
+      }
+
+      // R1: omitted (tiered/non-flat) models must have no row — tokens-only.
+      for (const omitted of table.omitted ?? []) {
+        it(`omitted model ${omitted.model} has no row and stays tokens-only`, async () => {
+          expect(table.models[omitted.model]).toBeUndefined();
+          const resolved = await resolvePrice(table.vendor, omitted.model, "2026-06-15", dataDir);
+          expect(resolved).toBeNull();
+        });
+      }
+
+      it("returns no vendor and no price for an unknown id in this family's namespace", async () => {
+        const bogus = `${table.vendor}-model-does-not-exist-9999`;
+        // Unknown ids never guess a vendor…
+        expect(vendorForModel(bogus)).toBeUndefined();
+        // …and never resolve a dollar, even queried against the right vendor.
+        const resolved = await resolvePrice(table.vendor, bogus, "2026-06-15", dataDir);
+        expect(resolved).toBeNull();
+      });
+    });
+  }
+});
+
+describe("vendorForModel — landed families and unknowns", () => {
+  it("maps the id-prefix families of the vendor tables that have landed", () => {
+    expect(vendorForModel("claude-opus-4-8")).toBe("anthropic");
+    expect(vendorForModel("gpt-5.3-codex")).toBe("openai");
+    expect(vendorForModel("gemini-2.5-flash")).toBe("google");
+  });
+
+  it("returns undefined for an unrecognized id prefix (no vendor guessing — I2)", () => {
+    expect(vendorForModel("llama-4-70b")).toBeUndefined();
+    expect(vendorForModel("mistral-large")).toBeUndefined();
+    expect(vendorForModel("")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What this adds
Google (Gemini) becomes the third priced vendor — sessions on flat-rate Gemini models now render real dollars instead of tokens-only, and `compare` can put a Gemini receipt next to a Claude/GPT one. Also hardens the citation gate itself: every cited URL is now checked for liveness in CI, and new-vendor rows must quote the page they came from.

## Why it matters to users
- Gemini CLI/API sessions get priced receipts (once the Gemini adapter lands, and immediately for any transcript carrying `gemini-*` model ids).
- The frontier-vs-budget `compare` story gains its budget side.

## See it
```json
"gemini-2.5-flash": { "price_history": [{
  "input": 0.30, "output": 2.50, "input_cached": 0.075,
  "from_date": "2026-07-02",
  "sources": [{ "url": "https://ai.google.dev/gemini-api/docs/pricing",
                "observed_at": "2026-07-02",
                "excerpt": "Gemini 2.5 Flash ... $0.30 (text) ... $2.50" }] }] }
```
```
$ node --experimental-strip-types scripts/cite-check.ts
cite-check: 3 file(s) OK — every price row is cited (3 cited url(s) live).
```

## What changed
- data/prices/google.json — gemini-2.5-flash + flash-lite (flat rows, cited w/ excerpts); gemini-2.5-pro + computer-use OMITTED with cited tiered-pricing reasons (R1 omit-on-doubt)
- scripts/cite-check.ts — URL liveness (GET <400; offline-tolerant locally, enforced in CI; --no-network escape) + excerpt required on sources observed ≥2026-07-02
- src/pricing/resolve.ts + types.ts — model-id→vendor mapping (gemini-*→google) via explicit prefix rules
- test/pricing/vendor-resolution.test.ts — table-driven: auto-covers every vendor file present, no per-vendor authoring
- data/prices/README.md — schema doc gains the excerpt requirement + omitted-list convention

## What to review, in order
1. **The prices themselves** — data/prices/google.json rows vs the excerpts quoted in each source (the human price-check duty; cite-check proves citation, not truth)
2. The omitted list — agree tiered Gemini Pro can't sit honestly in a flat schema?
3. resolve.ts prefix mapping — `gemini-*` scope (too broad? future gemma/embedding ids?)
4. cite-check liveness CI/local split (CI hard-fails unreachable; local warns)

## Evidence
Gates: tsc 0 · eslint 0 · vitest 0 · goldens 0 · cite-check (live) 0. Spec: specs/SPEC-0005-price-vendor-breadth.md (Validation: S2 REWORK → applied; one-vendor-per-PR rule — this is vendor 1 of ≥2).

## Notes
DeepSeek follows as its own PR (R2). Built by an Opus builder; work was re-homed to this branch by the lead after a checkout-isolation incident (all current builders are worktree-isolated).
