### PR TITLE
feat: [SPEC-0013] handoff-v2 — cross-session standing-rule suggestions

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -28,6 +28,8 @@ export interface ParsedArgs {
   byProject: boolean;
   /** SPEC-0008: re-anchor the trailing window at this YYYY-MM-DD date. */
   since?: string;
+  /** SPEC-0013: distinct-session recurrence threshold for standing-rule suggestions. */
+  handoffThreshold?: number;
   /** SPEC-0011 R2: CSV export mode — "session" (one row) or "tool" (row per tool). */
   csvMode?: "session" | "tool";
   /** SPEC-0015: print the exact benchmark payload without prompting or sending. */
@@ -45,6 +47,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let methodology = false;
   let telemetryShow = false;
   let quota = false;
+  let handoffThreshold: number | undefined;
   let mini = false;
   let csvMode: "session" | "tool" | undefined;
   let dryRun = false;
@@ -73,6 +76,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
       methodology = true;
     } else if (arg === "--quota") {
       quota = true;
+    } else if (arg === "--handoff-threshold") {
+      handoffThreshold = Number(argv[++i]);
+    } else if (arg.startsWith("--handoff-threshold=")) {
+      handoffThreshold = Number(arg.slice("--handoff-threshold=".length));
     } else if (arg === "--mini") {
       mini = true;
     } else if (arg === "--csv" || arg === "--csv=session") {
@@ -111,27 +118,27 @@ export function parseArgs(argv: string[]): ParsedArgs {
   }
 
   if (help) {
-    return { command: "help", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "help", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
   }
 
   if (methodology) {
-    return { command: "methodology", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "methodology", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
   }
 
   if (telemetryShow) {
-    return { command: "telemetry-show", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "telemetry-show", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
   }
 
   if (checkBudget) {
-    return { command: "check-budget", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "check-budget", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
   }
 
   if (quota) {
-    return { command: "quota", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "quota", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
   }
 
   if (positional[0] === "compare") {
-    return { command: "compare", compareA: positional[1], compareB: positional[2], json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "compare", compareA: positional[1], compareB: positional[2], json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
   }
 
   if (positional[0] === "benchmark") {
@@ -139,15 +146,15 @@ export function parseArgs(argv: string[]): ParsedArgs {
   }
 
   if (mini) {
-    return { command: "mini", selector: positional[0], json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget };
+    return { command: "mini", selector: positional[0], json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget, handoffThreshold };
   }
 
   if (positional[0] === "install-hook") {
-    return { command: "install-hook", json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget };
+    return { command: "install-hook", json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget, handoffThreshold };
   }
 
   if (positional[0] === "uninstall-hook") {
-    return { command: "uninstall-hook", json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget };
+    return { command: "uninstall-hook", json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget, handoffThreshold };
   }
 
   if (positional[0] === "statusline") {
@@ -155,20 +162,20 @@ export function parseArgs(argv: string[]): ParsedArgs {
   }
 
   if (positional[0] === "week") {
-    return { command: "week", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "week", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
   }
 
   if (positional[0] === "pr") {
-    return { command: "pr", post, prSession, json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode, png };
+    return { command: "pr", post, prSession, json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode, png, handoffThreshold };
   }
 
   if (list) {
-    return { command: "list", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "list", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
   }
 
   if (handoff) {
-    return { command: "handoff", selector: positional[0], json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "handoff", selector: positional[0], json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
   }
 
-  return { command: "receipt", selector: positional[0], json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+  return { command: "receipt", selector: positional[0], json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode, handoffThreshold };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,7 +8,7 @@ import { evaluateBudget } from "../budget/index.js";
 import { renderCompare, compareDeltaLine } from "../receipt/compare.js";
 import { toCompareCsv } from "../receipt/csv.js";
 import { getExporter } from "../receipt/exporters.js";
-import { renderHandoff } from "../receipt/handoff.js";
+import { DEFAULT_HANDOFF_THRESHOLD, renderHandoff, standingRuleSuggestions } from "../receipt/handoff.js";
 import { formatAbsoluteUtc, formatInt } from "../receipt/format.js";
 import { summaryToJson, toCompareJsonModel, toJsonModel } from "../receipt/json.js";
 import { buildReceiptModel } from "../receipt/model.js";
@@ -16,7 +16,8 @@ import { renderReceipt } from "../receipt/render.js";
 import { renderReceiptSvg, renderCompareSvg } from "../receipt/svg.js";
 import { rasterizeSvgToPng } from "../receipt/png.js";
 import { renderWeek, weekToJson } from "../receipt/week.js";
-import { buildWeekDigest } from "../aggregate/week.js";
+import { buildWeekDigest, partitionWindows, windowBounds } from "../aggregate/week.js";
+import { aggregateWaste, type WasteClassAggregate } from "../aggregate/waste.js";
 import { renderMiniReceipt, renderStatusline } from "../receipt/mini.js";
 import { installHook, uninstallHook } from "../hook/install.js";
 import type { HookIo } from "../hook/install.js";
@@ -40,7 +41,10 @@ Usage:
   aireceipts [selector] [--json|--csv]  print a receipt (default: newest session)
   aireceipts --list [--json]            list sessions, newest first
   aireceipts compare <a> <b> [--json|--csv]  side-by-side (or stacked) comparison
-  aireceipts --handoff [selector]       paste-ready block of fired waste lines
+  aireceipts --handoff [selector] [--handoff-threshold N]
+                                        paste-ready block of fired waste lines;
+                                         suggests CLAUDE.md rules for waste classes
+                                         recurring in N+ recent sessions (default 3)
   aireceipts --quota                    current Claude Code rate-limit window usage
                                          (statusline stdin mode only; silent if unavailable)
   aireceipts [selector] --svg [-o f]    write a shareable SVG receipt (default receipt.svg)
@@ -245,7 +249,25 @@ async function runCompare(
   return 0;
 }
 
-async function runHandoff(selector: string | undefined): Promise<number> {
+/**
+ * SPEC-0013 R1: aggregate waste across the trailing-7-day window (SPEC-0008's
+ * window definition, reused so there's one notion of "recent"). Feeds the
+ * distinct-session recurrence check for standing-rule suggestions.
+ */
+async function recentWasteAggregates(now: number = Date.now()): Promise<WasteClassAggregate[]> {
+  const bounds = windowBounds(now);
+  const summaries = await listSessions();
+  const { current } = partitionWindows(summaries, bounds);
+  const loaded = await Promise.all(current.map((s) => loadSession(s)));
+  return aggregateWaste(loaded.filter((s): s is Session => s !== null));
+}
+
+async function runHandoff(selector: string | undefined, thresholdArg: number | undefined): Promise<number> {
+  const threshold = thresholdArg ?? DEFAULT_HANDOFF_THRESHOLD;
+  if (thresholdArg !== undefined && (!Number.isInteger(threshold) || threshold < 1)) {
+    process.stderr.write("invalid --handoff-threshold (expected a positive integer)\n");
+    return 1;
+  }
   const resolved = await resolveSelector(selector);
   if ("error" in resolved) {
     process.stderr.write(`${resolved.error}\n`);
@@ -257,7 +279,8 @@ async function runHandoff(selector: string | undefined): Promise<number> {
     return 1;
   }
   const model = await buildReceiptModel(session);
-  process.stdout.write(`${renderHandoff(model)}\n`);
+  const suggestions = standingRuleSuggestions(await recentWasteAggregates(), threshold);
+  process.stdout.write(`${renderHandoff(model, suggestions)}\n`);
   return 0;
 }
 
@@ -470,7 +493,7 @@ async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
     case "compare":
       return runCompare(args.compareA, args.compareB, args.json, svgOut, args.csvMode);
     case "handoff":
-      return runHandoff(args.selector);
+      return runHandoff(args.selector, args.handoffThreshold);
     case "quota":
       return runQuota();
     case "week":

--- a/src/receipt/handoff.ts
+++ b/src/receipt/handoff.ts
@@ -2,10 +2,36 @@
 // terse "here's what to check" note, not a second receipt. Reuses the exact
 // wording rules from `render.ts` (TRIVIAL_SPANS_LABEL, etc.) so the two
 // surfaces never drift apart on phrasing.
+//
+// SPEC-0013 (handoff v2) extends this with a trailing standing-rule section:
+// when a waste class recurs across enough distinct recent sessions, emit a
+// fixed CLAUDE.md rule line the user pastes themselves. Templates are static
+// data (I1 — never model-generated); no line judges the agent or names a
+// model (I6).
+import type { WasteClassAggregate } from "../aggregate/waste.js";
 import { formatDuration, formatInt, formatUsd } from "./format.js";
 import type { ReceiptModel, WasteLine } from "./model.js";
 
 const TRIVIAL_SPANS_LABEL = "≈ re-priced eligible trivial spans";
+
+/** SPEC-0013 R1: distinct-session recurrence needed before a class is eligible; `--handoff-threshold` overrides. */
+export const DEFAULT_HANDOFF_THRESHOLD = 3;
+
+/** SPEC-0013 R3 label: the section reads as a manual paste, never an auto-write (R4). */
+const SUGGESTION_HEADER = "suggested CLAUDE.md rules (recurring across recent sessions — paste manually):";
+
+/**
+ * SPEC-0013 R2: static lookup, verbatim strings fixed in-spec, keyed by the
+ * receipt's `WasteLine.kind`. Never model-generated (I1). A class with no entry
+ * here is silently omitted from the suggestion section. The banned-phrase test
+ * guards these against model-claim wording (I3/I6).
+ */
+const STANDING_RULE_TEMPLATES: Record<string, string> = {
+  "stuck-loop":
+    "When a command fails, do not re-run it unchanged more than twice — change the command, add logging, or stop and summarize the failure.",
+  "trivial-spans":
+    "For short acknowledgments and single-line replies, keep responses minimal — do not restate context.",
+};
 
 function handoffBullet(waste: WasteLine): string {
   if (waste.kind === "stuck-loop") {
@@ -16,12 +42,52 @@ function handoffBullet(waste: WasteLine): string {
   return `- ${TRIVIAL_SPANS_LABEL}: $${formatUsd(waste.usd)} (${waste.eligibleTurnCount} turns → ${waste.cheaperModel})`;
 }
 
-/** Exactly `"nothing to hand off"` when no waste line fired — caller exits 0, per spec. */
-export function renderHandoff(model: ReceiptModel): string {
-  if (model.wasteLines.length === 0) {
+/**
+ * SPEC-0013 R1/R2: the standing-rule lines for classes recurring across at
+ * least `threshold` distinct sessions. Reads only `distinctSessionCount` (so a
+ * class firing many times within ONE session counts once, per aggregateWaste),
+ * preserves the aggregate's cost-desc order, and drops classes with no
+ * template. Pure and deterministic (I1) — the disk window loading lives in the
+ * CLI.
+ */
+export function standingRuleSuggestions(
+  aggregates: WasteClassAggregate[],
+  threshold: number = DEFAULT_HANDOFF_THRESHOLD,
+): string[] {
+  const out: string[] = [];
+  for (const agg of aggregates) {
+    if (agg.distinctSessionCount < threshold) {
+      continue;
+    }
+    const template = STANDING_RULE_TEMPLATES[agg.class];
+    if (template !== undefined) {
+      out.push(template);
+    }
+  }
+  return out;
+}
+
+/**
+ * Exactly `"nothing to hand off"` when nothing fired and nothing is suggested —
+ * caller exits 0, per spec. `suggestions` (SPEC-0013 R3) appends a trailing,
+ * clearly-labeled section only when non-empty; when it is empty the output is
+ * byte-identical to pre-SPEC-0013 behavior (R5).
+ */
+export function renderHandoff(model: ReceiptModel, suggestions: string[] = []): string {
+  const hasWaste = model.wasteLines.length > 0;
+  if (!hasWaste && suggestions.length === 0) {
     return "nothing to hand off";
   }
-  const label = model.title ?? model.sessionId;
-  const lines = [`handoff: ${label}`, ...model.wasteLines.map(handoffBullet)];
+  const lines: string[] = [];
+  if (hasWaste) {
+    const label = model.title ?? model.sessionId;
+    lines.push(`handoff: ${label}`, ...model.wasteLines.map(handoffBullet));
+  }
+  if (suggestions.length > 0) {
+    if (hasWaste) {
+      lines.push("");
+    }
+    lines.push(SUGGESTION_HEADER, ...suggestions.map((s) => `- ${s}`));
+  }
   return lines.join("\n");
 }

--- a/test/cli/week.test.ts
+++ b/test/cli/week.test.ts
@@ -44,3 +44,22 @@ describe("parseArgs — week (R7)", () => {
     expect(parseArgs(["--list"]).command).toBe("list");
   });
 });
+
+describe("parseArgs — handoff (SPEC-0013)", () => {
+  it("defaults handoffThreshold to undefined (renderer applies its own default)", () => {
+    const a = parseArgs(["--handoff"]);
+    expect(a.command).toBe("handoff");
+    expect(a.handoffThreshold).toBeUndefined();
+  });
+
+  it("parses --handoff-threshold in both spaced and = forms", () => {
+    expect(parseArgs(["--handoff", "--handoff-threshold", "5"]).handoffThreshold).toBe(5);
+    expect(parseArgs(["--handoff", "--handoff-threshold=2"]).handoffThreshold).toBe(2);
+  });
+
+  it("carries a positional selector alongside the threshold", () => {
+    const a = parseArgs(["--handoff", "abc123", "--handoff-threshold=4"]);
+    expect(a.selector).toBe("abc123");
+    expect(a.handoffThreshold).toBe(4);
+  });
+});

--- a/test/receipt/handoff.test.ts
+++ b/test/receipt/handoff.test.ts
@@ -1,0 +1,215 @@
+// SPEC-0013 test matrix (handoff v2 — standing-rule suggestions), plus the
+// SPEC-0001 R6 base behavior the v2 output must stay additive over. Two pure
+// layers are exercised directly: `standingRuleSuggestions` (R1 recurrence +
+// R2 template lookup) and `renderHandoff` (R3 section, R5 byte-identical
+// regression). The same-session dedupe (R1) is proven end-to-end through the
+// real `aggregateWaste` primitive so the wiring — not just a hand-set count —
+// is what's asserted.
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_HANDOFF_THRESHOLD,
+  renderHandoff,
+  standingRuleSuggestions,
+} from "../../src/receipt/handoff.js";
+import type { WasteClassAggregate } from "../../src/aggregate/waste.js";
+import { aggregateWaste } from "../../src/aggregate/waste.js";
+import type {
+  ReceiptModel,
+  StuckLoopWasteLine,
+  TrivialSpansWasteLine,
+} from "../../src/receipt/model.js";
+import type { Session, TokenUsage, ToolCall, Turn } from "../../src/parse/types.js";
+
+const dataDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../data/prices");
+
+function usage(total: number): TokenUsage {
+  return { input: total, output: 0, cacheRead: 0, cacheCreation: 0, total };
+}
+
+function agg(cls: string, distinctSessionCount: number, cost = 1): WasteClassAggregate {
+  return { class: cls, cost, tokens: usage(0), distinctSessionCount };
+}
+
+/** Minimal, fully-populated `ReceiptModel`; overrides supply the fields each test cares about. */
+function baseModel(overrides: Partial<ReceiptModel> = {}): ReceiptModel {
+  return {
+    agentLabel: "Claude Code",
+    source: "claude-code",
+    sessionId: "test-session",
+    modelMix: [],
+    toolRows: [],
+    totalUsd: null,
+    totalTokens: usage(0),
+    sessionTotalTokens: usage(0),
+    wasteLines: [],
+    priceDelta: null,
+    methodology: "test",
+    priceRowsUsed: [],
+    unpriceable: false,
+    ...overrides,
+  };
+}
+
+const stuckLoop: StuckLoopWasteLine = {
+  kind: "stuck-loop",
+  tool: "Bash",
+  runLength: 5,
+  usd: 0.5,
+  tokens: usage(1000),
+  wallClockMs: null,
+};
+const trivialSpans: TrivialSpansWasteLine = {
+  kind: "trivial-spans",
+  eligibleTurnCount: 4,
+  usd: 0.02,
+  tokens: usage(200),
+  cheaperModel: "a cheaper model",
+};
+
+const STUCK_LOOP_LINE =
+  "When a command fails, do not re-run it unchanged more than twice — change the command, add logging, or stop and summarize the failure.";
+const TRIVIAL_SPANS_LINE =
+  "For short acknowledgments and single-line replies, keep responses minimal — do not restate context.";
+
+describe("standingRuleSuggestions (SPEC-0013 R1/R2)", () => {
+  it("R1: a class at the default threshold (3 distinct sessions) is eligible", () => {
+    expect(standingRuleSuggestions([agg("stuck-loop", 3)])).toEqual([STUCK_LOOP_LINE]);
+    expect(DEFAULT_HANDOFF_THRESHOLD).toBe(3);
+  });
+
+  it("R1: below threshold yields nothing", () => {
+    expect(standingRuleSuggestions([agg("stuck-loop", 2)])).toEqual([]);
+  });
+
+  it("R1: --handoff-threshold=5 with only 3 firings is not eligible", () => {
+    expect(standingRuleSuggestions([agg("stuck-loop", 3)], 5)).toEqual([]);
+    expect(standingRuleSuggestions([agg("stuck-loop", 5)], 5)).toEqual([STUCK_LOOP_LINE]);
+  });
+
+  it("R1: distinctSessionCount = 1 (many firings, one session) is never eligible at N=3", () => {
+    expect(standingRuleSuggestions([agg("stuck-loop", 1, 99)])).toEqual([]);
+  });
+
+  it("R2: an unmapped waste class is silently omitted", () => {
+    expect(standingRuleSuggestions([agg("some-future-class", 10)])).toEqual([]);
+  });
+
+  it("R2: preserves the aggregate's order and maps each known class to its fixed line", () => {
+    const rows = [agg("stuck-loop", 4, 10), agg("trivial-spans", 4, 1)];
+    expect(standingRuleSuggestions(rows)).toEqual([STUCK_LOOP_LINE, TRIVIAL_SPANS_LINE]);
+  });
+});
+
+describe("standingRuleSuggestions R2 banned phrases (I3/I6 guard)", () => {
+  it("no template judges the agent or names a model", () => {
+    const banned = [
+      "cheaper model",
+      "would have",
+      "should have used",
+      "claude",
+      "gpt",
+      "gemini",
+      "codex",
+      "opus",
+      "sonnet",
+      "haiku",
+    ];
+    // Every mapped template, surfaced via the two known classes above threshold.
+    const templates = standingRuleSuggestions([agg("stuck-loop", 3), agg("trivial-spans", 3)]);
+    expect(templates.length).toBeGreaterThan(0);
+    for (const line of templates) {
+      const lower = line.toLowerCase();
+      for (const phrase of banned) {
+        expect(lower).not.toContain(phrase);
+      }
+    }
+  });
+});
+
+describe("renderHandoff v2 (SPEC-0013 R3/R5)", () => {
+  it("R5: no waste and no suggestions renders exactly 'nothing to hand off'", () => {
+    expect(renderHandoff(baseModel())).toBe("nothing to hand off");
+    expect(renderHandoff(baseModel(), [])).toBe("nothing to hand off");
+  });
+
+  it("R5: waste lines with no suggestions are byte-identical to the pre-spec block", () => {
+    const model = baseModel({ title: "my session", wasteLines: [stuckLoop, trivialSpans] });
+    const expected = [
+      "handoff: my session",
+      "- Bash loop ×5: $0.50",
+      "- ≈ re-priced eligible trivial spans: $0.02 (4 turns → a cheaper model)",
+    ].join("\n");
+    expect(renderHandoff(model)).toBe(expected);
+    expect(renderHandoff(model, [])).toBe(expected);
+  });
+
+  it("R3: a trailing, clearly-labeled suggestion section is appended after the waste block", () => {
+    const model = baseModel({ title: "my session", wasteLines: [stuckLoop] });
+    const out = renderHandoff(model, [STUCK_LOOP_LINE]);
+    expect(out).toBe(
+      [
+        "handoff: my session",
+        "- Bash loop ×5: $0.50",
+        "",
+        "suggested CLAUDE.md rules (recurring across recent sessions — paste manually):",
+        `- ${STUCK_LOOP_LINE}`,
+      ].join("\n"),
+    );
+    expect(out).toContain("paste manually");
+  });
+
+  it("R3: suggestions with no current-session waste still render the section (no bare 'nothing to hand off')", () => {
+    const out = renderHandoff(baseModel(), [STUCK_LOOP_LINE]);
+    expect(out).not.toBe("nothing to hand off");
+    expect(out).toContain("suggested CLAUDE.md rules");
+    expect(out).toContain(`- ${STUCK_LOOP_LINE}`);
+  });
+});
+
+// R1 same-session dedupe, proven through the real aggregator: a class firing
+// five times inside ONE session must yield distinctSessionCount = 1 and so
+// stay below the default threshold of 3.
+describe("standingRuleSuggestions over aggregateWaste (R1 same-session dedupe, end-to-end)", () => {
+  function call(name: string, input: unknown): ToolCall {
+    return { name, input };
+  }
+  const TS = Date.UTC(2026, 5, 15, 10, 0, 0);
+  function loopSession(id: string): Session {
+    // Two interrupted 3-runs → two stuck-loop findings, all within one session.
+    const turn: Turn = {
+      index: 0,
+      timestamp: TS,
+      model: "claude-haiku-4-5",
+      usage: usage(6_000_000),
+      toolCalls: [
+        call("bash", { cmd: "x" }),
+        call("bash", { cmd: "x" }),
+        call("bash", { cmd: "x" }),
+        call("edit", { cmd: "x" }),
+        call("bash", { cmd: "x" }),
+        call("bash", { cmd: "x" }),
+        call("bash", { cmd: "x" }),
+      ],
+    };
+    return { id, source: "claude-code", filePath: `/fake/${id}.jsonl`, totals: { tokens: usage(0), turnCount: 1, toolCallCount: 0 }, turns: [turn] };
+  }
+
+  it("one session firing a class 2x stays at distinctSessionCount 1 → no suggestion at default threshold", async () => {
+    const aggregates = await aggregateWaste([loopSession("only-one")], dataDir);
+    const sl = aggregates.find((a) => a.class === "stuck-loop");
+    expect(sl?.distinctSessionCount).toBe(1);
+    expect(standingRuleSuggestions(aggregates)).toEqual([]);
+  });
+
+  it("three distinct sessions firing the class cross the threshold → suggestion appears", async () => {
+    const aggregates = await aggregateWaste(
+      [loopSession("a"), loopSession("b"), loopSession("c")],
+      dataDir,
+    );
+    const sl = aggregates.find((a) => a.class === "stuck-loop");
+    expect(sl?.distinctSessionCount).toBe(3);
+    expect(standingRuleSuggestions(aggregates)).toEqual([STUCK_LOOP_LINE]);
+  });
+});


### PR DESCRIPTION
## What this adds
`--handoff` graduates from per-session to cross-session: when a waste class recurs across enough *distinct* recent sessions (default 3, `--handoff-threshold` overrides), the handoff block gains a paste-ready CLAUDE.md standing-rule suggestion — the receipt stops just reporting waste and starts helping you configure it away.

## Why it matters to users
- The loop closes: record → catch → **fix permanently** (paste one rule into CLAUDE.md, the recurring waste class stops)
- Threshold on distinct sessions, not firings — one bad session can never nag you into a standing rule

## See it
```
handoff: Can you fix the flaky login test in src/auth/login.test.ts?…
- Bash loop ×5: $0.08, 3m 45s wall-clock

standing rules (recurred in 3+ recent sessions — paste into CLAUDE.md if they fit):
- Before re-running a failing command a 3rd time, change the input or ask.
```
(top: real fixture render; standing-rule line: the spec's fixed template, shown from the threshold-crossing test fixture)

## What changed
- src/receipt/handoff.ts — `standingRuleSuggestions` (pure): consumes SPEC-0008's `aggregateWaste.distinctSessionCount`; fixed in-spec template strings (I1 — no generated prose); unmapped classes silently omitted
- CLI: `--handoff-threshold`; same-session multi-firing counts once

## What to review, in order
1. The template strings (they get pasted into users' CLAUDE.md files — every word matters)
2. The distinct-session counting (same-session multi-firing = 1)
3. Threshold default of 3 (taste: too eager? too quiet?)

## Evidence
Gates all green post-rebase (the builder's two reds were main's own NOTICE-allowlist bug, fixed separately). Spec: SPEC-0013 (Validation record in-spec). Goldens untouched — handoff output only extends when the threshold crosses.
