### PR TITLE
fix: aireceipts pr --session reaches sidechain transcripts (fixes #26)

### DIFF
--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -5,12 +5,11 @@
 // failed post can never eat the receipt. Selection errors (no/many matches)
 // happen before there's anything to render and exit 1 with a stderr message.
 import * as path from "node:path";
-import { selectSummary } from "../parse/load.js";
 import type { Session, SessionSummary } from "../parse/types.js";
 import { buildReceiptModel, sliceSessionForReceipt } from "../receipt/model.js";
 import { renderReceipt } from "../receipt/render.js";
 import { branchCommits, defaultRunner, worktreeRoots, type CommandRunner } from "./git.js";
-import { selectCandidates } from "./select.js";
+import { selectCandidates, selectExplicitSession } from "./select.js";
 import { computeSlice } from "./slice.js";
 import { rollupChildren, type RollupWindow, type SubagentRow } from "./rollup.js";
 import { renderPrBody } from "./body.js";
@@ -54,7 +53,7 @@ async function resolveSession(
 ): Promise<{ summary: SessionSummary } | { error: string }> {
   const sessions = await deps.listSessions();
   if (opts.session) {
-    const summary = selectSummary(sessions, opts.session);
+    const summary = await selectExplicitSession(sessions, opts.session);
     return summary ? { summary } : { error: `no session matched "${opts.session}"` };
   }
   if (sessions.length === 0) {

--- a/src/pr/select.ts
+++ b/src/pr/select.ts
@@ -3,6 +3,9 @@
 // window in time (R1d). Zero candidates → caller errors; multiple → caller lists
 // them and requires --session (never guess). Slicing (R1e) happens only after a
 // single session is chosen; time is a filter here, never the slicer.
+import * as path from "node:path";
+import { discoverChildFiles } from "../parse/children.js";
+import { loadById, selectSummary } from "../parse/load.js";
 import type { SessionSummary } from "../parse/types.js";
 import { cwdInsideRoots } from "./git.js";
 
@@ -13,6 +16,29 @@ export type Selection =
   | { kind: "one"; summary: SessionSummary }
   | { kind: "many"; matches: SessionSummary[] }
   | { kind: "none" };
+
+export interface ExplicitSelectionDeps {
+  discoverChildren: (parentFilePath: string) => Promise<string[]>;
+  loadChildSummary: (parent: SessionSummary, childFilePath: string) => Promise<SessionSummary | null>;
+}
+
+const defaultExplicitDeps: ExplicitSelectionDeps = {
+  discoverChildren: discoverChildFiles,
+  loadChildSummary: async (parent, childFilePath) => loadById(parent.source, childFilePath),
+};
+
+function idStem(id: string): string {
+  return path.basename(id).replace(/\.jsonl$/, "");
+}
+
+function matchesExplicitSelector(summary: SessionSummary, selector: string): boolean {
+  return (
+    summary.id === selector ||
+    summary.filePath === selector ||
+    idStem(summary.id) === selector ||
+    idStem(summary.filePath) === selector
+  );
+}
 
 /** A commit instant falls inside the session window padded by ±15 min (R1d). */
 function overlaps(startedAt: number, endedAt: number, commitMs: readonly number[]): boolean {
@@ -48,4 +74,41 @@ export function selectCandidates(
     return { kind: "one", summary: matches[0] };
   }
   return { kind: "many", matches };
+}
+
+/**
+ * Resolve an explicit `aireceipts pr --session <id-or-path>`.
+ *
+ * The top-level list intentionally excludes subagents, so explicit PR
+ * selection searches each parent's child index as a second step. This does not
+ * affect auto-selection: sidechains still roll up into their parent unless the
+ * user names one directly.
+ */
+export async function selectExplicitSession(
+  sessions: SessionSummary[],
+  selector: string,
+  deps: Partial<ExplicitSelectionDeps> = {},
+): Promise<SessionSummary | null> {
+  const sel = selector.trim();
+  const indexed = selectSummary(sessions, sel);
+  if (!sel || /^\d+$/.test(sel)) {
+    return indexed;
+  }
+
+  const topLevel = sessions.find((s) => matchesExplicitSelector(s, sel));
+  if (topLevel) {
+    return topLevel;
+  }
+
+  const { discoverChildren, loadChildSummary } = { ...defaultExplicitDeps, ...deps };
+  for (const parent of sessions) {
+    const childFiles = await discoverChildren(parent.filePath);
+    const childFile = childFiles.find((file) => file === sel || idStem(file) === sel);
+    if (!childFile) {
+      continue;
+    }
+    return loadChildSummary(parent, childFile);
+  }
+
+  return indexed;
 }

--- a/test/cli/hook-commands.test.ts
+++ b/test/cli/hook-commands.test.ts
@@ -51,8 +51,8 @@ describe("--mini fail-safe (R6)", () => {
 describe("install-hook consent on EOF / no TTY (R1)", () => {
   it("defaults to No — exits 0, writes nothing, never hangs on closed stdin", () => {
     const dir = mkdtempSync(join(tmpdir(), "aireceipts-eof-"));
-    // Real CLI entry via tsx, empty stdin (immediate EOF), isolated config dir.
-    const res = spawnSync("npx", ["tsx", "src/cli.ts", "install-hook"], {
+    // Real CLI entry via vite-node, empty stdin (immediate EOF), isolated config dir.
+    const res = spawnSync(process.execPath, ["node_modules/vite-node/vite-node.mjs", "src/cli.ts", "install-hook"], {
       input: "",
       timeout: 30_000,
       encoding: "utf8",

--- a/test/pr/run.test.ts
+++ b/test/pr/run.test.ts
@@ -5,12 +5,14 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { loadById } from "../../src/parse/load.js";
-import type { Session } from "../../src/parse/types.js";
 import type { CommandResult, CommandRunner } from "../../src/pr/git.js";
 import { DOGFOOD_MARKER } from "../../src/pr/body.js";
 import { runPr, type PrDeps } from "../../src/pr/index.js";
 
 const FIX = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "pr");
+const ANCHORS = path.join(FIX, "claude-anchors.jsonl");
+const PARENT_WITH_SUBAGENTS = path.join(FIX, "parent-with-subagents.jsonl");
+const CHILD_ONE = path.join(FIX, "parent-with-subagents", "subagents", "agent-child1.jsonl");
 const ok = (stdout: string): CommandResult => ({ stdout, stderr: "", code: 0, missing: false });
 
 /** git mock: one worktree at /home/dev/repo, one branch commit (our SHA) at 10:02. */
@@ -22,14 +24,22 @@ const gitOk: CommandRunner = (_cmd, args) => {
   return { stdout: "", stderr: "", code: 1, missing: false };
 };
 
+const gitSubagentTime: CommandRunner = (_cmd, args) => {
+  if (args[0] === "worktree") return ok("worktree /home/dev/repo\n");
+  if (args[0] === "rev-parse") return ok("origin/main\n");
+  if (args[0] === "merge-base") return ok("0000000000000000000000000000000000000000\n");
+  if (args[0] === "log") return ok("1111111111111111111111111111111111111111|2026-06-27T12:01:00.000Z\n");
+  return { stdout: "", stderr: "", code: 1, missing: false };
+};
+
 async function makeDeps(over: Partial<PrDeps> = {}): Promise<{ deps: PrDeps; events: string[]; out: string[]; err: string[] }> {
-  const session = (await loadById("claude-code", path.join(FIX, "claude-anchors.jsonl")))!;
+  const session = (await loadById("claude-code", ANCHORS))!;
   const events: string[] = [];
   const out: string[] = [];
   const err: string[] = [];
   const deps: PrDeps = {
     listSessions: async () => [session],
-    loadSession: async () => session as Session,
+    loadSession: async (summary) => loadById(summary.source, summary.id),
     runGit: gitOk,
     runGh: () => ok("[]"),
     rollup: async () => [],
@@ -61,6 +71,27 @@ describe("R3 render-first ordering", () => {
     expect(ghCalled).toBe(false);
     expect(out[0].startsWith(DOGFOOD_MARKER)).toBe(true);
     expect(out[0]).toContain("session slice: turns 2–4 of 6");
+  });
+
+  it("explicit --session can select a subagent by stem, render, and post", async () => {
+    const parent = (await loadById("claude-code", PARENT_WITH_SUBAGENTS))!;
+    const ghCalls: string[] = [];
+    const gh: CommandRunner = (_cmd, args) => {
+      ghCalls.push(args.join(" "));
+      if (args[0] === "pr") return ok('{"number": 26}');
+      return ok("[]");
+    };
+    const { deps, out, err } = await makeDeps({
+      listSessions: async () => [parent],
+      runGit: gitSubagentTime,
+      runGh: gh,
+    });
+    const code = await runPr({ post: true, session: "agent-child1" }, deps);
+    expect(code).toBe(0);
+    expect(out[0].startsWith(DOGFOOD_MARKER)).toBe(true);
+    expect(out[0]).toContain("session `agent-child1`");
+    expect(ghCalls.some((c) => c.includes("issues/26/comments"))).toBe(true);
+    expect(err.join("\n")).toContain("posted receipt (created) to PR #26");
   });
 
   it("posts after rendering: body to stdout FIRST, then the gh upsert (exit 0)", async () => {
@@ -112,11 +143,30 @@ describe("R1d selection outcomes", () => {
   });
 
   it("multiple matches → lists ids and requires --session, exit 1", async () => {
-    const session = (await loadById("claude-code", path.join(FIX, "claude-anchors.jsonl")))!;
-    const { deps, out, err } = await makeDeps({ listSessions: async () => [session, { ...session, id: "dupe", filePath: "dupe.jsonl" }] });
+    const session = (await loadById("claude-code", ANCHORS))!;
+    const { deps, out, err } = await makeDeps({
+      listSessions: async () => [session, { ...session, id: "dupe", filePath: "dupe.jsonl" }],
+    });
     const code = await runPr({ post: false }, deps);
     expect(code).toBe(1);
     expect(out).toHaveLength(0);
     expect(err.join("\n")).toContain("multiple sessions match");
+  });
+
+  it("auto-selection still skips a sidechain transcript", async () => {
+    const child = (await loadById("claude-code", CHILD_ONE))!;
+    const { deps, out, err } = await makeDeps({ listSessions: async () => [child], runGit: gitSubagentTime });
+    const code = await runPr({ post: false }, deps);
+    expect(code).toBe(1);
+    expect(out).toHaveLength(0);
+    expect(err.join("\n")).toContain("no session matches");
+  });
+
+  it("bogus explicit --session id errors without rendering", async () => {
+    const { deps, out, err } = await makeDeps();
+    const code = await runPr({ post: false, session: "missing-child" }, deps);
+    expect(code).toBe(1);
+    expect(out).toHaveLength(0);
+    expect(err.join("\n")).toContain('no session matched "missing-child"');
   });
 });

--- a/test/pr/select.test.ts
+++ b/test/pr/select.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from "vitest";
 import type { SessionSummary } from "../../src/parse/types.js";
 import { cwdInsideRoots } from "../../src/pr/git.js";
-import { OVERLAP_SLACK_MS, selectCandidates } from "../../src/pr/select.js";
+import { OVERLAP_SLACK_MS, selectCandidates, selectExplicitSession } from "../../src/pr/select.js";
 
 const emptyTotals = { tokens: { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 }, turnCount: 0, toolCallCount: 0 };
 
@@ -76,5 +76,34 @@ describe("R1d overlap + selection", () => {
       isSidechain: true,
     });
     expect(selectCandidates([s], roots, commitMs)).toEqual({ kind: "none" });
+  });
+});
+
+describe("R1c explicit --session child selection", () => {
+  const parent = summary({ id: "/tmp/parent.jsonl", filePath: "/tmp/parent.jsonl" });
+  const childPath = "/tmp/parent/subagents/agent-child1.jsonl";
+  const child = summary({
+    id: childPath,
+    filePath: childPath,
+    isSidechain: true,
+    parentSessionId: "parent",
+    agentId: "child1",
+    parentFilePath: parent.filePath,
+  });
+  const deps = {
+    discoverChildren: async () => [childPath],
+    loadChildSummary: async () => child,
+  };
+
+  it("matches a subagent transcript by id stem", async () => {
+    await expect(selectExplicitSession([parent], "agent-child1", deps)).resolves.toBe(child);
+  });
+
+  it("matches a subagent transcript by absolute path", async () => {
+    await expect(selectExplicitSession([parent], childPath, deps)).resolves.toBe(child);
+  });
+
+  it("returns null for a bogus explicit id", async () => {
+    await expect(selectExplicitSession([parent], "missing-child", deps)).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## What this adds
Explicit --session now accepts sidechain ids/paths (auto-selection still excludes them — unchanged). A subagent-built PR can finally self-receipt, closing the gap PR #25 dogfooding found.

## What to review
src/pr/select.ts explicit-selector path + the three new tests.

## Evidence
All gates 0. Built by Codex; fixes #26.