### PR TITLE
docs: structured PR description standard

### DIFF
--- a/.claude/skills/build-spec/SKILL.md
+++ b/.claude/skills/build-spec/SKILL.md
@@ -13,6 +13,16 @@ not get built. The spec must also carry a `## Validation` record (from /validate
 an approved spec without one means the gate was skipped — stop and run it. This skill
 never edits a spec's status to `approved`; that's the maintainer's button (AGENTS.md, button 1).
 
+## 0.5 Context discipline (two builders died of autocompact thrashing — this is law)
+
+- NEVER read real transcripts from `~/.claude/projects` or any user data dir — they are
+  megabytes and will thrash your context. Fixtures in `test/fixtures/**` only.
+- Before any Read: `ls -la` the file; >100KB → read targeted ranges or grep, never whole.
+- Pipe every command's output through a filter (`| tail -20`, `grep -c`, `--reporter=dot`) —
+  raw vitest/npm/build output is a context bomb.
+- If you feel context pressure (repeated compaction), STOP and report progress to the lead
+  instead of pushing through — a partial report beats a dead builder.
+
 ## 1. Branch — never touch main
 
 `git checkout -b feat/<milestone>-<slug> origin/main`. Everything in this skill lands on

--- a/.claude/skills/build-spec/SKILL.md
+++ b/.claude/skills/build-spec/SKILL.md
@@ -72,7 +72,15 @@ follow-up." Then run `/review-docs` on the touched docs (advisory at PR time, bu
 release gate re-runs it as blocking, so fix now). A feature PR with stale docs is an
 incomplete PR.
 
-## 7. Commit + PR
+## 7. Commit + PR (structured description — non-negotiable)
+
+The PR description follows `.github/pull_request_template.md` exactly: What this
+adds / Why it matters to users (user-facing only) / **See it** (mandatory output
+capture for any user-visible change — a terminal code block or committed image
+path; the receipt IS the screenshot) / What changed / **What to review, in order**
+(numbered, riskiest first, file:line pointers) / Evidence (gates + spec +
+validation record) / Notes. A reviewer should know in 30 seconds what was added,
+what to look at first, and what a user gains.
 
 Conventional commit subject, backticked code terms, bullets for multiple changes. Open
 the PR against `main`; wait for CI green (ci.yml matrix + goldens + mutation if

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -53,6 +53,12 @@ they're risky. **Docs staleness is a finding**: if the diff changes user-visible
 behavior (flags, commands, output) and no README/docs/help update rides in the PR,
 flag it (build-spec 6.5 requires docs in the same PR).
 
+## 4.6 Description conformance
+
+The PR description must follow the template: missing "What to review" ordering,
+or a user-visible change without a "See it" output capture, is a finding — a PR
+you can't evaluate in 30 seconds wastes every reviewer after you.
+
 ## 5. Post the review
 
 State pass/fail per section above with specifics (`file:line`), not a vague "looks

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What this adds
+<!-- One short paragraph: the capability, in plain language. -->
+
+## Why it matters to users
+<!-- Only for user-facing changes: 1–3 bullets on what a user can now do or see.
+     Delete this section for internal/infra changes. -->
+
+## See it
+<!-- MANDATORY for any user-visible change: paste the actual output — a terminal
+     capture in a code block (the receipt IS the screenshot), or reference the
+     committed SVG/PNG under its files-changed path. No output = not reviewable. -->
+
+## What changed
+<!-- Grouped bullets, one line each: module → what happened to it. -->
+
+## What to review, in order
+<!-- Numbered, most-critical first, with file:line pointers. Name the riskiest
+     decision explicitly. "Everything" is not an answer. -->
+
+## Evidence
+<!-- Gates one-liner (tsc/eslint/vitest N/N/goldens/spec-lint), spec link
+     (specs/SPEC-NNNN) + its Validation record, dogfood receipt if applicable. -->
+
+## Notes
+<!-- Builder/process notes, deviations, follow-ups spawned. -->


### PR DESCRIPTION
## What this adds
Every PR now answers, in fixed order: what was added, why a user cares, what it looks like (mandatory output capture for user-visible changes), what changed, what to review first, and the evidence. Encoded as .github/pull_request_template.md + enforced by the build-spec skill (authoring) and review-pr skill (conformance finding).

## See it
PR #5 has been retrofitted to this standard as the exemplar.

## What to review, in order
1. .github/pull_request_template.md — the section order and mandates
2. build-spec SKILL step 7 wording
3. review-pr SKILL 4.6 conformance check

## Evidence
spec-lint green; docs-only change, no runtime surface.