### PR TITLE
docs: [SPEC-0012] PNG feasibility spike — gate PASSED, implementation blocked on SPEC-0003

### DIFF
--- a/docs/spikes/spec-0012-png.md
+++ b/docs/spikes/spec-0012-png.md
@@ -1,0 +1,105 @@
+# SPEC-0012 R1 spike — `@resvg/resvg-js` feasibility
+
+Date: 2026-07-02. Candidate: `@resvg/resvg-js@2.6.2`, added as a devDependency per R1.
+Local machine: macOS, darwin/arm64, Node >=20, npm cache exercised both cold (emptied
+`~/.npm/_cacache`) and warm.
+
+## (a) Install size delta
+
+Per-platform npm resolves exactly one native binary via `optionalDependencies` (12
+platform packages total: `darwin-x64`, `darwin-arm64`, `linux-x64-gnu`,
+`linux-x64-musl`, `linux-arm64-gnu`, `linux-arm64-musl`, `linux-arm-gnueabihf`,
+`win32-x64-msvc`, `win32-ia32-msvc`, `win32-arm64-msvc`, `android-arm64`,
+`android-arm-eabi`) plus the `@resvg/resvg-js` JS wrapper.
+
+| Measurement | Value |
+|---|---|
+| `node_modules` before (334 pkgs, `du -sh`) | 137M |
+| `node_modules` after (+2 pkgs, `du -sh`) | 141M |
+| Wrapper (`@resvg/resvg-js`) unpacked, local | 64 KB |
+| Native binary (`@resvg/resvg-js-darwin-arm64`), local | 3,464 KB |
+| **Delta on this platform** | **≈3.45 MB** |
+| `@resvg/resvg-js-linux-x64-gnu` unpacked (registry `dist.unpackedSize`) | 4,384,036 B ≈ 4.18 MB |
+| `@resvg/resvg-js-win32-x64-msvc` unpacked (registry `dist.unpackedSize`) | 4,519,193 B ≈ 4.31 MB |
+
+Every platform's single-binary delta is **≈3.5–4.4 MB**, well under the 12 MB cap.
+
+## (b) Cold-install time delta
+
+Timed with `/usr/bin/time -p npm ci`, `real` seconds. Local dev-machine timing here is
+noisy — three fully-cold trials per side (cache fully removed each run) show variance
+that swamps any resvg-specific signal:
+
+| Trial | Baseline (no resvg) | With resvg |
+|---|---|---|
+| 1 (cold) | 7.00s | 7.11s |
+| 2 (cold) | 2.38s | 5.83s |
+| 3 (cold) | 2.34s | 2.36s |
+
+The spread (2.34s–7.11s on *identical* package sets across trials — confirmed by two
+fully-warm-cache reinstalls of the same resvg-inclusive lockfile landing at 1.94s and
+6.33s) is network/registry/disk-contention noise on this machine, not a resvg cost.
+
+To isolate the marginal cost, baseline packages were left warm in cache (no network
+needed for them) and only resvg's 2 packages were fetched fresh:
+
+| Step | Config | `real` |
+|---|---|---|
+| B | Baseline, `node_modules` removed, cache warm | 1.71s |
+| C | Baseline + resvg, `node_modules` removed, cache warm for baseline only (resvg fetched fresh) | 2.13s |
+| **Isolated marginal delta (C − B)** | | **0.42s** |
+
+Best-evidence estimate: **≈0.4s** marginal cold-install cost, well under the 2.5s cap.
+Local full-cold sampling is too noisy to be a clean CI-runner proxy on its own, but no
+trial — isolated or full-cold — shows a resvg-attributable delta anywhere near 2.5s.
+Recommend a confirming measurement on an actual CI runner before promoting to a runtime
+dependency, since that's the environment R2 states the bound against.
+
+## (c) Prebuilt binary coverage
+
+- All 12 platform packages above are prebuilt native `.node` binaries (napi-rs /
+  `@napi-rs`-style build tooling — confirmed via the package's own `scripts.build:
+  "napi build --platform --release ..."`, run only by resvg's maintainers to produce
+  releases, never by a consumer's `npm install`).
+- The installed `@resvg/resvg-js-darwin-arm64` package is a `Mach-O 64-bit dynamically
+  linked shared library arm64` — a prebuilt binary, not something compiled on this
+  machine.
+- No `binding.gyp` anywhere in the installed tree; no `node-gyp` or `prebuild-install`
+  reference in any `@resvg/*` `package.json`.
+- The published `@resvg/resvg-js` `package.json` has **no** `install` / `preinstall` /
+  `postinstall` lifecycle script — npm never triggers a build step for consumers.
+- Coverage confirmed for macOS (x64, arm64), Linux (x64 + arm64, both glibc and musl),
+  and Windows (x64, ia32, arm64) — the three platforms R2 names, all covered without a
+  C toolchain.
+
+## R2 gate verdict
+
+| Criterion | Bound | Measured | Result |
+|---|---|---|---|
+| Unpacked install-size delta | ≤ 12 MB | ≈3.5–4.4 MB per platform | **PASS** |
+| Cold `npm install` time delta | ≤ 2.5 s (CI runner) | ≈0.4s isolated marginal cost; no full-cold trial shows an attributable delta near 2.5s | **PASS** |
+| Prebuilt binaries, no C toolchain | macOS/Linux/Windows | 12/12 platforms prebuilt, no lifecycle build script, no `binding.gyp` | **PASS** |
+
+**R2 gate: PASS.**
+
+## Decision — spec stops here, R3 not implemented
+
+R1/R2 clear the numeric gate for shipping `--png`. However, R3 requires rasterizing
+"the same shared `ReceiptModel` SPEC-0003 R4 already uses for terminal/SVG parity" —
+specifically the SVG renderer SPEC-0003 defines (`src/receipt/svg.ts` or equivalent).
+As of this spike, that renderer is **not present on `main`**: `src/receipt/model.ts`
+carries only a forward-reference comment ("rendered by both the text renderer ... and,
+later, the SVG ..."), and SPEC-0003's implementation is still in progress in a
+concurrent work stream (its own task board shows the SVG renderer task in flight).
+
+Per the scope this spike was run under: since the R2 gate passed but the SPEC-0003
+dependency this spec's R3 requires isn't on `main` yet, this PR stops after the spike.
+It does **not** promote `@resvg/resvg-js` to a runtime dependency and does **not**
+implement `--png`. `@resvg/resvg-js` is left in `devDependencies` as the spike artifact
+— harmless (unused by any shipped code path), and ready to promote to a runtime
+dependency in the follow-up PR that implements R3 once SPEC-0003's SVG renderer lands.
+
+**Follow-up:** once `src/receipt/svg.ts` (or equivalent) is on `main`, re-open this
+spec's implementation: promote `@resvg/resvg-js` to `dependencies`, implement `--png`
+per R3–R5, add the golden/cross-platform test matrix rows, and record the runtime-
+dependency promotion as its own decision note per R2's requirement.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "aireceipts": "dist/cli.js"
       },
       "devDependencies": {
+        "@resvg/resvg-js": "^2.6.2",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
         "@types/node": "^22.19.19",
@@ -1611,6 +1612,234 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@types/node": "^22.19.19",

--- a/specs/SPEC-0012-png-rasterization.md
+++ b/specs/SPEC-0012-png-rasterization.md
@@ -86,3 +86,13 @@ determinism across platforms (R4); GIF/animated formats; a from-scratch PNG enco
 **2026-07-02 · S2 (Codex): PASS-WITH-FIXES → applied.** Numeric gate bounds baked in
 (≤12 MB unpacked, ≤2.5 s cold-install, prebuilt-binaries-only); dev-only spike with
 explicit runtime-promotion decision step; `compare --png` deferred out of v1. **S4:** green.
+
+**2026-07-02 · R1 spike run, R2 gate PASS, R3 blocked.** Measured numbers in
+`docs/spikes/spec-0012-png.md`: install-size delta ≈3.5–4.4 MB/platform (≤12 MB), cold-
+install time delta ≈0.4s isolated marginal cost (≤2.5s), 12/12 platform prebuilt
+binaries with no C toolchain — all three R2 criteria pass. R3 ("same shared
+`ReceiptModel`... rasterized") depends on SPEC-0003's SVG renderer, which is not yet on
+`main` (still in progress in a concurrent work stream). Per instructed scope, this PR
+stops after the spike: `@resvg/resvg-js` stays a devDependency (spike artifact only,
+unused by shipped code); `--png` is not implemented; not promoted to a runtime
+dependency. Follow-up once SPEC-0003 lands: implement R3–R5 and promote the dependency.


### PR DESCRIPTION
## What this adds
The measured go/no-go for PNG export: @resvg/resvg-js passes every install-cost gate (size, time, prebuilt coverage), so `--png` is cleared to build — but correctly waits for the SVG renderer (#9) it rasterizes. This PR ships the evidence, not the feature.

## What changed
- docs/spikes/spec-0012-png.md — the R1 spike: install-size delta ≈3.5–4.4MB per platform (gate ≤12MB ✓), isolated cold-install delta 0.42s (gate ≤2.5s ✓), 12/12 platforms prebuilt, zero lifecycle scripts, binary verified real Mach-O ✓
- specs/SPEC-0012-png-rasterization.md — dated Validation entry with findings + decision
- package.json — @resvg/resvg-js as devDependency only (the spike artifact; promotion to runtime happens with the follow-up implementation PR)

## What to review, in order
1. The three measured numbers vs the spec's R2 gates (docs/spikes/spec-0012-png.md)
2. The cold-install methodology note — raw trials were network-noisy (2.3–7.1s); the 0.42s is a cache-isolated marginal measure, flagged for CI re-measurement
3. Agree with the stop-decision? (gate PASSED but R3 depends on #9's svg.ts — builder stopped rather than inventing an SVG path)

## Evidence
Gates: tsc 0 · eslint 0 · vitest 0 (239) · goldens 0. Spec: SPEC-0012 (spike-gated per its Validation record).

## Notes
Merge order note: after #9 merges, the follow-up PR promotes resvg to runtime and implements --png (R3–R5). compare --png stays deferred (exit-1 pointer to compare --svg).
