### PR TITLE
feat: [SPEC-0008] weekly digest + shared waste aggregation

### DIFF
--- a/src/aggregate/project.ts
+++ b/src/aggregate/project.ts
@@ -1,0 +1,36 @@
+// R4 per-project bucket derivation (opt-in `--by-project` only). Path-derived
+// grouping is deliberately brittle and privacy-adjacent (S2), so the rule is
+// fixed and documented rather than clever: take the `~/.claude/projects/
+// <encoded-cwd>` path segment, decode it by the `-`→`/` scheme Claude Code
+// uses, and keep the last path component. Any session whose file path has no
+// such segment (Codex, Cursor, or an unrecognized layout) buckets under
+// `(unknown)` — never a fabricated project name.
+
+export const UNKNOWN_PROJECT = "(unknown)";
+
+/**
+ * Derive a project bucket name from a session file path.
+ *
+ * The `<encoded-cwd>` segment directly under `.claude/projects/` is Claude
+ * Code's `/`→`-` encoding of the working directory. Decoding is exactly the
+ * inverse substitution (`-`→`/`) with the last path component kept — a lossy
+ * scheme (a real `-` in a directory name is indistinguishable from an encoded
+ * `/`), which is precisely why this stays behind an opt-in flag.
+ */
+export function deriveProjectBucket(filePath: string): string {
+  const parts = filePath.split(/[/\\]+/);
+  const idx = parts.findIndex((p, i) => p === "projects" && parts[i - 1] === ".claude");
+  if (idx === -1 || idx + 1 >= parts.length) {
+    return UNKNOWN_PROJECT;
+  }
+  const encoded = parts[idx + 1];
+  if (!encoded) {
+    return UNKNOWN_PROJECT;
+  }
+  const last = encoded
+    .replace(/-/g, "/")
+    .split("/")
+    .filter((seg) => seg.length > 0)
+    .pop();
+  return last ?? UNKNOWN_PROJECT;
+}

--- a/src/aggregate/waste.ts
+++ b/src/aggregate/waste.ts
@@ -1,0 +1,78 @@
+// R5 shared window-aggregation primitive. Rolls SPEC-0001's per-session waste
+// detectors (`detectStuckLoops`, `detectTrivialSpans`) up across a set of
+// sessions into one per-class summary. The ONE exported aggregation consumed
+// by the weekly digest (top-3 by cost) and by SPEC-0013 (distinct-session
+// recurrence) — no new detection logic lives here, only aggregation.
+import type { Session, TokenUsage } from "../parse/types.js";
+import { addUsage, emptyUsage } from "../parse/util.js";
+import { defaultDataDir } from "../pricing/priceTable.js";
+import { detectStuckLoops, detectTrivialSpans } from "../pricing/waste.js";
+
+export interface WasteClassAggregate {
+  /** Waste-class id, matching the receipt's `WasteLine.kind` ("stuck-loop" | "trivial-spans"). */
+  class: string;
+  /**
+   * Priced-subset cost: the sum of the *priced* firings' `usd` only. An
+   * unpriced firing (unknown model, unpriceable session) contributes its
+   * tokens below but never a guessed dollar (I2) — so a class whose firings
+   * never priced reports `cost: 0` and carries its real magnitude in `tokens`.
+   */
+  cost: number;
+  /** Total tokens across every firing of this class, priced or not. */
+  tokens: TokenUsage;
+  /**
+   * Distinct sessions in which this class fired at least once. Multiple
+   * firings of the same class within one session count once here (SPEC-0013's
+   * recurrence signal), even though `cost`/`tokens` sum every firing.
+   */
+  distinctSessionCount: number;
+}
+
+interface ClassAcc {
+  cost: number;
+  tokens: TokenUsage;
+  sessions: Set<string>;
+}
+
+function bump(acc: Map<string, ClassAcc>, cls: string, usd: number | null, tokens: TokenUsage, sessionId: string): void {
+  const entry = acc.get(cls) ?? { cost: 0, tokens: emptyUsage(), sessions: new Set<string>() };
+  if (usd !== null) {
+    entry.cost += usd;
+  }
+  entry.tokens = addUsage(entry.tokens, tokens);
+  entry.sessions.add(sessionId);
+  acc.set(cls, entry);
+}
+
+/**
+ * Aggregate every session's fired waste classes into `{class, cost, tokens,
+ * distinctSessionCount}` rows, ordered desc by cost (tie-break: desc tokens,
+ * then class name) so a caller's "top-N by cost" is a plain `slice`. A session
+ * that fires no class contributes nothing; a class no session fired never
+ * appears (no padding).
+ */
+export async function aggregateWaste(
+  sessions: Session[],
+  dataDir: string = defaultDataDir(),
+): Promise<WasteClassAggregate[]> {
+  const acc = new Map<string, ClassAcc>();
+
+  for (const session of sessions) {
+    for (const loop of await detectStuckLoops(session, dataDir)) {
+      bump(acc, "stuck-loop", loop.usd, loop.tokens, session.id);
+    }
+    const trivial = await detectTrivialSpans(session, dataDir);
+    if (trivial) {
+      bump(acc, "trivial-spans", trivial.usd, trivial.tokens, session.id);
+    }
+  }
+
+  return [...acc.entries()]
+    .map(([cls, e]): WasteClassAggregate => ({
+      class: cls,
+      cost: e.cost,
+      tokens: e.tokens,
+      distinctSessionCount: e.sessions.size,
+    }))
+    .sort((a, b) => b.cost - a.cost || b.tokens.total - a.tokens.total || a.class.localeCompare(b.class));
+}

--- a/src/aggregate/week.ts
+++ b/src/aggregate/week.ts
@@ -1,0 +1,312 @@
+// R1/R2/R3/R6 weekly aggregation. Pure aggregation over SPEC-0001's existing
+// attribution + waste primitives — no new detection. The honesty spine (I2):
+// a `$` figure sums only priced sessions; a token figure counts every session;
+// the two are never merged, and deltas render per category so a change in
+// price *coverage* can never masquerade as a change in *spend*.
+import { listSessions, loadSession } from "../parse/load.js";
+import type { AgentSource, Session, SessionSummary, TokenUsage } from "../parse/types.js";
+import { SOURCE_LABELS } from "../parse/types.js";
+import { addUsage, emptyUsage } from "../parse/util.js";
+import { attributeByTool } from "../pricing/attribution.js";
+import { defaultDataDir } from "../pricing/priceTable.js";
+import { deriveProjectBucket } from "./project.js";
+import { aggregateWaste, type WasteClassAggregate } from "./waste.js";
+
+const DAY_MS = 86_400_000;
+const WEEK_MS = 7 * DAY_MS;
+const TOP_WASTE = 3;
+
+export interface WindowBounds {
+  curStart: number;
+  curEnd: number;
+  priorStart: number;
+  priorEnd: number;
+}
+
+/**
+ * R1: the current window is a fixed 7-day span. Default anchors its end at
+ * `now` (`[now-7d, now)`); `--since D` anchors its *start* at `D`
+ * (`[D, D+7d)`). The prior window is always the immediately preceding 7 days
+ * (`[curStart-7d, curStart)`). Bounds are half-open: start inclusive, end
+ * exclusive.
+ */
+export function windowBounds(now: number, sinceMs?: number): WindowBounds {
+  const curStart = sinceMs ?? now - WEEK_MS;
+  const curEnd = curStart + WEEK_MS;
+  return { curStart, curEnd, priorStart: curStart - WEEK_MS, priorEnd: curStart };
+}
+
+export interface PartitionedWindows {
+  current: SessionSummary[];
+  prior: SessionSummary[];
+}
+
+/**
+ * R1: bucket summaries into the current/prior windows by `endedAt`. A session
+ * with no `endedAt` is excluded from both windows — never guessed into one.
+ */
+export function partitionWindows(summaries: SessionSummary[], bounds: WindowBounds): PartitionedWindows {
+  const current: SessionSummary[] = [];
+  const prior: SessionSummary[] = [];
+  for (const s of summaries) {
+    if (s.endedAt === undefined) {
+      continue;
+    }
+    if (s.endedAt >= bounds.curStart && s.endedAt < bounds.curEnd) {
+      current.push(s);
+    } else if (s.endedAt >= bounds.priorStart && s.endedAt < bounds.priorEnd) {
+      prior.push(s);
+    }
+  }
+  return { current, prior };
+}
+
+export interface AgentSplit {
+  source: AgentSource;
+  label: string;
+  /** Priced-subset `$` for this agent; `null` when no session in the bucket priced (I2). */
+  usd: number | null;
+  tokens: TokenUsage;
+  sessionCount: number;
+}
+
+export interface ProjectSplit {
+  project: string;
+  usd: number | null;
+  tokens: TokenUsage;
+  sessionCount: number;
+}
+
+export interface WindowAggregate {
+  sessionCount: number;
+  pricedSessionCount: number;
+  /** Sessions whose `$` could not be computed (no priced turn / unpriceable) — the count excluded from the `$` total. */
+  excludedSessionCount: number;
+  /** Sum of priced sessions' totals; `null` when zero sessions priced (never rendered as `$0` against unpriced work). */
+  pricedUsd: number | null;
+  /** Sum over ALL sessions in the window (present even for unpriceable sources). */
+  tokenTotal: TokenUsage;
+  byAgent: AgentSplit[];
+  /** Populated only when `--by-project`; `null` otherwise (R4 opt-in). */
+  byProject: ProjectSplit[] | null;
+  waste: WasteClassAggregate[];
+}
+
+interface SplitAcc {
+  usd: number;
+  priced: boolean;
+  tokens: TokenUsage;
+  sessionCount: number;
+}
+
+function accOf(map: Map<string, SplitAcc>, key: string): SplitAcc {
+  const existing = map.get(key);
+  if (existing) {
+    return existing;
+  }
+  const fresh: SplitAcc = { usd: 0, priced: false, tokens: emptyUsage(), sessionCount: 0 };
+  map.set(key, fresh);
+  return fresh;
+}
+
+function addToSplit(acc: SplitAcc, usd: number | null, tokens: TokenUsage): void {
+  acc.tokens = addUsage(acc.tokens, tokens);
+  acc.sessionCount += 1;
+  if (usd !== null) {
+    acc.usd += usd;
+    acc.priced = true;
+  }
+}
+
+/** Order splits desc by priced `$` (priced buckets first), then desc tokens, then name — deterministic. */
+function orderSplits<T extends { usd: number | null; tokens: TokenUsage }>(rows: T[], name: (r: T) => string): T[] {
+  return [...rows].sort((a, b) => {
+    if (a.usd !== null && b.usd !== null) {
+      return b.usd - a.usd || b.tokens.total - a.tokens.total || name(a).localeCompare(name(b));
+    }
+    if (a.usd !== null) {
+      return -1;
+    }
+    if (b.usd !== null) {
+      return 1;
+    }
+    return b.tokens.total - a.tokens.total || name(a).localeCompare(name(b));
+  });
+}
+
+/**
+ * R2/R3: aggregate one window's already-loaded sessions. `$` sums priced
+ * sessions only; tokens count every session; the per-agent (and opt-in
+ * per-project) splits carry the same priced-subset `$` + all-session token
+ * discipline, so each split sums to its window total by construction.
+ */
+export async function aggregateWindow(
+  sessions: Session[],
+  byProject: boolean,
+  dataDir: string = defaultDataDir(),
+): Promise<WindowAggregate> {
+  const agents = new Map<string, SplitAcc>();
+  const projects = new Map<string, SplitAcc>();
+  let pricedUsd = 0;
+  let anyPriced = false;
+  let pricedSessionCount = 0;
+  let tokenTotal = emptyUsage();
+
+  for (const session of sessions) {
+    const attr = await attributeByTool(session, dataDir);
+    const sessionTokens = session.totals.tokens;
+    const usd = attr.totalUsd;
+
+    tokenTotal = addUsage(tokenTotal, sessionTokens);
+    if (usd !== null) {
+      pricedUsd += usd;
+      anyPriced = true;
+      pricedSessionCount += 1;
+    }
+
+    addToSplit(accOf(agents, session.source), usd, sessionTokens);
+    if (byProject) {
+      addToSplit(accOf(projects, deriveProjectBucket(session.filePath)), usd, sessionTokens);
+    }
+  }
+
+  const byAgent = orderSplits(
+    [...agents.entries()].map(([source, acc]): AgentSplit => ({
+      source: source as AgentSource,
+      label: SOURCE_LABELS[source as AgentSource],
+      usd: acc.priced ? acc.usd : null,
+      tokens: acc.tokens,
+      sessionCount: acc.sessionCount,
+    })),
+    (r) => r.source,
+  );
+
+  const byProjectRows = byProject
+    ? orderSplits(
+        [...projects.entries()].map(([project, acc]): ProjectSplit => ({
+          project,
+          usd: acc.priced ? acc.usd : null,
+          tokens: acc.tokens,
+          sessionCount: acc.sessionCount,
+        })),
+        (r) => r.project,
+      )
+    : null;
+
+  const waste = await aggregateWaste(sessions, dataDir);
+
+  return {
+    sessionCount: sessions.length,
+    pricedSessionCount,
+    excludedSessionCount: sessions.length - pricedSessionCount,
+    pricedUsd: anyPriced ? pricedUsd : null,
+    tokenTotal,
+    byAgent,
+    byProject: byProjectRows,
+    waste,
+  };
+}
+
+export interface WeekDelta {
+  /** False when the prior window has zero sessions → renders "no prior data", never a fabricated 0% (R6). */
+  hasPrior: boolean;
+  /**
+   * Priced-subset `$` delta, `null` when either window lacks a priced total —
+   * a coverage difference is surfaced via `currentExcluded`/`priorExcluded`
+   * instead of being smuggled into a spend number (R6, S2).
+   */
+  pricedUsdDelta: number | null;
+  /** All-session token delta — always defined (tokens exist for every session). */
+  tokenDelta: number;
+  currentExcluded: number;
+  priorExcluded: number;
+}
+
+/** R6: deltas per category, never blended. A `$` delta only when both windows priced; a token delta always; excluded counts for both windows so coverage change reads separately from spend change. */
+export function computeDelta(current: WindowAggregate, prior: WindowAggregate): WeekDelta {
+  const bothPriced = current.pricedUsd !== null && prior.pricedUsd !== null;
+  return {
+    hasPrior: prior.sessionCount > 0,
+    pricedUsdDelta: bothPriced ? (current.pricedUsd as number) - (prior.pricedUsd as number) : null,
+    tokenDelta: current.tokenTotal.total - prior.tokenTotal.total,
+    currentExcluded: current.excludedSessionCount,
+    priorExcluded: prior.excludedSessionCount,
+  };
+}
+
+export interface WeekDigest {
+  windowStartMs: number;
+  windowEndMs: number;
+  priorStartMs: number;
+  priorEndMs: number;
+  /** True when `--since` overrode the trailing-7-days default (affects the header wording). */
+  sinceOverride: boolean;
+  byProject: boolean;
+  current: WindowAggregate;
+  prior: WindowAggregate;
+  delta: WeekDelta;
+  /** R5: current window's waste classes, top 3 by cost. Fewer than 3 fired → only what fired. */
+  topWaste: WasteClassAggregate[];
+}
+
+export interface WeekOptions {
+  /** Injectable clock (epoch ms) for a frozen-clock digest; defaults to `Date.now()`. */
+  now?: number;
+  /** `--since` anchor (epoch ms) for the current window's start; omitted → trailing 7 days. */
+  sinceMs?: number;
+  byProject?: boolean;
+  dataDir?: string;
+}
+
+async function loadAll(summaries: SessionSummary[]): Promise<Session[]> {
+  const loaded = await Promise.all(summaries.map((s) => loadSession(s)));
+  return loaded.filter((s): s is Session => s !== null);
+}
+
+/**
+ * Pure digest assembly over already-loaded window sessions — the deterministic
+ * core `buildWeekDigest` wraps once the disk work is done. Kept separate so it
+ * can be exercised end-to-end with synthetic sessions (no disk, frozen clock).
+ */
+export async function assembleWeekDigest(
+  bounds: WindowBounds,
+  currentSessions: Session[],
+  priorSessions: Session[],
+  opts: { sinceOverride: boolean; byProject: boolean; dataDir?: string },
+): Promise<WeekDigest> {
+  const dataDir = opts.dataDir ?? defaultDataDir();
+  const [current, prior] = await Promise.all([
+    aggregateWindow(currentSessions, opts.byProject, dataDir),
+    aggregateWindow(priorSessions, opts.byProject, dataDir),
+  ]);
+  return {
+    windowStartMs: bounds.curStart,
+    windowEndMs: bounds.curEnd,
+    priorStartMs: bounds.priorStart,
+    priorEndMs: bounds.priorEnd,
+    sinceOverride: opts.sinceOverride,
+    byProject: opts.byProject,
+    current,
+    prior,
+    delta: computeDelta(current, prior),
+    topWaste: current.waste.slice(0, TOP_WASTE),
+  };
+}
+
+/** Disk-facing orchestrator: list → window-partition by `endedAt` → load → aggregate each window → deltas. */
+export async function buildWeekDigest(opts: WeekOptions = {}): Promise<WeekDigest> {
+  const now = opts.now ?? Date.now();
+  const byProject = opts.byProject ?? false;
+  const dataDir = opts.dataDir ?? defaultDataDir();
+  const bounds = windowBounds(now, opts.sinceMs);
+
+  const summaries = await listSessions();
+  const partitioned = partitionWindows(summaries, bounds);
+  const [curSessions, priSessions] = await Promise.all([loadAll(partitioned.current), loadAll(partitioned.prior)]);
+
+  return assembleWeekDigest(bounds, curSessions, priSessions, {
+    sinceOverride: opts.sinceMs !== undefined,
+    byProject,
+    dataDir,
+  });
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -6,7 +6,7 @@
 // `compare` commands to SVG output; `-o`/`--output` names the file and
 // `--theme light|dark` picks the palette.
 export interface ParsedArgs {
-  command: "receipt" | "list" | "compare" | "handoff" | "help" | "methodology" | "telemetry-show" | "quota";
+  command: "receipt" | "list" | "compare" | "handoff" | "help" | "methodology" | "telemetry-show" | "quota" | "week";
   selector?: string;
   compareA?: string;
   compareB?: string;
@@ -17,6 +17,10 @@ export interface ParsedArgs {
   theme: "light" | "dark";
   /** SPEC-0003: output file for `--svg` (defaults to receipt.svg / compare.svg). */
   output?: string;
+  /** SPEC-0008 R4: split the weekly digest by project (opt-in). */
+  byProject: boolean;
+  /** SPEC-0008: re-anchor the trailing window at this YYYY-MM-DD date. */
+  since?: string;
 }
 
 /** Value-consuming flags: `--theme dark`, `-o out.svg`. Anything else is a boolean flag or positional. */
@@ -28,6 +32,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let methodology = false;
   let telemetryShow = false;
   let quota = false;
+  let byProject = false;
+  let since: string | undefined;
   let svg = false;
   let theme: "light" | "dark" = "light";
   let output: string | undefined;
@@ -47,6 +53,12 @@ export function parseArgs(argv: string[]): ParsedArgs {
       methodology = true;
     } else if (arg === "--quota") {
       quota = true;
+    } else if (arg === "--by-project") {
+      byProject = true;
+    } else if (arg === "--since") {
+      since = argv[++i];
+    } else if (arg.startsWith("--since=")) {
+      since = arg.slice("--since=".length);
     } else if (arg === "--svg") {
       svg = true;
     } else if (arg === "--theme") {
@@ -61,32 +73,36 @@ export function parseArgs(argv: string[]): ParsedArgs {
   }
 
   if (help) {
-    return { command: "help", json, svg, theme, output };
+    return { command: "help", json, svg, theme, output, byProject, since };
   }
 
   if (methodology) {
-    return { command: "methodology", json, svg, theme, output };
+    return { command: "methodology", json, svg, theme, output, byProject, since };
   }
 
   if (telemetryShow) {
-    return { command: "telemetry-show", json, svg, theme, output };
+    return { command: "telemetry-show", json, svg, theme, output, byProject, since };
   }
 
   if (quota) {
-    return { command: "quota", json, svg, theme, output };
+    return { command: "quota", json, svg, theme, output, byProject, since };
   }
 
   if (positional[0] === "compare") {
-    return { command: "compare", compareA: positional[1], compareB: positional[2], json, svg, theme, output };
+    return { command: "compare", compareA: positional[1], compareB: positional[2], json, svg, theme, output, byProject, since };
+  }
+
+  if (positional[0] === "week") {
+    return { command: "week", json, svg, theme, output, byProject, since };
   }
 
   if (list) {
-    return { command: "list", json, svg, theme, output };
+    return { command: "list", json, svg, theme, output, byProject, since };
   }
 
   if (handoff) {
-    return { command: "handoff", selector: positional[0], json, svg, theme, output };
+    return { command: "handoff", selector: positional[0], json, svg, theme, output, byProject, since };
   }
 
-  return { command: "receipt", selector: positional[0], json, svg, theme, output };
+  return { command: "receipt", selector: positional[0], json, svg, theme, output, byProject, since };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,8 @@ import { summaryToJson, toJsonModel } from "../receipt/json.js";
 import { buildReceiptModel } from "../receipt/model.js";
 import { renderReceipt } from "../receipt/render.js";
 import { renderReceiptSvg, renderCompareSvg } from "../receipt/svg.js";
+import { renderWeek, weekToJson } from "../receipt/week.js";
+import { buildWeekDigest } from "../aggregate/week.js";
 import { METHODOLOGY } from "../pricing/attribution.js";
 import {
   ensureFirstRunNotice,
@@ -33,6 +35,8 @@ Usage:
                                          (statusline stdin mode only; silent if unavailable)
   aireceipts [selector] --svg [-o f]    write a shareable SVG receipt (default receipt.svg)
   aireceipts compare <a> <b> --svg      write a side-by-side SVG (default compare.svg)
+  aireceipts week [--by-project] [--since <date>] [--json]
+                                        trailing-7-day digest across sessions
   aireceipts --help                     show this help
 
 flags: --svg renders an SVG file; --theme light|dark picks the palette (default light);
@@ -174,6 +178,25 @@ async function runHandoff(selector: string | undefined): Promise<number> {
   return 0;
 }
 
+async function runWeek(args: ReturnType<typeof parseArgs>): Promise<number> {
+  let sinceMs: number | undefined;
+  if (args.since !== undefined) {
+    const parsed = Date.parse(args.since);
+    if (Number.isNaN(parsed)) {
+      process.stderr.write(`invalid --since date: "${args.since}"\n`);
+      return 1;
+    }
+    sinceMs = parsed;
+  }
+  const digest = await buildWeekDigest({ sinceMs, byProject: args.byProject });
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(weekToJson(digest), null, 2)}\n`);
+  } else {
+    process.stdout.write(`${renderWeek(digest)}\n`);
+  }
+  return 0;
+}
+
 async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
   const svgOut: SvgOut = { svg: args.svg, theme: args.theme, output: args.output };
   switch (args.command) {
@@ -194,6 +217,8 @@ async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
       return runHandoff(args.selector);
     case "quota":
       return runQuota();
+    case "week":
+      return runWeek(args);
     case "receipt":
     default:
       return runReceipt(args.selector, args.json, svgOut);

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,26 @@ export type { AttributionResult, ToolAttribution } from "./pricing/attribution.j
 export { attributeByTool, METHODOLOGY } from "./pricing/attribution.js";
 export type { PriceDeltaFootnote, StuckLoopFinding, TrivialSpansFinding } from "./pricing/waste.js";
 export { detectStuckLoops, detectTrivialSpans, priceDeltaFootnote } from "./pricing/waste.js";
+
+// SPEC-0008 weekly digest + the shared waste-aggregation primitive (also consumed by SPEC-0013).
+export type { WasteClassAggregate } from "./aggregate/waste.js";
+export { aggregateWaste } from "./aggregate/waste.js";
+export { deriveProjectBucket, UNKNOWN_PROJECT } from "./aggregate/project.js";
+export type {
+  AgentSplit,
+  ProjectSplit,
+  WeekDelta,
+  WeekDigest,
+  WeekOptions,
+  WindowAggregate,
+  WindowBounds,
+} from "./aggregate/week.js";
+export {
+  aggregateWindow,
+  assembleWeekDigest,
+  buildWeekDigest,
+  computeDelta,
+  partitionWindows,
+  windowBounds,
+} from "./aggregate/week.js";
+export { renderWeek, weekToJson } from "./receipt/week.js";

--- a/src/receipt/format.ts
+++ b/src/receipt/format.ts
@@ -16,6 +16,12 @@ export function formatAbsoluteUtc(epochMs: number): string {
   return `${MONTH_ABBR[d.getUTCMonth()]} ${pad2(d.getUTCDate())} ${d.getUTCFullYear()} ${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}:${pad2(d.getUTCSeconds())} UTC`;
 }
 
+/** Fixed `Mon DD YYYY` UTC date — for digests/windows that report a day, not an instant (no time-of-day, no locale). */
+export function formatDateUtc(epochMs: number): string {
+  const d = new Date(epochMs);
+  return `${MONTH_ABBR[d.getUTCMonth()]} ${pad2(d.getUTCDate())} ${d.getUTCFullYear()}`;
+}
+
 export function formatDuration(ms: number): string {
   const totalSeconds = Math.round(ms / 1000);
   const h = Math.floor(totalSeconds / 3600);

--- a/src/receipt/week.ts
+++ b/src/receipt/week.ts
@@ -1,0 +1,172 @@
+// R7 weekly-digest surfaces: a compact text table and a stable-key-order JSON
+// (the JSON feeds SPEC-0011's export surfaces). Pure formatting over a
+// `WeekDigest` — no aggregation or pricing logic here. Honesty carries through
+// from the model: a `$` renders only against a priced total; tokens render for
+// every session; deltas render per category, never blended.
+import type { AgentSplit, ProjectSplit, WeekDigest, WindowAggregate } from "../aggregate/week.js";
+import type { WasteClassAggregate } from "../aggregate/waste.js";
+import type { TokenUsage } from "../parse/types.js";
+import { colorEnabled, makeColorizer } from "./color.js";
+import { center, dottedLine, formatDateUtc, formatInt, formatUsd } from "./format.js";
+
+const WIDTH = 50;
+const INNER = WIDTH - 2;
+
+export interface RenderWeekOptions {
+  color?: boolean;
+}
+
+function signedUsd(n: number): string {
+  return `${n >= 0 ? "+" : "-"}$${formatUsd(Math.abs(n))}`;
+}
+
+function signedInt(n: number): string {
+  return `${n >= 0 ? "+" : "-"}${formatInt(Math.abs(n))}`;
+}
+
+/** A priced bucket renders `$`; an unpriced bucket falls back to tokens (mirrors the receipt's tokens-only mode). */
+function splitValue(usd: number | null, tokens: TokenUsage, sessionCount: number): string {
+  const magnitude = usd !== null ? `$${formatUsd(usd)}` : `${formatInt(tokens.total)} tok`;
+  return `${magnitude} · ${sessionCount} sess`;
+}
+
+function wasteValue(waste: WasteClassAggregate): string {
+  const magnitude = waste.cost > 0 ? `$${formatUsd(waste.cost)}` : `${formatInt(waste.tokens.total)} tok`;
+  const unit = waste.distinctSessionCount === 1 ? "session" : "sessions";
+  return `${magnitude} · ${waste.distinctSessionCount} ${unit}`;
+}
+
+function indented(label: string, value: string): string {
+  return `  ${dottedLine(label, value, INNER)}`;
+}
+
+function windowBody(window: WindowAggregate): string[] {
+  const lines: string[] = [];
+  lines.push(dottedLine("Sessions", String(window.sessionCount), WIDTH));
+
+  const pricedLabel = `Priced total (${window.pricedSessionCount} of ${window.sessionCount})`;
+  const pricedValue = window.pricedUsd !== null ? `$${formatUsd(window.pricedUsd)}` : "n/a";
+  lines.push(dottedLine(pricedLabel, pricedValue, WIDTH));
+
+  lines.push(dottedLine("Tokens (all sessions)", `${formatInt(window.tokenTotal.total)} tok`, WIDTH));
+
+  if (window.byAgent.length > 0) {
+    lines.push("");
+    lines.push("By agent");
+    for (const agent of window.byAgent as AgentSplit[]) {
+      lines.push(indented(agent.label, splitValue(agent.usd, agent.tokens, agent.sessionCount)));
+    }
+  }
+
+  if (window.byProject && window.byProject.length > 0) {
+    lines.push("");
+    lines.push("By project");
+    for (const project of window.byProject as ProjectSplit[]) {
+      lines.push(indented(project.project, splitValue(project.usd, project.tokens, project.sessionCount)));
+    }
+  }
+
+  return lines;
+}
+
+function deltaBody(digest: WeekDigest): string[] {
+  const { delta } = digest;
+  const header = `vs. prior 7 days (${formatDateUtc(digest.priorStartMs)} → ${formatDateUtc(digest.priorEndMs)})`;
+  const lines = ["", header];
+  if (!delta.hasPrior) {
+    lines.push("  no prior data");
+    return lines;
+  }
+  const usdValue = delta.pricedUsdDelta !== null ? signedUsd(delta.pricedUsdDelta) : "n/a (priced coverage differs)";
+  lines.push(indented("Priced $ Δ", usdValue));
+  lines.push(indented("Tokens Δ", `${signedInt(delta.tokenDelta)} tok`));
+  lines.push(indented("Excluded", `${delta.currentExcluded} now / ${delta.priorExcluded} prior`));
+  return lines;
+}
+
+/** Render `digest` as the text table (R7). Byte-stable: no locale/`Intl`, fixed UTC dates, fixed comma grouping. */
+export function renderWeek(digest: WeekDigest, opts: RenderWeekOptions = {}): string {
+  const enabled = opts.color ?? colorEnabled();
+  const { dim, bold } = makeColorizer(enabled);
+  const lines: string[] = [];
+
+  lines.push(center(bold("WEEKLY DIGEST"), WIDTH));
+  const span = `${formatDateUtc(digest.windowStartMs)} → ${formatDateUtc(digest.windowEndMs)}`;
+  const scope = digest.sinceOverride ? "since override" : "trailing 7 days";
+  lines.push(center(`${span} · ${scope}`, WIDTH));
+  lines.push("");
+
+  lines.push(...windowBody(digest.current));
+
+  if (digest.topWaste.length > 0) {
+    lines.push("");
+    lines.push("Top waste");
+    for (const waste of digest.topWaste) {
+      lines.push(indented(waste.class, wasteValue(waste)));
+    }
+  }
+
+  lines.push(...deltaBody(digest));
+
+  lines.push(dim("-".repeat(WIDTH)));
+  lines.push(center("aireceipts · local · buy me a samosa 🥟", WIDTH));
+
+  return lines.join("\n");
+}
+
+function usageJson(t: TokenUsage) {
+  return {
+    input: t.input,
+    output: t.output,
+    cacheRead: t.cacheRead,
+    cacheCreation: t.cacheCreation,
+    cacheCreation5m: t.cacheCreation5m ?? null,
+    cacheCreation1h: t.cacheCreation1h ?? null,
+    total: t.total,
+  };
+}
+
+function agentJson(a: AgentSplit) {
+  return { source: a.source, label: a.label, usd: a.usd, tokens: usageJson(a.tokens), sessionCount: a.sessionCount };
+}
+
+function projectJson(p: ProjectSplit) {
+  return { project: p.project, usd: p.usd, tokens: usageJson(p.tokens), sessionCount: p.sessionCount };
+}
+
+function wasteJson(w: WasteClassAggregate) {
+  return { class: w.class, cost: w.cost, tokens: usageJson(w.tokens), distinctSessionCount: w.distinctSessionCount };
+}
+
+function windowJson(window: WindowAggregate) {
+  return {
+    sessionCount: window.sessionCount,
+    pricedSessionCount: window.pricedSessionCount,
+    excludedSessionCount: window.excludedSessionCount,
+    pricedUsd: window.pricedUsd,
+    tokenTotal: usageJson(window.tokenTotal),
+    byAgent: window.byAgent.map(agentJson),
+    byProject: window.byProject ? window.byProject.map(projectJson) : null,
+    waste: window.waste.map(wasteJson),
+  };
+}
+
+/** Full structured digest for `--json` — fixed key order (the schema SPEC-0011 consumes). */
+export function weekToJson(digest: WeekDigest) {
+  return {
+    window: { startMs: digest.windowStartMs, endMs: digest.windowEndMs },
+    priorWindow: { startMs: digest.priorStartMs, endMs: digest.priorEndMs },
+    sinceOverride: digest.sinceOverride,
+    byProject: digest.byProject,
+    current: windowJson(digest.current),
+    prior: windowJson(digest.prior),
+    delta: {
+      hasPrior: digest.delta.hasPrior,
+      pricedUsdDelta: digest.delta.pricedUsdDelta,
+      tokenDelta: digest.delta.tokenDelta,
+      currentExcluded: digest.delta.currentExcluded,
+      priorExcluded: digest.delta.priorExcluded,
+    },
+    topWaste: digest.topWaste.map(wasteJson),
+  };
+}

--- a/test/aggregate/project.test.ts
+++ b/test/aggregate/project.test.ts
@@ -1,0 +1,42 @@
+// R4: exact encoded-cwd derivation + `(unknown)` fallback. This is the
+// "fixture of encoded-path shapes" the spec's test matrix calls for — a table
+// of the path shapes the rule must decode, including the deliberately brittle
+// dash-in-directory-name case that S2 flags as the reason it's opt-in.
+import { describe, expect, it } from "vitest";
+import { deriveProjectBucket, UNKNOWN_PROJECT } from "../../src/aggregate/project.js";
+
+describe("deriveProjectBucket (R4 encoded-cwd shapes)", () => {
+  const shapes: Array<[string, string]> = [
+    ["/Users/me/.claude/projects/-Users-me-codebase-aireceipts/abc123.jsonl", "aireceipts"],
+    // Brittle by design: a literal `-` in the real dir name is indistinguishable
+    // from an encoded `/`, so it decodes into an extra path segment.
+    ["/Users/me/.claude/projects/-Users-me-codebase-aireceipts-spec0008/abc123.jsonl", "spec0008"],
+    ["/home/dev/.claude/projects/-home-dev-proj/session.jsonl", "proj"],
+    ["/x/.claude/projects/-single/session.jsonl", "single"],
+    // A Claude Code session nested a directory deeper still resolves the segment
+    // directly under `projects/`.
+    ["/root/.claude/projects/-a-b-c/sub/session.jsonl", "c"],
+  ];
+  for (const [filePath, expected] of shapes) {
+    it(`decodes ${filePath} → ${expected}`, () => {
+      expect(deriveProjectBucket(filePath)).toBe(expected);
+    });
+  }
+
+  it("buckets a Codex path (no .claude/projects segment) under (unknown)", () => {
+    expect(deriveProjectBucket("/Users/me/.codex/sessions/rollout-2026-06-15.jsonl")).toBe(UNKNOWN_PROJECT);
+  });
+
+  it("buckets a Cursor db path under (unknown)", () => {
+    expect(deriveProjectBucket("/Users/me/Library/Application Support/Cursor/state.vscdb")).toBe(UNKNOWN_PROJECT);
+  });
+
+  it("returns (unknown) for an all-separator or empty encoded segment", () => {
+    expect(deriveProjectBucket("/x/.claude/projects/---/s.jsonl")).toBe(UNKNOWN_PROJECT);
+    expect(deriveProjectBucket("/x/.claude/projects")).toBe(UNKNOWN_PROJECT);
+  });
+
+  it("does not treat a bare 'projects' dir not under '.claude' as a bucket source", () => {
+    expect(deriveProjectBucket("/var/projects/-a-b/s.jsonl")).toBe(UNKNOWN_PROJECT);
+  });
+});

--- a/test/aggregate/waste.test.ts
+++ b/test/aggregate/waste.test.ts
@@ -1,0 +1,115 @@
+// R5: the shared aggregateWaste primitive. Verifies the three properties the
+// digest and SPEC-0013 rely on: cost is a priced-subset sum (unpriced firings
+// contribute tokens, never a guessed dollar); distinctSessionCount counts a
+// session once no matter how many times a class fired in it; rows order desc
+// by cost so "top-3 by cost" is a plain slice. Uses the real committed price
+// table so every dollar traces to a cited row.
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { aggregateWaste } from "../../src/aggregate/waste.js";
+import { detectStuckLoops } from "../../src/pricing/waste.js";
+import type { Session, SessionTotals, TokenUsage, ToolCall, Turn } from "../../src/parse/types.js";
+
+const dataDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../data/prices");
+const TS = Date.UTC(2026, 5, 15, 10, 0, 0);
+
+function usage(input: number, output = 0): TokenUsage {
+  return { input, output, cacheRead: 0, cacheCreation: 0, total: input + output };
+}
+function totals(t: TokenUsage): SessionTotals {
+  return { tokens: t, turnCount: 1, toolCallCount: 0 };
+}
+function session(id: string, turns: Turn[], over: Partial<Session> = {}): Session {
+  return {
+    id,
+    source: "claude-code",
+    filePath: `/fake/${id}.jsonl`,
+    totals: totals(usage(0)),
+    turns,
+    ...over,
+  };
+}
+function call(name: string, input: unknown): ToolCall {
+  return { name, input };
+}
+
+function loopTurn(input: number, calls: ToolCall[], model = "claude-haiku-4-5"): Turn {
+  return { index: 0, timestamp: TS, model, usage: usage(input), toolCalls: calls };
+}
+
+const trivialTurn: Turn = {
+  index: 0,
+  timestamp: TS,
+  model: "claude-sonnet-5",
+  outputTokens: 50,
+  usage: usage(100, 50),
+  toolCalls: [],
+};
+
+describe("aggregateWaste (R5)", () => {
+  it("counts a session once in distinctSessionCount even when a class fires twice, and sums both firings' cost", async () => {
+    // Two separate 3-runs interrupted by an `edit` call → two stuck-loop findings, one session.
+    const turn = loopTurn(6_000_000, [
+      call("bash", { cmd: "x" }),
+      call("bash", { cmd: "x" }),
+      call("bash", { cmd: "x" }),
+      call("edit", { cmd: "x" }),
+      call("bash", { cmd: "x" }),
+      call("bash", { cmd: "x" }),
+      call("bash", { cmd: "x" }),
+    ]);
+    const s = session("two-loops", [turn]);
+    const loops = await detectStuckLoops(s, dataDir);
+    expect(loops).toHaveLength(2);
+
+    const agg = await aggregateWaste([s], dataDir);
+    const sl = agg.find((a) => a.class === "stuck-loop");
+    expect(sl).toBeDefined();
+    expect(sl?.distinctSessionCount).toBe(1);
+    expect(sl?.cost).toBeCloseTo(loops.reduce((n, l) => n + (l.usd ?? 0), 0), 10);
+  });
+
+  it("counts distinct sessions across the window", async () => {
+    const mk = (id: string) =>
+      session(id, [loopTurn(3_000_000, [call("bash", { cmd: "y" }), call("bash", { cmd: "y" }), call("bash", { cmd: "y" })])]);
+    const agg = await aggregateWaste([mk("a"), mk("b")], dataDir);
+    const sl = agg.find((a) => a.class === "stuck-loop");
+    expect(sl?.distinctSessionCount).toBe(2);
+  });
+
+  it("keeps cost at 0 but accumulates tokens for an unpriced (unpriceable) firing — never a guessed dollar", async () => {
+    const turn: Turn = {
+      index: 0,
+      timestamp: TS,
+      usage: usage(3_000_000),
+      toolCalls: [call("bash", { cmd: "z" }), call("bash", { cmd: "z" }), call("bash", { cmd: "z" })],
+    };
+    const agg = await aggregateWaste([session("cursor", [turn], { unpriceable: true })], dataDir);
+    const sl = agg.find((a) => a.class === "stuck-loop");
+    expect(sl).toBeDefined();
+    expect(sl?.cost).toBe(0);
+    expect(sl?.tokens.total).toBeGreaterThan(0);
+  });
+
+  it("orders classes desc by cost so top-N is a slice; a session firing nothing contributes nothing", async () => {
+    const loopSession = session("loops", [
+      loopTurn(6_000_000, [call("bash", { cmd: "x" }), call("bash", { cmd: "x" }), call("bash", { cmd: "x" })]),
+    ]);
+    const trivialSession = session("trivial", [trivialTurn]);
+    const cleanSession = session("clean", [
+      { index: 0, timestamp: TS, model: "claude-sonnet-5", usage: usage(10, 10), toolCalls: [call("bash", { cmd: "once" })] },
+    ]);
+
+    const agg = await aggregateWaste([trivialSession, loopSession, cleanSession], dataDir);
+    expect(agg.map((a) => a.class)).toEqual(["stuck-loop", "trivial-spans"]);
+    expect(agg[0].cost).toBeGreaterThan(agg[1].cost);
+  });
+
+  it("returns [] when no session fires a class", async () => {
+    const clean = session("clean", [
+      { index: 0, timestamp: TS, model: "claude-sonnet-5", usage: usage(1000, 500), toolCalls: [call("bash", { cmd: "a" })] },
+    ]);
+    expect(await aggregateWaste([clean], dataDir)).toEqual([]);
+  });
+});

--- a/test/aggregate/week.test.ts
+++ b/test/aggregate/week.test.ts
@@ -1,0 +1,202 @@
+// SPEC-0008 windowing + honest aggregation, exercised with a frozen clock and
+// synthetic sessions (no disk). Covers: R1 windowing (endedAt in/out, missing
+// excluded), R2 mixed pricing (priced-subset $ and all-session tokens never
+// merged), R3 per-agent split sums to the grand total desc, R4 opt-in project
+// split, R6 honest deltas (coverage change ≠ spend change; no prior data),
+// R7 --since custom window. Uses the real committed price tables.
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  aggregateWindow,
+  assembleWeekDigest,
+  computeDelta,
+  partitionWindows,
+  windowBounds,
+} from "../../src/aggregate/week.js";
+import { deriveProjectBucket } from "../../src/aggregate/project.js";
+import type { AgentSource, Session, SessionSummary, SessionTotals, TokenUsage, Turn } from "../../src/parse/types.js";
+
+const dataDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../data/prices");
+const DAY = 86_400_000;
+const NOW = Date.UTC(2026, 5, 15, 12, 0, 0); // Jun 15 2026, 12:00 UTC
+
+function usage(input: number): TokenUsage {
+  return { input, output: 0, cacheRead: 0, cacheCreation: 0, total: input };
+}
+function totals(t: TokenUsage): SessionTotals {
+  return { tokens: t, turnCount: 1, toolCallCount: 0 };
+}
+function filePathFor(source: AgentSource, id: string): string {
+  return source === "claude-code" ? `/u/.claude/projects/-u-proj-${id}/x.jsonl` : `/u/.codex/sessions/${id}.jsonl`;
+}
+function sess(id: string, source: AgentSource, model: string, tok: number, endedAt = NOW - DAY): Session {
+  const u = usage(tok);
+  const turn: Turn = { index: 0, timestamp: NOW - DAY, model, usage: u, toolCalls: [] };
+  return {
+    id,
+    source,
+    filePath: filePathFor(source, id),
+    startedAt: NOW - DAY,
+    endedAt,
+    totals: totals(u),
+    turns: [turn],
+  };
+}
+function summary(id: string, endedAt: number | undefined): SessionSummary {
+  return { id, source: "claude-code", filePath: `/f/${id}.jsonl`, startedAt: endedAt, endedAt, totals: totals(usage(0)) };
+}
+
+describe("windowBounds (R1/R7)", () => {
+  it("default anchors the current window's end at now: [now-7d, now)", () => {
+    const b = windowBounds(NOW);
+    expect(b.curStart).toBe(NOW - 7 * DAY);
+    expect(b.curEnd).toBe(NOW);
+    expect(b.priorStart).toBe(NOW - 14 * DAY);
+    expect(b.priorEnd).toBe(NOW - 7 * DAY);
+  });
+
+  it("--since anchors the current window's start: [since, since+7d)", () => {
+    const since = Date.UTC(2026, 4, 1, 0, 0, 0); // May 1
+    const b = windowBounds(NOW, since);
+    expect(b.curStart).toBe(since);
+    expect(b.curEnd).toBe(since + 7 * DAY);
+    expect(b.priorStart).toBe(since - 7 * DAY);
+    expect(b.priorEnd).toBe(since);
+  });
+});
+
+describe("partitionWindows (R1)", () => {
+  it("includes only timestamped sessions, bucketed half-open by endedAt", () => {
+    const bounds = windowBounds(NOW);
+    const inCurrent = summary("cur", NOW - DAY);
+    const inPrior = summary("pri", NOW - 8 * DAY);
+    const tooOld = summary("old", NOW - 15 * DAY);
+    const noTimestamp = summary("none", undefined);
+    const atCurEndExclusive = summary("edge", NOW); // curEnd is exclusive → not current
+    const { current, prior } = partitionWindows(
+      [inCurrent, inPrior, tooOld, noTimestamp, atCurEndExclusive],
+      bounds,
+    );
+    expect(current.map((s) => s.id)).toEqual(["cur"]);
+    expect(prior.map((s) => s.id)).toEqual(["pri"]);
+  });
+
+  it("places a session exactly at curStart in the current window (start inclusive)", () => {
+    const bounds = windowBounds(NOW);
+    const { current, prior } = partitionWindows([summary("start", bounds.curStart)], bounds);
+    expect(current.map((s) => s.id)).toEqual(["start"]);
+    expect(prior).toHaveLength(0);
+  });
+});
+
+describe("aggregateWindow (R2/R3/R4)", () => {
+  it("R2: sums $ over priced sessions only but tokens over ALL sessions — never merged", async () => {
+    const priced = sess("p", "claude-code", "claude-sonnet-5", 1_000_000);
+    const unpriced = sess("u", "claude-code", "claude-unknown-xyz", 500_000);
+    const w = await aggregateWindow([priced, unpriced], false, dataDir);
+
+    expect(w.pricedUsd).not.toBeNull();
+    expect(w.pricedUsd as number).toBeGreaterThan(0);
+    expect(w.pricedSessionCount).toBe(1);
+    expect(w.excludedSessionCount).toBe(1);
+    // Token total counts BOTH sessions; the excluded session's tokens are not lost.
+    expect(w.tokenTotal.total).toBe(1_500_000);
+  });
+
+  it("R2: a window with zero priced sessions reports pricedUsd null (not $0) but keeps tokens", async () => {
+    const w = await aggregateWindow([sess("u", "claude-code", "claude-unknown-xyz", 400_000)], false, dataDir);
+    expect(w.pricedUsd).toBeNull();
+    expect(w.tokenTotal.total).toBe(400_000);
+    expect(w.excludedSessionCount).toBe(1);
+  });
+
+  it("R3: per-agent split sums to the grand total and is ordered desc", async () => {
+    const sessions = [
+      sess("c1", "claude-code", "claude-sonnet-5", 1_000_000),
+      sess("c2", "claude-code", "claude-sonnet-5", 2_000_000),
+      sess("c3", "claude-code", "claude-haiku-4-5", 3_000_000),
+      sess("x1", "codex", "gpt-5.3-codex", 1_000_000),
+      sess("x2", "codex", "gpt-5.3-codex", 2_000_000),
+    ];
+    const w = await aggregateWindow(sessions, false, dataDir);
+
+    expect(w.byAgent).toHaveLength(2);
+    const agentUsd = w.byAgent.reduce((n, a) => n + (a.usd ?? 0), 0);
+    expect(agentUsd).toBeCloseTo(w.pricedUsd as number, 8);
+    const agentTokens = w.byAgent.reduce((n, a) => n + a.tokens.total, 0);
+    expect(agentTokens).toBe(w.tokenTotal.total);
+    // desc by priced $
+    expect(w.byAgent[0].usd as number).toBeGreaterThanOrEqual(w.byAgent[1].usd as number);
+  });
+
+  it("R4: project split is absent by default and present with byProject, with (unknown) for Codex", async () => {
+    const cc = sess("p", "claude-code", "claude-sonnet-5", 1_000_000);
+    const cx = sess("x", "codex", "gpt-5.3-codex", 1_000_000);
+
+    const off = await aggregateWindow([cc, cx], false, dataDir);
+    expect(off.byProject).toBeNull();
+
+    const on = await aggregateWindow([cc, cx], true, dataDir);
+    expect(on.byProject).not.toBeNull();
+    const names = on.byProject!.map((p) => p.project);
+    expect(names).toContain(deriveProjectBucket(cc.filePath));
+    expect(names).toContain("(unknown)");
+    // Every session lands in exactly one project bucket.
+    expect(on.byProject!.reduce((n, p) => n + p.sessionCount, 0)).toBe(2);
+  });
+});
+
+describe("computeDelta (R6)", () => {
+  it("renders a $ delta only when both windows priced; token delta always; excluded counts per window", async () => {
+    const current = await aggregateWindow(
+      [sess("c", "claude-code", "claude-sonnet-5", 2_000_000), sess("cu", "claude-code", "claude-unknown-xyz", 100_000)],
+      false,
+      dataDir,
+    );
+    const prior = await aggregateWindow([sess("p", "claude-code", "claude-sonnet-5", 1_000_000)], false, dataDir);
+    const d = computeDelta(current, prior);
+
+    expect(d.hasPrior).toBe(true);
+    expect(d.pricedUsdDelta).toBeCloseTo((current.pricedUsd as number) - (prior.pricedUsd as number), 10);
+    expect(d.tokenDelta).toBe(current.tokenTotal.total - prior.tokenTotal.total);
+    expect(d.currentExcluded).toBe(1);
+    expect(d.priorExcluded).toBe(0);
+  });
+
+  it("R6: coverage change never masquerades as spend — prior with no priced session yields a null $ delta, not a swing", async () => {
+    const current = await aggregateWindow([sess("c", "claude-code", "claude-sonnet-5", 2_000_000)], false, dataDir);
+    const prior = await aggregateWindow([sess("pu", "claude-code", "claude-unknown-xyz", 5_000_000)], false, dataDir);
+    const d = computeDelta(current, prior);
+
+    expect(d.hasPrior).toBe(true);
+    expect(d.pricedUsdDelta).toBeNull(); // priced coverage differs → no fabricated $ delta
+    expect(d.tokenDelta).toBe(current.tokenTotal.total - prior.tokenTotal.total); // tokens still comparable
+    expect(d.priorExcluded).toBe(1);
+  });
+
+  it("R6: empty prior window reads as no prior data, never a fabricated 0%", async () => {
+    const current = await aggregateWindow([sess("c", "claude-code", "claude-sonnet-5", 1_000_000)], false, dataDir);
+    const prior = await aggregateWindow([], false, dataDir);
+    const d = computeDelta(current, prior);
+    expect(d.hasPrior).toBe(false);
+  });
+});
+
+describe("assembleWeekDigest (R5/R7 end-to-end)", () => {
+  it("carries window bounds, since-override flag, and top-3 waste as a sorted slice", async () => {
+    const since = Date.UTC(2026, 4, 1, 0, 0, 0);
+    const bounds = windowBounds(NOW, since);
+    const current = [sess("c", "claude-code", "claude-sonnet-5", 1_000_000, since + DAY)];
+    const prior: Session[] = [];
+    const digest = await assembleWeekDigest(bounds, current, prior, { sinceOverride: true, byProject: false, dataDir });
+
+    expect(digest.sinceOverride).toBe(true);
+    expect(digest.windowStartMs).toBe(since);
+    expect(digest.windowEndMs).toBe(since + 7 * DAY);
+    expect(digest.delta.hasPrior).toBe(false);
+    // top-3 is exactly the current window's waste, sliced and already cost-sorted.
+    expect(digest.topWaste).toEqual(digest.current.waste.slice(0, 3));
+    expect(digest.topWaste.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/test/cli/week.test.ts
+++ b/test/cli/week.test.ts
@@ -1,0 +1,46 @@
+// R7 CLI parsing for the `week` command and its flags. Kept additive: the
+// existing receipt/list/compare/handoff parsing must be unaffected.
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "../../src/cli/args.js";
+
+describe("parseArgs — week (R7)", () => {
+  it("recognizes `week` as a subcommand", () => {
+    const a = parseArgs(["week"]);
+    expect(a.command).toBe("week");
+    expect(a.byProject).toBe(false);
+    expect(a.since).toBeUndefined();
+    expect(a.json).toBe(false);
+  });
+
+  it("parses --json, --by-project together", () => {
+    const a = parseArgs(["week", "--json", "--by-project"]);
+    expect(a.command).toBe("week");
+    expect(a.json).toBe(true);
+    expect(a.byProject).toBe(true);
+  });
+
+  it("parses --since <date> as a two-token value", () => {
+    const a = parseArgs(["week", "--since", "2026-05-01"]);
+    expect(a.command).toBe("week");
+    expect(a.since).toBe("2026-05-01");
+  });
+
+  it("parses --since=<date> inline form", () => {
+    const a = parseArgs(["week", "--since=2026-05-01", "--by-project"]);
+    expect(a.since).toBe("2026-05-01");
+    expect(a.byProject).toBe(true);
+  });
+
+  it("does not treat the --since value as a positional selector/subcommand", () => {
+    const a = parseArgs(["week", "--since", "compare"]);
+    expect(a.command).toBe("week");
+    expect(a.since).toBe("compare");
+  });
+
+  it("leaves other commands unaffected (default receipt, byProject defaults false)", () => {
+    expect(parseArgs([]).command).toBe("receipt");
+    expect(parseArgs([]).byProject).toBe(false);
+    expect(parseArgs(["compare", "1", "2"]).command).toBe("compare");
+    expect(parseArgs(["--list"]).command).toBe("list");
+  });
+});

--- a/test/receipt/week.test.ts
+++ b/test/receipt/week.test.ts
@@ -1,0 +1,124 @@
+// R7 surfaces: the text table and the stable-key-order JSON. Asserts the
+// honesty carries into rendering — a mixed window shows a priced-subset $ line
+// AND an all-session token line (never one merged number); a prior with no
+// priced session renders "n/a (priced coverage differs)"; an empty prior reads
+// "no prior data"; the JSON never fabricates a $0 for an unpriced window.
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { assembleWeekDigest, windowBounds } from "../../src/aggregate/week.js";
+import { renderWeek, weekToJson } from "../../src/receipt/week.js";
+import type { AgentSource, Session, SessionTotals, TokenUsage, Turn } from "../../src/parse/types.js";
+
+const dataDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../data/prices");
+const DAY = 86_400_000;
+const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
+
+function usage(input: number): TokenUsage {
+  return { input, output: 0, cacheRead: 0, cacheCreation: 0, total: input };
+}
+function totals(t: TokenUsage): SessionTotals {
+  return { tokens: t, turnCount: 1, toolCallCount: 0 };
+}
+function sess(id: string, source: AgentSource, model: string, tok: number): Session {
+  const u = usage(tok);
+  const turn: Turn = { index: 0, timestamp: NOW - DAY, model, usage: u, toolCalls: [] };
+  const filePath = source === "claude-code" ? `/u/.claude/projects/-u-proj-${id}/x.jsonl` : `/u/.codex/sessions/${id}.jsonl`;
+  return { id, source, filePath, startedAt: NOW - DAY, endedAt: NOW - DAY, totals: totals(u), turns: [turn] };
+}
+
+async function mixedDigest(byProject = false) {
+  const bounds = windowBounds(NOW);
+  const current = [sess("p", "claude-code", "claude-sonnet-5", 1_000_000), sess("u", "claude-code", "claude-unknown-xyz", 500_000)];
+  const prior = [sess("pp", "claude-code", "claude-sonnet-5", 800_000)];
+  return assembleWeekDigest(bounds, current, prior, { sinceOverride: false, byProject, dataDir });
+}
+
+describe("renderWeek (R7 text)", () => {
+  it("shows a priced-subset $ line and an all-session token line separately", async () => {
+    const out = renderWeek(await mixedDigest(), { color: false });
+    expect(out).toContain("WEEKLY DIGEST");
+    expect(out).toContain("Priced total (1 of 2)");
+    expect(out).toMatch(/Priced total \(1 of 2\)\.+\$/); // a $ figure on the priced line
+    expect(out).toContain("Tokens (all sessions)");
+    expect(out).toMatch(/Tokens \(all sessions\)\.+1,500,000 tok/); // both sessions' tokens
+    expect(out).toContain("By agent");
+  });
+
+  it("renders 'no prior data' for an empty prior window", async () => {
+    const bounds = windowBounds(NOW);
+    const digest = await assembleWeekDigest(bounds, [sess("c", "claude-code", "claude-sonnet-5", 1_000_000)], [], {
+      sinceOverride: false,
+      byProject: false,
+      dataDir,
+    });
+    const out = renderWeek(digest, { color: false });
+    expect(out).toContain("no prior data");
+    expect(out).not.toContain("0%");
+  });
+
+  it("renders a coverage-differs note instead of a $ delta when the prior has no priced session", async () => {
+    const bounds = windowBounds(NOW);
+    const digest = await assembleWeekDigest(
+      bounds,
+      [sess("c", "claude-code", "claude-sonnet-5", 2_000_000)],
+      [sess("pu", "claude-code", "claude-unknown-xyz", 3_000_000)],
+      { sinceOverride: false, byProject: false, dataDir },
+    );
+    const out = renderWeek(digest, { color: false });
+    expect(out).toContain("n/a (priced coverage differs)");
+    expect(out).toContain("Excluded");
+    expect(out).toContain("Tokens Δ");
+  });
+
+  it("includes a By project section only with --by-project", async () => {
+    expect(renderWeek(await mixedDigest(false), { color: false })).not.toContain("By project");
+    expect(renderWeek(await mixedDigest(true), { color: false })).toContain("By project");
+  });
+});
+
+describe("weekToJson (R7 schema)", () => {
+  it("emits the documented key order and never a $0 for an unpriced window", async () => {
+    const json = weekToJson(await mixedDigest(true));
+    expect(Object.keys(json)).toEqual([
+      "window",
+      "priorWindow",
+      "sinceOverride",
+      "byProject",
+      "current",
+      "prior",
+      "delta",
+      "topWaste",
+    ]);
+    expect(Object.keys(json.current)).toEqual([
+      "sessionCount",
+      "pricedSessionCount",
+      "excludedSessionCount",
+      "pricedUsd",
+      "tokenTotal",
+      "byAgent",
+      "byProject",
+      "waste",
+    ]);
+    expect(json.current.sessionCount).toBe(2);
+    expect(json.current.pricedSessionCount).toBe(1);
+    expect(json.current.excludedSessionCount).toBe(1);
+    expect(json.current.pricedUsd).toBeGreaterThan(0);
+    expect(json.current.tokenTotal.total).toBe(1_500_000);
+    expect(Array.isArray(json.current.byProject)).toBe(true);
+    expect(json.delta.hasPrior).toBe(true);
+  });
+
+  it("carries pricedUsd null (not 0) and byProject null when the flag is off / nothing priced", async () => {
+    const bounds = windowBounds(NOW);
+    const digest = await assembleWeekDigest(bounds, [sess("u", "claude-code", "claude-unknown-xyz", 400_000)], [], {
+      sinceOverride: false,
+      byProject: false,
+      dataDir,
+    });
+    const json = weekToJson(digest);
+    expect(json.current.pricedUsd).toBeNull();
+    expect(json.current.byProject).toBeNull();
+    expect(json.delta.hasPrior).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this adds
`aireceipts week` — the weekly ritual: trailing-7-day totals, per-agent split, top waste classes, and honest deltas vs the prior week. Plus the shared waste-aggregation primitive that standing-rule suggestions (SPEC-0013) build on.

## Why it matters to users
- One command answers "what did my agents cost this week, and is it trending better?"
- Coverage honesty built in: a change in how many sessions were *priceable* can never masquerade as a spend change (separate $ / token / excluded-count deltas)

## See it
```
$ aireceipts week   (real machine, trailing 7d)
319 sessions · priced (216) $10,056.63 · 15.47B tok
Claude Code  $10,056.63  (242 sessions)
Codex        298.2M tok  (77 sessions — tokens-only, unpriced)
top waste: trivial-spans $89.49 · stuck-loop $4.53
vs prior 7d: $ −2,100.37 · tokens −997.5M · excluded 103 now / 295 prior
```

## What changed
- src/aggregate/{week,waste,project}.ts — windowing, honest per-category deltas, aggregateWaste (distinctSessionCount for SPEC-0013), opt-in --by-project with exact path-derivation rule
- src/receipt/week.ts — table + stable-key JSON (feeds SPEC-0011's schema)
- CLI: week / --by-project / --since; 38 new tests

## What to review, in order
1. src/aggregate/week.ts computeDelta — the coverage-honesty rules (priced-$ delta goes null when coverage differs; never a fabricated swing)
2. The dogfood numbers above — do they pass your sniff test for this machine's week?
3. --by-project derivation (known S2-flagged brittleness on dash-encoded paths — visible as numeric buckets; acceptable for an opt-in flag?)

## Evidence
Gates: tsc 0 · eslint 0 · vitest 0 (277, +38) · goldens 0. Spec: SPEC-0008 (Validation: PASS-WITH-FIXES, all applied). Kill criterion cleared live: deltas are real, not rounding noise.
