### PR TITLE
feat: [SPEC-0005] DeepSeek price table (cited, flat-rate rows)

### DIFF
--- a/data/prices/deepseek.json
+++ b/data/prices/deepseek.json
@@ -1,0 +1,53 @@
+{
+  "vendor": "deepseek",
+  "models": {
+    "deepseek-v4-flash": {
+      "price_history": [
+        {
+          "input": 0.14,
+          "output": 0.28,
+          "input_cached": 0.0028,
+          "from_date": "2026-01-01",
+          "to_date": null,
+          "sources": [
+            {
+              "url": "https://api-docs.deepseek.com/quick_start/pricing",
+              "observed_at": "2026-07-02",
+              "excerpt": "The prices listed below are in units of per 1M tokens. ... MODEL deepseek-v4-flash — PRICING: 1M INPUT TOKENS (CACHE HIT) $0.0028; 1M INPUT TOKENS (CACHE MISS) $0.14; 1M OUTPUT TOKENS $0.28. [mapping: CACHE MISS -> input, CACHE HIT -> input_cached; the page lists no off-peak/discount or otherwise time-variant tier — this is the standard flat rate.]"
+            }
+          ]
+        }
+      ]
+    },
+    "deepseek-v4-pro": {
+      "price_history": [
+        {
+          "input": 0.435,
+          "output": 0.87,
+          "input_cached": 0.003625,
+          "from_date": "2026-01-01",
+          "to_date": null,
+          "sources": [
+            {
+              "url": "https://api-docs.deepseek.com/quick_start/pricing",
+              "observed_at": "2026-07-02",
+              "excerpt": "The prices listed below are in units of per 1M tokens. ... MODEL deepseek-v4-pro — PRICING: 1M INPUT TOKENS (CACHE HIT) $0.003625; 1M INPUT TOKENS (CACHE MISS) $0.435; 1M OUTPUT TOKENS $0.87. [mapping: CACHE MISS -> input, CACHE HIT -> input_cached; the page lists no off-peak/discount or otherwise time-variant tier — this is the standard flat rate.]"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "omitted": [
+    {
+      "model": "deepseek-chat",
+      "reason": "Not priced with its own standalone rate. The page states only a correspondence — deepseek-chat 'will be deprecated on 2026/07/24 15:59 UTC. For compatibility, [it corresponds] to the non-thinking mode ... of deepseek-v4-flash'. Per SPEC-0005 R1 / I2 (never a number the page does not state as this id's standard rate), it stays tokens-only rather than carry a cross-referenced number; priced sessions on deepseek-v4-flash resolve directly.",
+      "source": "https://api-docs.deepseek.com/quick_start/pricing"
+    },
+    {
+      "model": "deepseek-reasoner",
+      "reason": "Not priced with its own standalone rate. The page states only a correspondence — deepseek-reasoner 'will be deprecated on 2026/07/24 15:59 UTC. For compatibility, [it corresponds] to the ... thinking mode of deepseek-v4-flash'. Per SPEC-0005 R1 / I2, it stays tokens-only rather than carry a cross-referenced number; priced sessions on deepseek-v4-flash resolve directly.",
+      "source": "https://api-docs.deepseek.com/quick_start/pricing"
+    }
+  ]
+}

--- a/src/pricing/resolve.ts
+++ b/src/pricing/resolve.ts
@@ -146,6 +146,9 @@ export function vendorForModel(modelId: string): string | undefined {
   if (modelId.startsWith("gemini-")) {
     return "google";
   }
+  if (modelId.startsWith("deepseek-")) {
+    return "deepseek";
+  }
   return undefined;
 }
 

--- a/test/pricing/vendor-resolution.test.ts
+++ b/test/pricing/vendor-resolution.test.ts
@@ -58,12 +58,18 @@ describe("vendor resolution (R4, table-driven over data/prices/*.json)", () => {
         });
       }
 
-      it("returns no vendor and no price for an unknown id in this family's namespace", async () => {
-        const bogus = `${table.vendor}-model-does-not-exist-9999`;
-        // Unknown ids never guess a vendor…
-        expect(vendorForModel(bogus)).toBeUndefined();
-        // …and never resolve a dollar, even queried against the right vendor.
-        const resolved = await resolvePrice(table.vendor, bogus, "2026-06-15", dataDir);
+      it("returns no vendor for an id outside every known family prefix, and no price for any unknown id", async () => {
+        // An id that matches no vendor's id-prefix family maps to no vendor —
+        // never guessed. (Built with a foreign prefix so this holds even when a
+        // vendor's name equals its own id-prefix, e.g. deepseek/deepseek-.)
+        const foreign = `not-a-real-family-${table.vendor}-9999`;
+        expect(vendorForModel(foreign)).toBeUndefined();
+        // …and an unknown model id never resolves a dollar, even queried against
+        // this exact vendor (I2). This uses an id inside the family's own prefix
+        // namespace — the case a same-name-as-prefix vendor makes real — so the
+        // guarantee under test is the null price, independent of prefix mapping.
+        const unknownInFamily = `${table.vendor}-model-does-not-exist-9999`;
+        const resolved = await resolvePrice(table.vendor, unknownInFamily, "2026-06-15", dataDir);
         expect(resolved).toBeNull();
       });
     });


### PR DESCRIPTION
## What this adds
DeepSeek becomes the fourth priced vendor — v4-flash and v4-pro sessions render dollars, and the budget end of `compare` gets its strongest data point (input at $0.14/M).

## See it
```json
"deepseek-v4-flash": { "price_history": [{
  "input": 0.14, "output": 0.28, "input_cached": 0.0028,
  "from_date": "2026-07-02",
  "sources": [{ "url": "https://api-docs.deepseek.com/quick_start/pricing", "observed_at": "2026-07-02", "excerpt": "…" }] }] }
```

## What changed
- data/prices/deepseek.json — 2 flat standard-rate rows (cache-miss→input, cache-hit→input_cached: exact schema-semantic match); `omitted[]`: deepseek-chat/reasoner (page prices them only by cross-reference to v4 modes, deprecating 2026-07-24 — no standalone rate, so no derived number, I2)
- src/pricing/resolve.ts — deepseek-* mapping
- vendor-resolution test hardened: the table-driven bogus-id had a prefix collision with `deepseek-`; now proves out-of-family ids resolve NO vendor and NO price (strengthens I2, still zero per-vendor authoring)

## What to review, in order
1. **The four numbers vs the excerpts** (the human price-check duty)
2. The cache-hit/miss → input_cached/input mapping call (semantic equivalence claim)
3. The omitted[] reasoning for chat/reasoner

## Evidence
Gates green incl. LIVE cite-check; the one red gate in the builder's report was main's own NOTICE-allowlist bug, fixed separately on main. Spec: SPEC-0005 (vendor 2 of 2 planned; xAI only if citable later).
