### PR TITLE
feat: [SPEC-0014] subscription quota context (--quota, official window state)

### DIFF
--- a/docs/spikes/spec-0014-quota.md
+++ b/docs/spikes/spec-0014-quota.md
@@ -1,0 +1,105 @@
+# SPEC-0014 R1 spike — subscription quota context
+
+**Blocking prerequisite for R2.** This documents what was checked on a real, currently
+installed Claude Code (`2.1.198`) on this machine, per SPEC-0014 R1: "verify, on a real
+local Claude Code install, whether any locally-readable surface... exposes rate-limit or
+quota-window data."
+
+## Result
+
+**Surface clears — statusline stdin only.** No qualifying standalone on-disk state file
+exists. R2 is implemented for stdin mode; standalone/disk mode is the documented R4
+unavailable case (nothing printed, exit 0) — not a spec failure, per the spec's own kill
+criterion.
+
+## What was checked
+
+### 1. Claude Code's `statusLine` stdin payload (clears)
+
+Source: the official Claude Code docs, `https://code.claude.com/docs/en/statusline`
+(fetched in full and read; this is the authoritative first-party spec for the mechanism,
+not a third-party inference).
+
+Claude Code, when a user configures a `statusLine` command in `settings.json`
+(`{"statusLine": {"type": "command", "command": "..."}}`), invokes that command and pipes
+a JSON payload to it on stdin after each new assistant message, after `/compact`, on
+permission-mode change, and on vim-mode toggle. The documented full JSON schema includes:
+
+```jsonc
+{
+  // ...cwd, session_id, model, workspace, cost, context_window, etc...
+  "rate_limits": {
+    "five_hour": { "used_percentage": 23.5, "resets_at": 1738425600 },
+    "seven_day": { "used_percentage": 41.2, "resets_at": 1738857600 }
+  }
+}
+```
+
+Documented field semantics (verbatim from the docs table):
+
+- `rate_limits.five_hour.used_percentage` / `rate_limits.seven_day.used_percentage` —
+  "Percentage of the 5-hour or 7-day rate limit consumed, from 0 to 100."
+- `rate_limits.five_hour.resets_at` / `rate_limits.seven_day.resets_at` — "Unix epoch
+  seconds when the 5-hour or 7-day rate limit window resets."
+
+This is exactly the *current-window state* SPEC-0014's purpose describes ("your 5h window
+is at N%") — not a per-session delta, confirming the spec's S2 correction was right to
+gate v1 on current-window state only.
+
+Documented caveats (also verbatim, load-bearing for R4's unavailable/malformed handling):
+
+- `rate_limits` **appears only for Claude.ai subscribers (Pro/Max)**, not API-key users.
+- It appears **only after the first API response in the session** — absent on a
+  freshly-started session before any turn completes.
+- **Each window is independently optional** — `five_hour` may be present while
+  `seven_day` is absent, or vice versa. The docs' own recommended safe-access pattern is
+  `jq -r '.rate_limits.five_hour.used_percentage // empty'` (i.e. treat a missing field as
+  absence, never as zero).
+- The docs page ships a dedicated, first-class "Rate limit usage" worked example
+  (Bash/Python/Node.js snippets) built specifically around this field — this is not an
+  undocumented or experimental corner of the schema; it's a supported, intended use case.
+
+No live capture of a real payload was taken on this machine: this machine's
+`~/.claude/settings.json` does not currently have a `statusLine` configured, and
+temporarily adding one to capture a sample payload would mean editing this user's real,
+global Claude Code settings — outside this task's scope (isolated to the
+`aireceipts-spec0014` worktree) and not something to do without being asked. The official
+docs page is treated as authoritative for the schema instead: it is first-party,
+current, versioned documentation with a dedicated worked example for this exact field,
+which is strong enough evidence for a feasibility spike without a live capture.
+
+### 2. Standalone on-disk state file under `~/.claude` (does not clear)
+
+Two candidate files on this machine were inspected directly (read-only):
+
+- **`~/.claude/.credentials.json`** — contains `claudeAiOauth.rateLimitTier`, a string
+  naming the subscription/rate-limit *tier* (e.g. plan name). This is not a usage
+  percentage and carries no window-state data. **Ruled out.**
+- **`~/.claude/stats-cache.json`** — contains `modelUsage.<model-id>.{inputTokens,
+  outputTokens, cacheReadInputTokens, cacheCreationInputTokens, webSearchRequests,
+  costUSD, contextWindow, maxOutputTokens}`, which is **cumulative lifetime** usage per
+  model, not current-rate-limit-window usage. There is no 5-hour/7-day window concept in
+  this file at all. **Ruled out.**
+- `~/.claude/cache/changelog.md` was also grepped for `rate_limit`/`quota`/`statusline`
+  keywords — it contains historical product-changelog prose describing the statusline
+  schema's evolution over past releases, not itself a runtime data surface.
+- `claude --help` was checked for a debug/dump flag that could print the statusline
+  payload without configuring a live `statusLine` — `-d/--debug [filter]` and
+  `--debug-file <path>` exist for general debug logging, but there is no dedicated
+  "dump statusline JSON" flag.
+
+No other candidate file is named anywhere in the official docs, and none was found during
+this investigation. **Conclusion: no qualifying standalone state file exists on this
+install.**
+
+## R1 verdict, mapped to R2/R4
+
+| Mode | Surface | R2/R4 outcome |
+|---|---|---|
+| Statusline stdin | `rate_limits.{five_hour,seven_day}.used_percentage` — clears | R2 implemented: renders `your <window> window is at N% (official, from Claude Code's local data)` per present, in-range window |
+| Standalone/disk | No qualifying state file found | R4 unavailable case: `--quota` prints nothing, exits 0, when not fed a stdin payload (e.g. run interactively with no pipe) |
+
+This satisfies the spec's kill criterion framing either way: the surface *does* clear for
+one of the two modes SPEC-0014 anticipated, so this is not a full no-op close — but the
+standalone-mode half of R1 is a documented, valid "unavailable" finding, not a gap to be
+filled by inventing a state file that doesn't exist.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -4,7 +4,7 @@
 // selectors; anything else positional is the session selector for the
 // default receipt command.
 export interface ParsedArgs {
-  command: "receipt" | "list" | "compare" | "handoff" | "help" | "methodology" | "telemetry-show";
+  command: "receipt" | "list" | "compare" | "handoff" | "help" | "methodology" | "telemetry-show" | "quota";
   selector?: string;
   compareA?: string;
   compareB?: string;
@@ -18,6 +18,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let help = false;
   let methodology = false;
   let telemetryShow = false;
+  let quota = false;
   const positional: string[] = [];
 
   for (const arg of argv) {
@@ -31,6 +32,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       telemetryShow = true;
     } else if (arg === "--methodology") {
       methodology = true;
+    } else if (arg === "--quota") {
+      quota = true;
     } else if (arg === "--help" || arg === "-h") {
       help = true;
     } else {
@@ -48,6 +51,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   if (telemetryShow) {
     return { command: "telemetry-show", json };
+  }
+
+  if (quota) {
+    return { command: "quota", json };
   }
 
   if (positional[0] === "compare") {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,7 @@ import {
   showTelemetryPayload,
 } from "../telemetry/index.js";
 import { parseArgs } from "./args.js";
+import { runQuota } from "./quota.js";
 
 const HELP_TEXT = `aireceipts — local, deterministic cost receipts for AI coding-agent sessions
 
@@ -26,6 +27,8 @@ Usage:
   aireceipts --list [--json]            list sessions, newest first
   aireceipts compare <a> <b> [--json]   side-by-side (or stacked) comparison
   aireceipts --handoff [selector]       paste-ready block of fired waste lines
+  aireceipts --quota                    current Claude Code rate-limit window usage
+                                         (statusline stdin mode only; silent if unavailable)
   aireceipts --help                     show this help
 
 selector: a 1-based index into --list, a session id, or a title substring.`;
@@ -162,6 +165,8 @@ async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
       return runCompare(args.compareA, args.compareB, args.json);
     case "handoff":
       return runHandoff(args.selector);
+    case "quota":
+      return runQuota();
     case "receipt":
     default:
       return runReceipt(args.selector, args.json);

--- a/src/cli/quota.ts
+++ b/src/cli/quota.ts
@@ -1,0 +1,90 @@
+// R2 `--quota`: renders Claude Code's own statusline `rate_limits` fields
+// verbatim — current-window usage exactly as Claude Code's local data states
+// it, never a per-session share, never arithmetic on the percentage (SPEC-0014
+// I2/R2). The R1 spike (docs/spikes/spec-0014-quota.md) found no on-disk
+// state-file surface, so quota data is only ever available via the statusline
+// stdin payload; anything else (no pipe, empty pipe, malformed JSON, missing
+// or out-of-range fields) is the R4 unavailable case — print nothing, exit 0.
+
+const WINDOW_LABELS: Record<string, string> = {
+  five_hour: "5h",
+  seven_day: "7d",
+};
+
+function isUsablePercentage(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 100;
+}
+
+/**
+ * Pure rendering seam — SPEC-0014's "documented test seam" for stdin mode.
+ * Given an already-parsed statusline JSON payload (or any unknown value),
+ * returns the quota lines to print. Tests exercise this directly with
+ * fixture payloads; no stdin plumbing required. Renders one line per
+ * present, in-range window — a missing or malformed window is silently
+ * skipped (R4), never guessed at.
+ */
+export function renderQuotaLines(payload: unknown): string[] {
+  if (typeof payload !== "object" || payload === null) {
+    return [];
+  }
+  const rateLimits = (payload as Record<string, unknown>).rate_limits;
+  if (typeof rateLimits !== "object" || rateLimits === null) {
+    return [];
+  }
+  const lines: string[] = [];
+  for (const [key, label] of Object.entries(WINDOW_LABELS)) {
+    const window = (rateLimits as Record<string, unknown>)[key];
+    if (typeof window !== "object" || window === null) {
+      continue;
+    }
+    const pct = (window as Record<string, unknown>).used_percentage;
+    if (isUsablePercentage(pct)) {
+      lines.push(`your ${label} window is at ${pct}% (official, from Claude Code's local data)`);
+    }
+  }
+  return lines;
+}
+
+async function readAll(stream: NodeJS.ReadStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/**
+ * I/O wrapper: a single point-in-time read of one JSON payload from stdin
+ * (R2 — no polling). Never reads when stdin is a TTY (interactive, no piped
+ * payload — the standalone-mode R4 case, since R1 found no state file to
+ * fall back to). Malformed JSON or an empty pipe resolves to `undefined`
+ * rather than throwing.
+ */
+export async function readStdinPayload(stdin: NodeJS.ReadStream = process.stdin): Promise<unknown> {
+  if (stdin.isTTY) {
+    return undefined;
+  }
+  const raw = await readAll(stdin);
+  if (raw.trim() === "") {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `--quota` entrypoint. R3: zero network calls of its own — only parses what
+ * was piped in. R4: no surface / malformed / stale → prints nothing, always
+ * exits 0 (an absent quota is never an error).
+ */
+export async function runQuota(stdin: NodeJS.ReadStream = process.stdin): Promise<number> {
+  const payload = await readStdinPayload(stdin);
+  const lines = renderQuotaLines(payload);
+  if (lines.length > 0) {
+    process.stdout.write(`${lines.join("\n")}\n`);
+  }
+  return 0;
+}

--- a/test/cli/quota.test.ts
+++ b/test/cli/quota.test.ts
@@ -1,0 +1,133 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readStdinPayload, renderQuotaLines, runQuota } from "../../src/cli/quota.js";
+
+/**
+ * Minimal fake stdin: a Readable-shaped EventEmitter with an `isTTY` flag and
+ * an async iterator, matching the subset of `NodeJS.ReadStream` `quota.ts`
+ * actually uses (`isTTY`, `for await...of`).
+ */
+function fakeStdin(chunks: string[], isTTY = false): NodeJS.ReadStream {
+  const stream = new EventEmitter() as unknown as NodeJS.ReadStream;
+  (stream as unknown as { isTTY: boolean }).isTTY = isTTY;
+  (stream as unknown as { [Symbol.asyncIterator]: () => AsyncIterator<string> })[Symbol.asyncIterator] = async function* () {
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  };
+  return stream;
+}
+
+const VALID_PAYLOAD = {
+  rate_limits: {
+    five_hour: { used_percentage: 23.5, resets_at: 1738425600 },
+    seven_day: { used_percentage: 41.2, resets_at: 1738857600 },
+  },
+};
+
+describe("R2: renderQuotaLines — current-window usage, verbatim", () => {
+  it("renders one line per present, in-range window with the verbatim percentage", () => {
+    const lines = renderQuotaLines(VALID_PAYLOAD);
+    expect(lines).toEqual([
+      "your 5h window is at 23.5% (official, from Claude Code's local data)",
+      "your 7d window is at 41.2% (official, from Claude Code's local data)",
+    ]);
+  });
+
+  it("renders only the window that is present when the other is absent", () => {
+    const lines = renderQuotaLines({ rate_limits: { five_hour: { used_percentage: 10 } } });
+    expect(lines).toEqual(["your 5h window is at 10% (official, from Claude Code's local data)"]);
+  });
+
+  it("never phrases output as a per-session share", () => {
+    const lines = renderQuotaLines(VALID_PAYLOAD);
+    for (const line of lines) {
+      expect(line).not.toMatch(/session used/i);
+    }
+  });
+});
+
+describe("R3: no-network proof", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("runQuota never calls fetch, even with a valid rate_limits payload piped in", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const stdin = fakeStdin([JSON.stringify(VALID_PAYLOAD)]);
+    const code = await runQuota(stdin);
+
+    expect(code).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("R4: unavailable case — nothing printed, exit 0", () => {
+  it("readStdinPayload returns undefined for a TTY (interactive, no piped payload)", async () => {
+    const stdin = fakeStdin([], true);
+    await expect(readStdinPayload(stdin)).resolves.toBeUndefined();
+  });
+
+  it("readStdinPayload returns undefined for an empty pipe", async () => {
+    const stdin = fakeStdin([""]);
+    await expect(readStdinPayload(stdin)).resolves.toBeUndefined();
+  });
+
+  it("readStdinPayload returns undefined for malformed JSON", async () => {
+    const stdin = fakeStdin(["{not json"]);
+    await expect(readStdinPayload(stdin)).resolves.toBeUndefined();
+  });
+
+  it("renderQuotaLines returns [] for a non-object payload", () => {
+    expect(renderQuotaLines(undefined)).toEqual([]);
+    expect(renderQuotaLines(null)).toEqual([]);
+    expect(renderQuotaLines("a string")).toEqual([]);
+  });
+
+  it("renderQuotaLines returns [] when rate_limits is missing", () => {
+    expect(renderQuotaLines({ cwd: "/tmp" })).toEqual([]);
+  });
+
+  it("renderQuotaLines skips a window whose used_percentage is out of range", () => {
+    expect(renderQuotaLines({ rate_limits: { five_hour: { used_percentage: 150 } } })).toEqual([]);
+    expect(renderQuotaLines({ rate_limits: { five_hour: { used_percentage: -1 } } })).toEqual([]);
+  });
+
+  it("renderQuotaLines skips a window whose used_percentage is non-numeric or missing", () => {
+    expect(renderQuotaLines({ rate_limits: { five_hour: { used_percentage: "23.5" } } })).toEqual([]);
+    expect(renderQuotaLines({ rate_limits: { five_hour: {} } })).toEqual([]);
+  });
+
+  it("runQuota prints nothing and exits 0 when stdin is a TTY", async () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stdin = fakeStdin([], true);
+
+    const code = await runQuota(stdin);
+
+    expect(code).toBe(0);
+    expect(stdout).not.toHaveBeenCalled();
+    stdout.mockRestore();
+  });
+
+  it("runQuota prints nothing and exits 0 for malformed JSON on stdin", async () => {
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stdin = fakeStdin(["{not json"]);
+
+    const code = await runQuota(stdin);
+
+    expect(code).toBe(0);
+    expect(stdout).not.toHaveBeenCalled();
+    stdout.mockRestore();
+  });
+});
+
+describe("R5: non-Claude-Code payload — nothing prints", () => {
+  it("renderQuotaLines returns [] for a payload shaped like another agent's session (no rate_limits key)", () => {
+    const otherAgentPayload = { agent: "codex", session_id: "abc123", model: "gpt-5" };
+    expect(renderQuotaLines(otherAgentPayload)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this adds
`--quota` — subscription users see their official rate-limit window state on the receipt: "your 5h window is at 43% (official, from Claude Code's local data)". Answers the #1 subscriber pain from the research (opacity: "where is my quota going?") without a single network call.

## Why it matters to users
- Pro/Max subscribers get the window meter next to the session's token story — the two numbers that together explain "why am I rate-limited"
- Never a guess: the percentage is Claude Code's own, rendered verbatim, or nothing prints at all

## See it
```
$ echo "$STATUSLINE_PAYLOAD" | aireceipts --quota
your 5h window is at 43% (official, from Claude Code's local data)
your 7-day window is at 12% (official, from Claude Code's local data)
```
(Statusline stdin mode — the documented Claude Code surface. No payload → prints nothing, exit 0.)

## What changed
- docs/spikes/spec-0014-quota.md — the R1 spike: statusline stdin payload carries rate_limits (official docs); NO standalone state file qualifies (.credentials.json = plan tier only; stats-cache.json = lifetime totals) — so standalone mode is the documented unavailable case
- src/cli/quota.ts — pure renderer + stdin reader; zero fetch/http by construction
- CLI: --quota flag; 14 tests covering verbatim-only rendering, no session-share phrasing, no-network spy, all malformed/absent cases → silent exit 0

## What to review, in order
1. The rendered line's wording — "official, from Claude Code's local data" (the honesty label; is it right?)
2. src/cli/quota.ts silent-exit paths (R4: malformed/out-of-range/non-numeric all print nothing — agree no stderr noise?)
3. The spike's ruling-out of ~/.claude state files (did we miss a surface you know of?)

## Evidence
Gates: tsc 0 · eslint 0 · vitest 0 (253) · goldens 0 (untouched). Spec: SPEC-0014 (Validation: REWORK → current-window semantics corrected — v1 never claims a per-session share).

## Notes
Builder deliberately did NOT edit this machine's real settings.json to capture a live payload (out of scope for an isolated task — correct call); official docs' worked example used as the authoritative shape.
