### PR TITLE
feat: [SPEC-0015] opt-in benchmark client contract (sends disabled)

### DIFF
--- a/src/benchmark/index.ts
+++ b/src/benchmark/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Single public surface for `src/benchmark/**` (SPEC-0015) — mirrors
+ * `src/telemetry/index.ts`'s convention. `src/cli/**` should import only
+ * from here; `schemas.ts`, `payload.ts`, `prompt.ts`, `send.ts`, and
+ * `response.ts` are internal implementation details.
+ */
+export { buildBenchmarkPayload, toBenchmarkAgentType, toModelFamily, bucketCostPerTurn } from "./payload.js";
+export { confirmPrompt } from "./prompt.js";
+export { BENCHMARK_UNAVAILABLE_MESSAGE, isBenchmarkServiceAvailable } from "./send.js";
+export { renderBenchmarkResult } from "./response.js";
+export type { BenchmarkCohortResponse } from "./response.js";
+export {
+  validateBenchmarkEvent,
+  BENCHMARK_AGENT_TYPE_VALUES,
+  MODEL_FAMILY_VALUES,
+  COST_PER_TURN_BUCKET_VALUES,
+  BENCHMARK_EVENT_NAMES,
+} from "./schemas.js";
+export type {
+  BenchmarkRunEvent,
+  BenchmarkEvent,
+  BenchmarkRunProperties,
+  BenchmarkAgentTypeValue,
+  ModelFamilyValue,
+  CostPerTurnBucketValue,
+} from "./schemas.js";

--- a/src/benchmark/no-network.test.ts
+++ b/src/benchmark/no-network.test.ts
@@ -1,0 +1,81 @@
+import { Readable, Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReceiptModel } from "../receipt/model.js";
+import { BENCHMARK_UNAVAILABLE_MESSAGE, buildBenchmarkPayload, confirmPrompt, isBenchmarkServiceAvailable } from "./index.js";
+
+const EMPTY_USAGE = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 };
+
+const SAMPLE_MODEL: ReceiptModel = {
+  agentLabel: "Claude Code",
+  source: "claude-code",
+  sessionId: "sess-1",
+  modelMix: [],
+  toolRows: [],
+  totalUsd: 0.42,
+  totalTokens: EMPTY_USAGE,
+  sessionTotalTokens: EMPTY_USAGE,
+  wasteLines: [],
+  priceDelta: null,
+  methodology: "",
+  priceRowsUsed: [],
+  unpriceable: false,
+};
+
+function inputStream(line: string): Readable {
+  return Readable.from([`${line}\n`]);
+}
+
+function sinkStream(): Writable {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+}
+
+/**
+ * R1/R6 no-network proof: every v1 code path `runBenchmark` (src/cli/index.ts)
+ * composes from this module's public surface — decline, accept-with-no-server,
+ * and --dry-run — must make zero `fetch` calls. Mirrors
+ * src/telemetry/sender.test.ts's "R6: no-network proof" pattern.
+ */
+describe("R1/R6: benchmark module makes zero fetch calls", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("decline path (user answers 'n') calls no fetch", async () => {
+    const consented = await confirmPrompt("Send?", inputStream("n"), sinkStream());
+    expect(consented).toBe(false);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("accept path with no server configured builds a payload, reports unavailable, and calls no fetch", async () => {
+    const consented = await confirmPrompt("Send?", inputStream("y"), sinkStream());
+    expect(consented).toBe(true);
+
+    const payload = buildBenchmarkPayload(SAMPLE_MODEL, 5);
+    expect(payload.name).toBe("benchmark_run");
+
+    expect(isBenchmarkServiceAvailable()).toBe(false);
+    expect(BENCHMARK_UNAVAILABLE_MESSAGE).toBe("benchmark service not yet available");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("--dry-run path (payload built without prompting) calls no fetch", async () => {
+    const payload = buildBenchmarkPayload(SAMPLE_MODEL, 5);
+    expect(payload.properties.agentType).toBe("claude-code");
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("isBenchmarkServiceAvailable() is a static false, structurally incapable of a network round trip", () => {
+    expect(isBenchmarkServiceAvailable()).toBe(false);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/benchmark/payload.test.ts
+++ b/src/benchmark/payload.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type { ReceiptModel, WasteLine } from "../receipt/model.js";
+import { bucketCostPerTurn, buildBenchmarkPayload, toBenchmarkAgentType, toModelFamily } from "./payload.js";
+import { benchmarkRunPropertiesSchema } from "./schemas.js";
+
+const EMPTY_USAGE = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 };
+
+function baseModel(overrides: Partial<ReceiptModel> = {}): ReceiptModel {
+  return {
+    agentLabel: "Claude Code",
+    source: "claude-code",
+    sessionId: "sess-1",
+    modelMix: [],
+    toolRows: [],
+    totalUsd: 1,
+    totalTokens: EMPTY_USAGE,
+    sessionTotalTokens: EMPTY_USAGE,
+    wasteLines: [],
+    priceDelta: null,
+    methodology: "",
+    priceRowsUsed: [],
+    unpriceable: false,
+    ...overrides,
+  };
+}
+
+describe("toBenchmarkAgentType", () => {
+  it("maps each real AgentSource straight through", () => {
+    expect(toBenchmarkAgentType("claude-code")).toBe("claude-code");
+    expect(toBenchmarkAgentType("codex")).toBe("codex");
+    expect(toBenchmarkAgentType("cursor")).toBe("cursor");
+  });
+
+  it("falls back to unknown for anything else", () => {
+    expect(toBenchmarkAgentType(undefined)).toBe("unknown");
+    expect(toBenchmarkAgentType("windsurf" as never)).toBe("unknown");
+  });
+});
+
+describe("toModelFamily", () => {
+  it("derives anthropic from claude-code via vendorForSource", () => {
+    expect(toModelFamily("claude-code")).toBe("anthropic");
+  });
+
+  it("derives openai from codex via vendorForSource", () => {
+    expect(toModelFamily("codex")).toBe("openai");
+  });
+
+  it("derives unknown from cursor (vendorForSource returns undefined)", () => {
+    expect(toModelFamily("cursor")).toBe("unknown");
+  });
+});
+
+describe("bucketCostPerTurn", () => {
+  it("buckets a null total as unpriced (I2: never fabricate a dollar)", () => {
+    expect(bucketCostPerTurn(null, 10)).toBe("unpriced");
+  });
+
+  it("buckets a non-finite total as unpriced", () => {
+    expect(bucketCostPerTurn(Number.NaN, 10)).toBe("unpriced");
+  });
+
+  it("buckets a zero turnCount as unpriced rather than dividing by zero", () => {
+    expect(bucketCostPerTurn(5, 0)).toBe("unpriced");
+  });
+
+  it("buckets a negative turnCount as unpriced", () => {
+    expect(bucketCostPerTurn(5, -1)).toBe("unpriced");
+  });
+
+  it.each([
+    [0.005, 1, "<$0.01"],
+    [0.03, 1, "$0.01-$0.05"],
+    [0.2, 1, "$0.05-$0.25"],
+    [0.5, 1, "$0.25-$1"],
+    [5, 1, ">$1"],
+    [0.2, 2, "$0.05-$0.25"],
+  ] as const)("buckets $%s over %s turns as %s", (totalUsd, turnCount, expected) => {
+    expect(bucketCostPerTurn(totalUsd, turnCount)).toBe(expected);
+  });
+
+  it("treats bucket boundaries as exclusive on the lower edge (e.g. exactly $0.01/turn is not <$0.01)", () => {
+    expect(bucketCostPerTurn(0.01, 1)).toBe("$0.01-$0.05");
+  });
+});
+
+describe("buildBenchmarkPayload", () => {
+  it("produces a payload that validates against the strict allowlist schema", () => {
+    const model = baseModel({ totalUsd: 0.3 });
+    const payload = buildBenchmarkPayload(model, 5);
+    expect(payload.name).toBe("benchmark_run");
+    expect(benchmarkRunPropertiesSchema.safeParse(payload.properties).success).toBe(true);
+  });
+
+  it("maps a stuck-loop waste line to hasStuckLoopWaste=true, hasTrivialSpanWaste=false", () => {
+    const wasteLines: WasteLine[] = [{ kind: "stuck-loop", tool: "bash", runLength: 4, usd: null, tokens: EMPTY_USAGE, wallClockMs: null }];
+    const payload = buildBenchmarkPayload(baseModel({ wasteLines }), 3);
+    expect(payload.properties.hasStuckLoopWaste).toBe(true);
+    expect(payload.properties.hasTrivialSpanWaste).toBe(false);
+  });
+
+  it("maps a trivial-spans waste line to hasTrivialSpanWaste=true, hasStuckLoopWaste=false", () => {
+    const wasteLines: WasteLine[] = [{ kind: "trivial-spans", eligibleTurnCount: 2, usd: 0.01, tokens: EMPTY_USAGE, cheaperModel: "haiku" }];
+    const payload = buildBenchmarkPayload(baseModel({ wasteLines }), 3);
+    expect(payload.properties.hasTrivialSpanWaste).toBe(true);
+    expect(payload.properties.hasStuckLoopWaste).toBe(false);
+  });
+
+  it("sets both waste flags false when there are no waste lines", () => {
+    const payload = buildBenchmarkPayload(baseModel({ wasteLines: [] }), 3);
+    expect(payload.properties.hasStuckLoopWaste).toBe(false);
+    expect(payload.properties.hasTrivialSpanWaste).toBe(false);
+  });
+
+  it("never carries the sessionId, agentLabel, or any other free-text field from ReceiptModel", () => {
+    const payload = buildBenchmarkPayload(baseModel({ sessionId: "sess-should-not-leak", agentLabel: "should-not-leak" }), 3);
+    const keys = Object.keys(payload.properties);
+    expect(keys.sort()).toEqual(["agentType", "costPerTurnBucket", "hasStuckLoopWaste", "hasTrivialSpanWaste", "modelFamily"]);
+  });
+});

--- a/src/benchmark/payload.ts
+++ b/src/benchmark/payload.ts
@@ -1,0 +1,63 @@
+import type { AgentSource } from "../parse/types.js";
+import { vendorForSource } from "../pricing/resolve.js";
+import type { ReceiptModel } from "../receipt/model.js";
+import type { BenchmarkAgentTypeValue, BenchmarkRunEvent, CostPerTurnBucketValue, ModelFamilyValue } from "./schemas.js";
+
+/**
+ * Derives SPEC-0015's coarse benchmark buckets from a `ReceiptModel` (R2).
+ * `turnCount` is passed separately rather than importing `Session` here —
+ * it lives on `Session.totals.turnCount`, not on `ReceiptModel` — keeping
+ * this module's dependency surface to exactly the fields it buckets.
+ */
+
+export function toBenchmarkAgentType(source: AgentSource | undefined): BenchmarkAgentTypeValue {
+  if (source === "claude-code" || source === "codex" || source === "cursor") {
+    return source;
+  }
+  return "unknown";
+}
+
+/** Reuses the pricing layer's vendor mapping so a raw model ID string never has to be parsed or touched here. */
+export function toModelFamily(source: AgentSource): ModelFamilyValue {
+  const vendor = vendorForSource(source);
+  return vendor === "anthropic" || vendor === "openai" ? vendor : "unknown";
+}
+
+/** `null`/non-finite/zero-turn sessions bucket to "unpriced" rather than dividing by zero or leaking a raw total. */
+export function bucketCostPerTurn(totalUsd: number | null, turnCount: number): CostPerTurnBucketValue {
+  if (totalUsd === null || !Number.isFinite(totalUsd) || turnCount <= 0) {
+    return "unpriced";
+  }
+  const perTurn = totalUsd / turnCount;
+  if (perTurn < 0.01) {
+    return "<$0.01";
+  }
+  if (perTurn < 0.05) {
+    return "$0.01-$0.05";
+  }
+  if (perTurn < 0.25) {
+    return "$0.05-$0.25";
+  }
+  if (perTurn < 1) {
+    return "$0.25-$1";
+  }
+  return ">$1";
+}
+
+/** The two existing `WasteLine` kinds (src/receipt/model.ts) map directly onto R2's two waste-class booleans — no new taxonomy needed. */
+function hasWasteKind(model: ReceiptModel, kind: "stuck-loop" | "trivial-spans"): boolean {
+  return model.wasteLines.some((line) => line.kind === kind);
+}
+
+export function buildBenchmarkPayload(model: ReceiptModel, turnCount: number): BenchmarkRunEvent {
+  return {
+    name: "benchmark_run",
+    properties: {
+      agentType: toBenchmarkAgentType(model.source),
+      modelFamily: toModelFamily(model.source),
+      costPerTurnBucket: bucketCostPerTurn(model.totalUsd, turnCount),
+      hasStuckLoopWaste: hasWasteKind(model, "stuck-loop"),
+      hasTrivialSpanWaste: hasWasteKind(model, "trivial-spans"),
+    },
+  };
+}

--- a/src/benchmark/prompt.test.ts
+++ b/src/benchmark/prompt.test.ts
@@ -1,0 +1,37 @@
+import { Readable, Writable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { confirmPrompt } from "./prompt.js";
+
+function inputStream(line: string): Readable {
+  return Readable.from([`${line}\n`]);
+}
+
+function sinkStream(): Writable {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+}
+
+describe("confirmPrompt (R1: per-call [y/N], no persisted 'always allow')", () => {
+  it.each(["y", "Y", "yes", "YES", "Yes"])("accepts %s as confirmation", async (answer) => {
+    expect(await confirmPrompt("Send?", inputStream(answer), sinkStream())).toBe(true);
+  });
+
+  it.each(["n", "N", "no", "", "maybe", "sure"])("rejects %s (default is no)", async (answer) => {
+    expect(await confirmPrompt("Send?", inputStream(answer), sinkStream())).toBe(false);
+  });
+
+  it("writes the [y/N] prompt text to the provided output stream", async () => {
+    const chunks: string[] = [];
+    const output = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(chunk.toString());
+        callback();
+      },
+    });
+    await confirmPrompt("Send anonymous benchmark data?", inputStream("n"), output);
+    expect(chunks.join("")).toContain("Send anonymous benchmark data? [y/N]");
+  });
+});

--- a/src/benchmark/prompt.ts
+++ b/src/benchmark/prompt.ts
@@ -1,0 +1,19 @@
+import { createInterface } from "node:readline/promises";
+import type { Readable, Writable } from "node:stream";
+
+/**
+ * R1: every `benchmark` invocation re-prompts `[y/N]` — v1 has no
+ * persisted "always allow" (SPEC-0015 Non-goals). Built from Node
+ * built-ins only; the project has no CLI-prompt dependency and this is a
+ * single yes/no question, not a case for adding one. `input`/`output` are
+ * injectable so tests never touch the real TTY.
+ */
+export async function confirmPrompt(question: string, input: Readable = process.stdin, output: Writable = process.stdout): Promise<boolean> {
+  const rl = createInterface({ input, output });
+  try {
+    const answer = await rl.question(`${question} [y/N] `);
+    return answer.trim().toLowerCase() === "y" || answer.trim().toLowerCase() === "yes";
+  } finally {
+    rl.close();
+  }
+}

--- a/src/benchmark/response.test.ts
+++ b/src/benchmark/response.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { renderBenchmarkResult, type BenchmarkCohortResponse } from "./response.js";
+
+describe("R4: small-cohort guard", () => {
+  it.each([0, 1, 24])("renders 'not enough data yet' for a cohort of %s, never a percentile", (cohortSize) => {
+    const response: BenchmarkCohortResponse = { cohortSize, percentile: 90 };
+    expect(renderBenchmarkResult(response)).toBe("not enough data yet");
+  });
+
+  it("renders a percentile once the cohort reaches exactly 25", () => {
+    const response: BenchmarkCohortResponse = { cohortSize: 25, percentile: 50 };
+    expect(renderBenchmarkResult(response)).not.toBe("not enough data yet");
+  });
+});
+
+describe("R5/I6: cohort-comparison framing only, never a ranking", () => {
+  it("includes 'vs. a cohort of ... similar sessions' framing", () => {
+    const response: BenchmarkCohortResponse = { cohortSize: 40, percentile: 73 };
+    expect(renderBenchmarkResult(response)).toContain("vs. a cohort of 40 similar sessions");
+  });
+
+  it.each(["better", "worse", "beat", "outperform", "rank", "top ", "worst", "best"])(
+    "never contains ranking language: %s",
+    (banned) => {
+      const response: BenchmarkCohortResponse = { cohortSize: 100, percentile: 12 };
+      expect(renderBenchmarkResult(response).toLowerCase()).not.toContain(banned);
+    },
+  );
+
+  it("small-cohort message also carries no ranking language", () => {
+    const response: BenchmarkCohortResponse = { cohortSize: 3, percentile: 99 };
+    expect(renderBenchmarkResult(response).toLowerCase()).not.toContain("best");
+  });
+});

--- a/src/benchmark/response.ts
+++ b/src/benchmark/response.ts
@@ -1,0 +1,31 @@
+/**
+ * R4/R5 rendering rules for a benchmark server's response. No server exists
+ * yet (v1 ships the client contract only — see SPEC-0015 Purpose), so this
+ * shape and renderer are exercised against a stubbed response in tests
+ * only; nothing in `src/cli/` calls this today, pending the server spec
+ * that will name a real endpoint and response contract.
+ */
+
+export interface BenchmarkCohortResponse {
+  /** Number of sessions in the comparison cohort. */
+  cohortSize: number;
+  /** This session's percentile within the cohort, 0-100. */
+  percentile: number;
+}
+
+const MIN_COHORT_SIZE = 25;
+
+/**
+ * R4: a cohort under 25 members never renders a percentile, however
+ * confident the number looks — small-sample percentiles are misleading,
+ * not just imprecise.
+ *
+ * R5/I6: framing is always "vs. a cohort of similar sessions" — never
+ * "better/worse than X" or any other ranking language.
+ */
+export function renderBenchmarkResult(response: BenchmarkCohortResponse): string {
+  if (response.cohortSize < MIN_COHORT_SIZE) {
+    return "not enough data yet";
+  }
+  return `This session's cost-per-turn is in the ${response.percentile}th percentile vs. a cohort of ${response.cohortSize} similar sessions.`;
+}

--- a/src/benchmark/schemas.test.ts
+++ b/src/benchmark/schemas.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { BENCHMARK_EVENT_NAMES, benchmarkRunPropertiesSchema, validateBenchmarkEvent, type BenchmarkRunEvent } from "./schemas.js";
+
+describe("R2: exactly one event name", () => {
+  it("is exhaustive over benchmark_run — no more, no less", () => {
+    expect([...BENCHMARK_EVENT_NAMES]).toEqual(["benchmark_run"]);
+  });
+});
+
+describe("R2: a valid event passes its schema", () => {
+  it("accepts a well-formed benchmark_run event", () => {
+    const event: BenchmarkRunEvent = {
+      name: "benchmark_run",
+      properties: {
+        agentType: "claude-code",
+        modelFamily: "anthropic",
+        costPerTurnBucket: "$0.01-$0.05",
+        hasStuckLoopWaste: false,
+        hasTrivialSpanWaste: true,
+      },
+    };
+    expect(validateBenchmarkEvent(event)).toBe(true);
+  });
+
+  it("validateBenchmarkEvent returns false (never throws) for an unrecognized event name", () => {
+    expect(validateBenchmarkEvent({ name: "unknown_event" as never, properties: {} as never })).toBe(false);
+  });
+});
+
+describe("R2/R6: leakage fixtures — banned content is structurally rejected", () => {
+  const validRun = {
+    agentType: "claude-code" as const,
+    modelFamily: "anthropic" as const,
+    costPerTurnBucket: "$0.01-$0.05" as const,
+    hasStuckLoopWaste: false,
+    hasTrivialSpanWaste: false,
+  };
+
+  it.each([
+    ["a raw file path", { path: "/Users/anand/secret-project/main.py" }],
+    ["a prompt snippet", { prompt: "write me a function that deletes prod" }],
+    ["a repo name", { repo: "altimateai/altimate-backend" }],
+    ["a hostname", { hostname: "anand-macbook.local" }],
+    ["a username", { username: "anand" }],
+    ["a session id", { sessionId: "sess_9f8a7b6c" }],
+    ["a raw dollar amount", { totalUsd: 12.34 }],
+    ["a raw model string", { model: "claude-fable-5-20260615" }],
+    ["transcript content", { transcript: "user: help me debug this\nassistant: sure" }],
+    ["an install ID", { installId: "install_abc123" }],
+    ["a repeated-caller token", { callerToken: "tok_persistent_9f8a" }],
+  ])("rejects an event with %s smuggled in via an extra property", (_label, extra) => {
+    const polluted = { ...validRun, ...extra };
+    expect(benchmarkRunPropertiesSchema.safeParse(polluted).success).toBe(false);
+  });
+
+  it("rejects an agentType outside the closed enum", () => {
+    expect(benchmarkRunPropertiesSchema.safeParse({ ...validRun, agentType: "windsurf" }).success).toBe(false);
+  });
+
+  it("rejects a modelFamily outside the closed enum (never a raw model ID)", () => {
+    expect(benchmarkRunPropertiesSchema.safeParse({ ...validRun, modelFamily: "claude-fable-5" }).success).toBe(false);
+  });
+
+  it("rejects a costPerTurnBucket outside the closed enum (never a raw dollar figure)", () => {
+    expect(benchmarkRunPropertiesSchema.safeParse({ ...validRun, costPerTurnBucket: "$12.34" }).success).toBe(false);
+  });
+
+  it("rejects a non-boolean waste flag", () => {
+    expect(benchmarkRunPropertiesSchema.safeParse({ ...validRun, hasStuckLoopWaste: "yes" }).success).toBe(false);
+  });
+});

--- a/src/benchmark/schemas.ts
+++ b/src/benchmark/schemas.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+/**
+ * Allowlist schema for SPEC-0015's opt-in benchmark event (R2).
+ *
+ * This is a NEW, separate schema from `src/telemetry/schemas.ts` — the
+ * benchmark event is not a fourth diagnostics event (SPEC-0002 Non-goals);
+ * it is its own value exchange under a different invariant (I1/I4 network
+ * exception), gated by its own per-call `[y/N]` prompt rather than the
+ * always-on diagnostics kill switches. Every field is enum-only — there is
+ * no free-text field anywhere in this module. `.strict()` rejects any
+ * payload carrying an extra key, so a caller can never smuggle an unlisted
+ * field (a path, a prompt, a dollar amount, a raw model string, an install
+ * ID) past the schema by attaching it under a new name. Banned forever, and
+ * structurally unrepresentable here: transcript content, prompts, file
+ * paths, repo names, hostnames, usernames, session IDs, raw dollar amounts,
+ * raw model strings, install IDs / caller tokens (R2, R6).
+ */
+
+export const BENCHMARK_AGENT_TYPE_VALUES = ["claude-code", "codex", "cursor", "unknown"] as const;
+export type BenchmarkAgentTypeValue = (typeof BENCHMARK_AGENT_TYPE_VALUES)[number];
+
+/** Derived from `vendorForSource` (src/pricing/resolve.ts) — never a raw model ID string. */
+export const MODEL_FAMILY_VALUES = ["anthropic", "openai", "unknown"] as const;
+export type ModelFamilyValue = (typeof MODEL_FAMILY_VALUES)[number];
+
+/** Coarse, fixed buckets — never the raw dollar total, which SPEC-0015 R2 explicitly bans. */
+export const COST_PER_TURN_BUCKET_VALUES = ["unpriced", "<$0.01", "$0.01-$0.05", "$0.05-$0.25", "$0.25-$1", ">$1"] as const;
+export type CostPerTurnBucketValue = (typeof COST_PER_TURN_BUCKET_VALUES)[number];
+
+export const benchmarkRunPropertiesSchema = z
+  .object({
+    agentType: z.enum(BENCHMARK_AGENT_TYPE_VALUES),
+    modelFamily: z.enum(MODEL_FAMILY_VALUES),
+    costPerTurnBucket: z.enum(COST_PER_TURN_BUCKET_VALUES),
+    hasStuckLoopWaste: z.boolean(),
+    hasTrivialSpanWaste: z.boolean(),
+  })
+  .strict();
+export type BenchmarkRunProperties = z.infer<typeof benchmarkRunPropertiesSchema>;
+
+/** Exactly one event exists in v1 (R2) — this array is the single source of truth other modules and tests assert against. */
+export const BENCHMARK_EVENT_NAMES = ["benchmark_run"] as const;
+export type BenchmarkEventName = (typeof BENCHMARK_EVENT_NAMES)[number];
+
+export interface BenchmarkRunEvent {
+  name: "benchmark_run";
+  properties: BenchmarkRunProperties;
+}
+export type BenchmarkEvent = BenchmarkRunEvent;
+
+/** `event.name` → its properties schema, exhaustive over `BENCHMARK_EVENT_NAMES`. */
+export const BENCHMARK_PROPERTIES_SCHEMA_BY_EVENT_NAME = {
+  benchmark_run: benchmarkRunPropertiesSchema,
+} as const satisfies Record<BenchmarkEventName, z.ZodTypeAny>;
+
+/** Validates a full envelope (name + properties) against its schema. Never throws — returns `false` on any mismatch, including an unrecognized `name`. */
+export function validateBenchmarkEvent(event: BenchmarkEvent): boolean {
+  const schema = BENCHMARK_PROPERTIES_SCHEMA_BY_EVENT_NAME[event.name] as z.ZodTypeAny | undefined;
+  if (!schema) {
+    return false;
+  }
+  return schema.safeParse(event.properties).success;
+}

--- a/src/benchmark/send.ts
+++ b/src/benchmark/send.ts
@@ -1,0 +1,14 @@
+/**
+ * R1 (v1 default state): no benchmark server exists yet (SPEC-0015
+ * Purpose) — this is not a fallback path, it is the only path. Until a
+ * separate server spec exists and names a real endpoint, this module
+ * deliberately contains no `fetch` call anywhere: there is no URL to send
+ * to, so there is nothing that could accidentally fire one.
+ */
+
+export const BENCHMARK_UNAVAILABLE_MESSAGE = "benchmark service not yet available";
+
+/** Always `false` in v1. A future server spec replaces this, not extends it in place. */
+export function isBenchmarkServiceAvailable(): boolean {
+  return false;
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -6,7 +6,7 @@
 // `compare` commands to SVG output; `-o`/`--output` names the file and
 // `--theme light|dark` picks the palette.
 export interface ParsedArgs {
-  command: "receipt" | "list" | "compare" | "handoff" | "help" | "methodology" | "telemetry-show" | "quota" | "week" | "check-budget";
+  command: "receipt" | "list" | "compare" | "handoff" | "help" | "methodology" | "telemetry-show" | "quota" | "week" | "check-budget" | "benchmark";
   selector?: string;
   compareA?: string;
   compareB?: string;
@@ -21,6 +21,8 @@ export interface ParsedArgs {
   byProject: boolean;
   /** SPEC-0008: re-anchor the trailing window at this YYYY-MM-DD date. */
   since?: string;
+  /** SPEC-0015: print the exact benchmark payload without prompting or sending. */
+  dryRun: boolean;
   /** SPEC-0009 R4: evaluate the budget and exit 1 if any configured cap is exceeded. */
   checkBudget: boolean;
 }
@@ -34,6 +36,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let methodology = false;
   let telemetryShow = false;
   let quota = false;
+  let dryRun = false;
   let checkBudget = false;
   let byProject = false;
   let since: string | undefined;
@@ -56,6 +59,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       methodology = true;
     } else if (arg === "--quota") {
       quota = true;
+    } else if (arg === "--dry-run") {
+      dryRun = true;
     } else if (arg === "--check-budget") {
       checkBudget = true;
     } else if (arg === "--by-project") {
@@ -78,40 +83,44 @@ export function parseArgs(argv: string[]): ParsedArgs {
   }
 
   if (help) {
-    return { command: "help", json, svg, theme, output, byProject, since, checkBudget };
+    return { command: "help", json, svg, theme, output, byProject, since, checkBudget, dryRun };
   }
 
   if (methodology) {
-    return { command: "methodology", json, svg, theme, output, byProject, since, checkBudget };
+    return { command: "methodology", json, svg, theme, output, byProject, since, checkBudget, dryRun };
   }
 
   if (telemetryShow) {
-    return { command: "telemetry-show", json, svg, theme, output, byProject, since, checkBudget };
+    return { command: "telemetry-show", json, svg, theme, output, byProject, since, checkBudget, dryRun };
   }
 
   if (checkBudget) {
-    return { command: "check-budget", json, svg, theme, output, byProject, since, checkBudget };
+    return { command: "check-budget", json, svg, theme, output, byProject, since, checkBudget, dryRun };
   }
 
   if (quota) {
-    return { command: "quota", json, svg, theme, output, byProject, since, checkBudget };
+    return { command: "quota", json, svg, theme, output, byProject, since, checkBudget, dryRun };
   }
 
   if (positional[0] === "compare") {
-    return { command: "compare", compareA: positional[1], compareB: positional[2], json, svg, theme, output, byProject, since, checkBudget };
+    return { command: "compare", compareA: positional[1], compareB: positional[2], json, svg, theme, output, byProject, since, checkBudget, dryRun };
+  }
+
+  if (positional[0] === "benchmark") {
+    return { command: "benchmark", selector: positional[1], json, svg, theme, output, byProject, since, dryRun } as ParsedArgs;
   }
 
   if (positional[0] === "week") {
-    return { command: "week", json, svg, theme, output, byProject, since, checkBudget };
+    return { command: "week", json, svg, theme, output, byProject, since, checkBudget, dryRun };
   }
 
   if (list) {
-    return { command: "list", json, svg, theme, output, byProject, since, checkBudget };
+    return { command: "list", json, svg, theme, output, byProject, since, checkBudget, dryRun };
   }
 
   if (handoff) {
-    return { command: "handoff", selector: positional[0], json, svg, theme, output, byProject, since, checkBudget };
+    return { command: "handoff", selector: positional[0], json, svg, theme, output, byProject, since, checkBudget, dryRun };
   }
 
-  return { command: "receipt", selector: positional[0], json, svg, theme, output, byProject, since, checkBudget };
+  return { command: "receipt", selector: positional[0], json, svg, theme, output, byProject, since, checkBudget, dryRun };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ import {
   recordCliRun,
   showTelemetryPayload,
 } from "../telemetry/index.js";
+import { buildBenchmarkPayload, confirmPrompt, BENCHMARK_UNAVAILABLE_MESSAGE } from "../benchmark/index.js";
 import { parseArgs } from "./args.js";
 import { runQuota } from "./quota.js";
 
@@ -40,6 +41,8 @@ Usage:
                                         trailing-7-day digest across sessions
   aireceipts --check-budget             exit 1 if ~/.aireceipts/budget.json's cap is
                                          exceeded (advisory; see docs)
+  aireceipts benchmark [--dry-run]      opt-in cost-per-turn benchmark (v1: client
+                                         contract only, sends disabled)
   aireceipts --help                     show this help
 
 flags: --svg renders an SVG file; --theme light|dark picks the palette (default light);
@@ -227,6 +230,43 @@ async function runWeek(args: ReturnType<typeof parseArgs>): Promise<number> {
   return 0;
 }
 
+/**
+ * SPEC-0015 v1: client contract only, sends disabled.
+ * `--dry-run` builds+prints the exact payload and returns without prompting
+ * (R3). Otherwise every call re-prompts `[y/N]` (R1, no persisted
+ * "always allow") — declining makes no network call and exits 0; accepting
+ * also makes no network call in v1, since no server endpoint exists yet
+ * (`isBenchmarkServiceAvailable()` is always `false` — see src/benchmark/send.ts).
+ */
+async function runBenchmark(selector: string | undefined, dryRun: boolean): Promise<number> {
+  const resolved = await resolveSelector(selector);
+  if ("error" in resolved) {
+    process.stderr.write(`${resolved.error}\n`);
+    return 1;
+  }
+  const session = await loadSession(resolved.summary);
+  if (!session) {
+    process.stderr.write(`failed to load session "${resolved.summary.id}"\n`);
+    return 1;
+  }
+  const model = await buildReceiptModel(session);
+  const payload = buildBenchmarkPayload(model, session.totals.turnCount);
+
+  if (dryRun) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return 0;
+  }
+
+  const consented = await confirmPrompt("Send anonymous benchmark data for this session?");
+  if (!consented) {
+    return 0;
+  }
+
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+  process.stdout.write(`${BENCHMARK_UNAVAILABLE_MESSAGE}\n`);
+  return 0;
+}
+
 async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
   const svgOut: SvgOut = { svg: args.svg, theme: args.theme, output: args.output };
   switch (args.command) {
@@ -251,6 +291,8 @@ async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
       return runWeek(args);
     case "check-budget":
       return runCheckBudget();
+    case "benchmark":
+      return runBenchmark(args.selector, args.dryRun);
     case "receipt":
     default:
       return runReceipt(args.selector, args.json, svgOut);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ const hasNodeSqlite = maj > 22 || (maj === 22 && min >= 5);
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts", "src/telemetry/**/*.test.ts"],
+    include: ["test/**/*.test.ts", "src/telemetry/**/*.test.ts", "src/benchmark/**/*.test.ts"],
     environment: "node",
     testTimeout: 20_000,
     pool: "forks",


### PR DESCRIPTION
## What this adds
The benchmark client contract (v1, sends disabled): `aireceipts benchmark` shows exactly what an opt-in "how do I compare?" submission would contain — coarse buckets only — and `--dry-run` prints the payload without even prompting. No server exists yet, so nothing can be sent; the contract ships first so the community can audit it before a byte ever moves.

## See it
```
$ aireceipts benchmark --dry-run
{"name":"benchmark_run","properties":{"agentType":"claude-code","modelFamily":"anthropic",
 "costPerTurnBucket":"$0.01-$0.05","hasStuckLoopWaste":false,"hasTrivialSpanWaste":false}}
```

## What changed
- src/benchmark/ — strict zod allowlist schema (separate from diagnostics telemetry), payload bucketing (I2-safe on unpriced sessions), per-call [y/N] prompt (no persisted always-allow), stubbed response rendering (R4/R5, I6 factual-percentile wording)
- CLI: benchmark command + --dry-run; 25 tests incl. leakage fixtures + a mocked-fetch zero-network proof

## What to review, in order
1. The payload field list (src/benchmark/schemas.ts) — this is the entire privacy contract; anything that shouldn't be there?
2. The [y/N] + "service not yet available" flow (accepting sends NOTHING in v1 — verify the no-fetch test)
3. vitest.config.ts include fix — builder found src/benchmark tests were silently NOT running and fixed the config (worth a glance: did anything else rely on that gap?)

## Evidence
Gates: tsc 0 · eslint 0 · vitest 0 (320) · goldens 0 · spec-lint 0. Spec: SPEC-0015 (Validation: REWORK → server cut to its own spec; client contract only).
