### PR TITLE
feat: [SPEC-0012] --png rasterization (resvg promoted to runtime)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "aireceipts",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
+        "@resvg/resvg-js": "^2.6.2",
         "zod": "^4.4.3"
       },
       "bin": {
         "aireceipts": "dist/cli.js"
       },
       "devDependencies": {
-        "@resvg/resvg-js": "^2.6.2",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
         "@types/node": "^22.19.19",
@@ -1618,7 +1618,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
       "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
-      "dev": true,
       "license": "MPL-2.0",
       "engines": {
         "node": ">= 10"
@@ -1645,7 +1644,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1662,7 +1660,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1679,7 +1676,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1696,7 +1692,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1713,7 +1708,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1730,7 +1724,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1747,7 +1740,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1764,7 +1756,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1781,7 +1772,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1798,7 +1788,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1815,7 +1804,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1832,7 +1820,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@resvg/resvg-js": "^2.6.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@resvg/resvg-js": "^2.6.2",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@types/node": "^22.19.19",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -3,8 +3,9 @@
 // are flags; `compare` is the one subcommand, taking two positional
 // selectors; anything else positional is the session selector for the
 // default receipt command. `--svg` (SPEC-0003) switches the receipt and
-// `compare` commands to SVG output; `-o`/`--output` names the file and
-// `--theme light|dark` picks the palette.
+// `compare` commands to SVG output; `--png` (SPEC-0012) rasterizes it, receipt
+// command only; `-o`/`--output` names the file and `--theme light|dark` picks
+// the palette.
 export interface ParsedArgs {
   command: "receipt" | "list" | "compare" | "handoff" | "help" | "methodology" | "telemetry-show" | "quota" | "week" | "check-budget" | "benchmark" | "mini" | "install-hook" | "uninstall-hook" | "statusline";
   selector?: string;
@@ -17,6 +18,8 @@ export interface ParsedArgs {
   theme: "light" | "dark";
   /** SPEC-0003: output file for `--svg` (defaults to receipt.svg / compare.svg). */
   output?: string;
+  /** SPEC-0012 R3: rasterize the receipt SVG to PNG (single-receipt only — R5 defers `compare --png`). */
+  png: boolean;
   /** SPEC-0008 R4: split the weekly digest by project (opt-in). */
   byProject: boolean;
   /** SPEC-0008: re-anchor the trailing window at this YYYY-MM-DD date. */
@@ -45,6 +48,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let byProject = false;
   let since: string | undefined;
   let svg = false;
+  let png = false;
   let theme: "light" | "dark" = "light";
   let output: string | undefined;
   const positional: string[] = [];
@@ -81,6 +85,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       since = arg.slice("--since=".length);
     } else if (arg === "--svg") {
       svg = true;
+    } else if (arg === "--png") {
+      png = true;
     } else if (arg === "--theme") {
       theme = argv[++i] === "dark" ? "dark" : "light";
     } else if (arg === "-o" || arg === "--output") {
@@ -93,60 +99,60 @@ export function parseArgs(argv: string[]): ParsedArgs {
   }
 
   if (help) {
-    return { command: "help", json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "help", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
   }
 
   if (methodology) {
-    return { command: "methodology", json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "methodology", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
   }
 
   if (telemetryShow) {
-    return { command: "telemetry-show", json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "telemetry-show", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
   }
 
   if (checkBudget) {
-    return { command: "check-budget", json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "check-budget", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
   }
 
   if (quota) {
-    return { command: "quota", json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "quota", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
   }
 
   if (positional[0] === "compare") {
-    return { command: "compare", compareA: positional[1], compareB: positional[2], json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "compare", compareA: positional[1], compareB: positional[2], json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
   }
 
   if (positional[0] === "benchmark") {
-    return { command: "benchmark", selector: positional[1], json, svg, theme, output, byProject, since, dryRun } as ParsedArgs;
+    return { command: "benchmark", selector: positional[1], json, svg, png, theme, output, byProject, since, dryRun } as ParsedArgs;
   }
 
   if (mini) {
-    return { command: "mini", selector: positional[0], json, svg, theme, output, byProject, since, dryRun, csvMode, checkBudget };
+    return { command: "mini", selector: positional[0], json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget };
   }
 
   if (positional[0] === "install-hook") {
-    return { command: "install-hook", json, svg, theme, output, byProject, since, dryRun, csvMode, checkBudget };
+    return { command: "install-hook", json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget };
   }
 
   if (positional[0] === "uninstall-hook") {
-    return { command: "uninstall-hook", json, svg, theme, output, byProject, since, dryRun, csvMode, checkBudget };
+    return { command: "uninstall-hook", json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget };
   }
 
   if (positional[0] === "statusline") {
-    return { command: "statusline", selector: positional[1], json, svg, theme, output, byProject, since, dryRun, csvMode, checkBudget } as ParsedArgs;
+    return { command: "statusline", selector: positional[1], json, svg, png, theme, output, byProject, since, dryRun, csvMode, checkBudget } as ParsedArgs;
   }
 
   if (positional[0] === "week") {
-    return { command: "week", json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "week", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
   }
 
   if (list) {
-    return { command: "list", json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "list", json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
   }
 
   if (handoff) {
-    return { command: "handoff", selector: positional[0], json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+    return { command: "handoff", selector: positional[0], json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
   }
 
-  return { command: "receipt", selector: positional[0], json, svg, theme, output, byProject, since, checkBudget, dryRun, csvMode };
+  return { command: "receipt", selector: positional[0], json, svg, png, theme, output, byProject, since, checkBudget, dryRun, csvMode };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,7 @@ import { summaryToJson, toCompareJsonModel, toJsonModel } from "../receipt/json.
 import { buildReceiptModel } from "../receipt/model.js";
 import { renderReceipt } from "../receipt/render.js";
 import { renderReceiptSvg, renderCompareSvg } from "../receipt/svg.js";
+import { rasterizeSvgToPng } from "../receipt/png.js";
 import { renderWeek, weekToJson } from "../receipt/week.js";
 import { buildWeekDigest } from "../aggregate/week.js";
 import { renderMiniReceipt, renderStatusline } from "../receipt/mini.js";
@@ -42,6 +43,7 @@ Usage:
   aireceipts --quota                    current Claude Code rate-limit window usage
                                          (statusline stdin mode only; silent if unavailable)
   aireceipts [selector] --svg [-o f]    write a shareable SVG receipt (default receipt.svg)
+  aireceipts [selector] --png [-o f]    write a rasterized PNG receipt (default receipt.png)
   aireceipts compare <a> <b> --svg      write a side-by-side SVG (default compare.svg)
   aireceipts week [--by-project] [--since <date>] [--json]
                                         trailing-7-day digest across sessions
@@ -55,13 +57,14 @@ Usage:
   aireceipts statusline                 one-line summary for Claude Code's statusLine
   aireceipts --help                     show this help
 
-flags: --svg renders an SVG file; --theme light|dark picks the palette (default light);
-       -o/--output names the file.
+flags: --svg renders an SVG file; --png rasterizes it (receipt only, not compare);
+       --theme light|dark picks the palette (default light); -o/--output names the file.
 --csv[=session|tool]: export CSV (session summary rows, or one row per tool).
 selector: a 1-based index into --list, a session id, or a title substring.`;
 
 interface SvgOut {
   svg: boolean;
+  png: boolean;
   theme: "light" | "dark";
   output?: string;
 }
@@ -69,6 +72,11 @@ interface SvgOut {
 async function writeSvg(svg: string, path: string): Promise<void> {
   await writeFile(path, svg, "utf8");
   process.stdout.write(`wrote ${path} (${Buffer.byteLength(svg)} bytes)\n`);
+}
+
+async function writePng(png: Buffer, path: string): Promise<void> {
+  await writeFile(path, png);
+  process.stdout.write(`wrote ${path} (${png.length} bytes)\n`);
 }
 
 async function noSessionsMessage(): Promise<string> {
@@ -106,6 +114,11 @@ async function runReceipt(selector: string | undefined, json: boolean, svgOut: S
   const model = await buildReceiptModel(session);
   if (svgOut.svg) {
     await writeSvg(renderReceiptSvg(model, { theme: svgOut.theme }), svgOut.output ?? "receipt.svg");
+    return 0;
+  }
+  if (svgOut.png) {
+    const svg = renderReceiptSvg(model, { theme: svgOut.theme });
+    await writePng(rasterizeSvgToPng(svg), svgOut.output ?? "receipt.png");
     return 0;
   }
   if (csvMode !== undefined) {
@@ -186,6 +199,12 @@ async function runCompare(
   // compare CSV is strictly two session rows + a delta (R3) — per-tool granularity has no two-row shape here.
   if (csvMode !== undefined && csvMode !== "session") {
     process.stderr.write(`compare supports --csv=session only (got "${csvMode}")\n`);
+    return 1;
+  }
+  // SPEC-0012 R5: compare --png is deferred (doubles the blast radius of a new
+  // native dependency) — checked before any session lookup, same as csvMode above.
+  if (svgOut.png) {
+    process.stderr.write("compare --png is not supported yet — use compare --svg\n");
     return 1;
   }
   const sessions = await listSessions();
@@ -424,7 +443,7 @@ export async function runStatusline(
 }
 
 async function dispatch(args: ReturnType<typeof parseArgs>): Promise<number> {
-  const svgOut: SvgOut = { svg: args.svg, theme: args.theme, output: args.output };
+  const svgOut: SvgOut = { svg: args.svg, png: args.png, theme: args.theme, output: args.output };
   switch (args.command) {
     case "mini":
       return runMini(args.selector);

--- a/src/receipt/png.ts
+++ b/src/receipt/png.ts
@@ -1,0 +1,26 @@
+// SPEC-0012 R3-R5: --png rasterizes the SAME shared SVG (svg.ts) via
+// @resvg/resvg-js — never a third independent renderer. Fixed pixel
+// dimensions are the SVG's fixed logical WIDTH (640) scaled by PNG_SCALE, so
+// every --png receipt lands at one deterministic pixel width.
+//
+// R4 determinism note: only the input SVG stays byte-deterministic
+// (SPEC-0003 R1, golden-gated) — PNG *pixel* bytes are NOT claimed equal
+// across platforms (rasterizer/font-hinting differences are real, per R4's
+// explicit non-goal). Cross-platform stability instead comes from pinning
+// the rasterizer version (`@resvg/resvg-js` in package.json's `dependencies`,
+// promoted from devDependencies per R2's passed gate — see
+// docs/spikes/spec-0012-png.md and this spec's Validation section).
+import { Resvg } from "@resvg/resvg-js";
+import { WIDTH } from "./svg.js";
+
+/** R3: scale applied to the SVG's fixed 640px logical width (2x ≈ 192 effective DPI against a 96 DPI logical baseline). */
+export const PNG_SCALE = 2;
+
+/** Fixed pixel width every `--png` receipt renders at (R3; single-receipt only — compare is deferred, R5). */
+export const PNG_WIDTH = WIDTH * PNG_SCALE;
+
+/** Rasterize an SVG string (from `renderReceiptSvg`) to PNG bytes at the fixed R3 width. */
+export function rasterizeSvgToPng(svg: string): Buffer {
+  const resvg = new Resvg(svg, { fitTo: { mode: "width", value: PNG_WIDTH } });
+  return resvg.render().asPng();
+}

--- a/src/receipt/svg.ts
+++ b/src/receipt/svg.ts
@@ -63,7 +63,8 @@ function paintsFor(theme: Theme): Paints {
 }
 
 // --- Canvas geometry (Design section, all logical px) ------------------------
-const WIDTH = 640;
+/** Fixed logical width every receipt SVG renders at (also SPEC-0012 R3's PNG basis). */
+export const WIDTH = 640;
 const PAD_X = 32;
 const LEFT = PAD_X;
 const RIGHT = WIDTH - PAD_X; // 608

--- a/test/receipt/png.test.ts
+++ b/test/receipt/png.test.ts
@@ -1,0 +1,54 @@
+// SPEC-0012 R3-R5 smoke tests for the PNG export. NOT golden (R4: PNG pixel
+// bytes are not claimed byte-deterministic across platforms) — this file only
+// asserts the objective, cross-platform-stable properties: fixed dimensions,
+// a non-empty buffer, and a correct PNG signature. The byte-deterministic
+// input SVG stays golden-gated by scripts/verify-goldens.mjs, unaffected.
+import { describe, expect, it } from "vitest";
+import { loadById } from "../../src/index.js";
+import { buildReceiptModel } from "../../src/receipt/model.js";
+import { renderReceiptSvg } from "../../src/receipt/svg.js";
+import { PNG_SCALE, PNG_WIDTH, rasterizeSvgToPng } from "../../src/receipt/png.js";
+
+const PRICED = { source: "claude-code", path: "test/fixtures/claude-code/clean-multi-tool-2-models.jsonl" };
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function svgHeight(svg: string): number {
+  const m = svg.match(/height="([0-9.]+)"/);
+  return Number(m![1]);
+}
+
+/** IHDR chunk width/height, big-endian u32s starting at byte 16. */
+function pngDimensions(png: Buffer): { width: number; height: number } {
+  return { width: png.readUInt32BE(16), height: png.readUInt32BE(20) };
+}
+
+describe("rasterizeSvgToPng — R3/R4/R5 smoke", () => {
+  it("rasterizes to a valid PNG with the fixed R3 width", async () => {
+    const session = await loadById(PRICED.source, PRICED.path);
+    if (!session) throw new Error(`failed to load ${PRICED.path}`);
+    const model = await buildReceiptModel(session);
+    const svg = renderReceiptSvg(model);
+    const png = rasterizeSvgToPng(svg);
+
+    expect(png.length).toBeGreaterThan(0);
+    expect(png.subarray(0, 8)).toEqual(PNG_SIGNATURE);
+
+    const { width, height } = pngDimensions(png);
+    expect(width).toBe(PNG_WIDTH);
+    // Height scales with the same fixed factor resvg applies to width (fitTo: mode "width").
+    expect(height).toBe(Math.round(svgHeight(svg) * PNG_SCALE));
+  });
+
+  it("is not claimed byte-deterministic (R4) — only dimensions/signature are asserted here", async () => {
+    const session = await loadById(PRICED.source, PRICED.path);
+    if (!session) throw new Error(`failed to load ${PRICED.path}`);
+    const model = await buildReceiptModel(session);
+    const svg = renderReceiptSvg(model);
+    const a = rasterizeSvgToPng(svg);
+    const b = rasterizeSvgToPng(svg);
+    // Same-machine reruns of the same input are typically byte-identical, but
+    // this is NOT the invariant under test (R4 explicitly disclaims it across
+    // platforms) — only shape/signature are the contract.
+    expect(pngDimensions(a)).toEqual(pngDimensions(b));
+  });
+});


### PR DESCRIPTION
## What this adds
`--png` — the receipt as a ready-to-post image file, no SVG-renderer roulette: we rasterize with the engine we tested (resvg, spike-gated in #7), at 2× width for crispness. `compare --png` stays deferred with a clear exit-1 pointer to `compare --svg` (spec-pinned).

## Why it matters to users
- `aireceipts --png` → drop the file anywhere an SVG is second-class (Slack previews, X uploads)
- Theme respected; light and dark both verified visually by the lead before this PR opened

## See it
Lead-inspected 2× dark render: masthead/title/cache line, aligned dotted rows, TOTAL + same-tokens compare adjacency, the stamp, scalloped edges (white backing = the torn-paper effect, deliberate).

## What changed
- src/receipt/png.ts — rasterizeSvgToPng via @resvg/resvg-js (promoted devDependency → dependency per the spike's PASS)
- CLI: --png [-o file] mirroring --svg conventions; compare --png = spec-pinned deferral
- test/receipt/png.test.ts — smoke assertions only (dimensions, magic bytes); PNG bytes are deliberately NOT golden (not stable across platforms — the SVG stays the golden layer)

## What to review, in order
1. The dependency promotion (adds ~3.5–4.4MB per platform — the numbers the spike measured against the ≤12MB gate)
2. PNG_SCALE=2 default (taste: retina-crisp vs file size ~50–100KB)
3. The white-backing design call for scallops

## Evidence
Gates all green post-rebase (builder's two reds were the since-fixed NOTICE allowlist on old base). Spec: SPEC-0012 R3–R5; spike record docs/spikes/spec-0012-png.md.
