### PR TITLE
fix: post-merge review findings (#31 #32 #33)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -304,9 +304,9 @@ async function runCompare(
  * window definition, reused so there's one notion of "recent"). Feeds the
  * distinct-session recurrence check for standing-rule suggestions.
  */
-async function recentWasteAggregates(now: number = Date.now()): Promise<WasteClassAggregate[]> {
+export async function recentWasteAggregates(now: number = Date.now()): Promise<WasteClassAggregate[]> {
   const bounds = windowBounds(now);
-  const summaries = await listSessions();
+  const summaries = await listFullSessions();
   const { current } = partitionWindows(summaries, bounds);
   const loaded = await Promise.all(current.map((s) => loadSession(s)));
   return aggregateWaste(loaded.filter((s): s is Session => s !== null));

--- a/src/parse/summaryCache.ts
+++ b/src/parse/summaryCache.ts
@@ -27,6 +27,18 @@ function finiteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+function optionalFiniteNumber(value: unknown): boolean {
+  return value === undefined || finiteNumber(value);
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function optionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === "boolean";
+}
+
 function tokenUsage(value: unknown): value is TokenUsage {
   if (!value || typeof value !== "object") {
     return false;
@@ -53,7 +65,18 @@ function sessionSummary(value: unknown): value is SessionSummary {
     typeof summary.id === "string" &&
     typeof summary.source === "string" &&
     SOURCES.has(summary.source as AgentSource) &&
+    optionalString(summary.title) &&
+    optionalString(summary.model) &&
+    optionalFiniteNumber(summary.startedAt) &&
+    optionalFiniteNumber(summary.endedAt) &&
     typeof summary.filePath === "string" &&
+    optionalBoolean(summary.unpriceable) &&
+    optionalString(summary.cwd) &&
+    optionalString(summary.gitBranch) &&
+    optionalBoolean(summary.isSidechain) &&
+    optionalString(summary.parentSessionId) &&
+    optionalString(summary.agentId) &&
+    optionalString(summary.parentFilePath) &&
     typeof totals === "object" &&
     totals !== null &&
     tokenUsage(totals.tokens) &&

--- a/src/receipt/blocks.ts
+++ b/src/receipt/blocks.ts
@@ -12,6 +12,7 @@
 // (I2/I3) are non-removable by construction rather than by renderer politeness.
 import { METHODOLOGY_BRIEF } from "../pricing/attribution.js";
 import type { ReceiptModel } from "./model.js";
+import { formatUsd } from "./format.js";
 
 export type TemplateName = "classic" | "grocery" | "datavis";
 
@@ -135,8 +136,33 @@ export function groceryLine(item: string, qty: string, amt: string): string {
 
 /** One honesty-invariant breach found by {@link validateReceiptBlocks}. */
 export interface BlockViolation {
-  code: "dollar-in-unpriced" | "missing-methodology" | "missing-delta-note" | "waste-label-drift";
+  code: "dollar-in-unpriced" | "untraced-dollar" | "missing-methodology" | "missing-delta-note" | "waste-label-drift";
   detail: string;
+}
+
+const DOLLAR_AMOUNT_RE = /\$-?\d[\d,]*(?:\.\d+)?/g;
+
+function dollarAmounts(s: string): string[] {
+  return s.match(DOLLAR_AMOUNT_RE) ?? [];
+}
+
+function addDollar(out: Set<string>, usd: number | null | undefined): void {
+  if (usd !== null && usd !== undefined) {
+    out.add(`$${formatUsd(usd)}`);
+  }
+}
+
+function tracedDollarAmounts(model: ReceiptModel): Set<string> {
+  const out = new Set<string>();
+  addDollar(out, model.totalUsd);
+  for (const row of model.toolRows) {
+    addDollar(out, row.usd);
+  }
+  for (const waste of model.wasteLines) {
+    addDollar(out, waste.usd);
+  }
+  addDollar(out, model.priceDelta?.usd);
+  return out;
 }
 
 /** Every display string a block puts on the receipt — what the `$`-scan inspects. */
@@ -183,6 +209,16 @@ export function validateReceiptBlocks(blocks: Block[], model: ReceiptModel): Blo
     const hasMethodology = blocks.some((b) => b.kind === "footnote" && b.text === METHODOLOGY_BRIEF);
     if (!hasMethodology) {
       violations.push({ code: "missing-methodology", detail: "priced receipt lacks the exact METHODOLOGY_BRIEF footnote" });
+    }
+    const allowedDollars = tracedDollarAmounts(model);
+    for (const b of blocks) {
+      for (const s of blockStrings(b)) {
+        for (const amount of dollarAmounts(s)) {
+          if (!allowedDollars.has(amount)) {
+            violations.push({ code: "untraced-dollar", detail: `priced receipt renders untraced ${amount} in ${b.kind}: ${s}` });
+          }
+        }
+      }
     }
     if (model.priceDelta) {
       const hasDeltaNote = blocks.some((b) => b.kind === "note" && b.text === PRICE_DELTA_NOTE);

--- a/test/cli/handoff-recent.test.ts
+++ b/test/cli/handoff-recent.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Session, SessionSummary, TokenUsage, Turn } from "../../src/parse/types.js";
+
+vi.mock("../../src/index.js", async (importActual) => {
+  const actual = await importActual<typeof import("../../src/index.js")>();
+  return {
+    ...actual,
+    listSessions: vi.fn(),
+    listFullSessions: vi.fn(),
+    loadSession: vi.fn(),
+  };
+});
+
+const index = await import("../../src/index.js");
+const { recentWasteAggregates } = await import("../../src/cli/index.js");
+
+const listSessionsMock = vi.mocked(index.listSessions);
+const listFullSessionsMock = vi.mocked(index.listFullSessions);
+const loadSessionMock = vi.mocked(index.loadSession);
+
+const DAY_MS = 86_400_000;
+const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
+
+function usage(input: number): TokenUsage {
+  return { input, output: 0, cacheRead: 0, cacheCreation: 0, total: input };
+}
+
+function summary(id: string, endedAt: number): SessionSummary {
+  return {
+    id,
+    source: "claude-code",
+    filePath: `/fake/${id}.jsonl`,
+    startedAt: endedAt - 1000,
+    endedAt,
+    totals: { tokens: usage(0), turnCount: 1, toolCallCount: 3 },
+  };
+}
+
+function wasteSession(id: string, endedAt: number): Session {
+  const tokens = usage(3_000_000);
+  const turn: Turn = {
+    index: 0,
+    timestamp: endedAt,
+    model: "claude-opus-4-8",
+    usage: tokens,
+    toolCalls: [
+      { name: "Bash", input: { command: "npm test" } },
+      { name: "Bash", input: { command: "npm test" } },
+      { name: "Bash", input: { command: "npm test" } },
+    ],
+  };
+  return {
+    ...summary(id, endedAt),
+    model: "claude-opus-4-8",
+    totals: { tokens, turnCount: 1, toolCallCount: 3 },
+    turns: [turn],
+  };
+}
+
+beforeEach(() => {
+  listSessionsMock.mockReset();
+  listFullSessionsMock.mockReset();
+  loadSessionMock.mockReset();
+});
+
+describe("recentWasteAggregates", () => {
+  it("windows by full parsed endedAt, not the lazy summary's mtime-derived endedAt", async () => {
+    const lazyMtimeSummary = summary("s", NOW - DAY_MS);
+    const fullParsedSummary = summary("s", NOW - 10 * DAY_MS);
+    listSessionsMock.mockResolvedValue([lazyMtimeSummary]);
+    listFullSessionsMock.mockResolvedValue([fullParsedSummary]);
+    loadSessionMock.mockResolvedValue(wasteSession("s", NOW - 10 * DAY_MS));
+
+    await expect(recentWasteAggregates(NOW)).resolves.toEqual([]);
+    expect(listFullSessionsMock).toHaveBeenCalledTimes(1);
+    expect(listSessionsMock).not.toHaveBeenCalled();
+    expect(loadSessionMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/parse/discovery-cache.test.ts
+++ b/test/parse/discovery-cache.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { ClaudeCodeAdapter } from "../../src/parse/claudeCode.js";
 import type { DiscoveryFs } from "../../src/parse/discovery.js";
 import { completeSummariesWithCache } from "../../src/parse/summaryCache.js";
+import type { SessionSummary } from "../../src/parse/types.js";
 
 const tmpRoots: string[] = [];
 
@@ -61,6 +62,25 @@ async function writeClaudeTranscript(root: string, name: string, i: number, extr
   return filePath;
 }
 
+async function writeCacheEntry(cachePath: string, filePath: string, summary: unknown): Promise<void> {
+  const s = await stat(filePath);
+  await mkdir(path.dirname(cachePath), { recursive: true });
+  await writeFile(
+    cachePath,
+    `${JSON.stringify(
+      {
+        version: 1,
+        entries: {
+          [filePath]: { mtimeMs: s.mtimeMs, size: s.size, summary },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
 describe("lazy discovery + summary cache", () => {
   it("reuses cached full summaries without changing the uncached parser answer, even after corrupt cache input", async () => {
     const root = await tempRoot("aireceipts-cache-");
@@ -92,6 +112,46 @@ describe("lazy discovery + summary cache", () => {
     expect(first).toEqual(uncached);
     expect(second).toEqual(uncached);
     expect(loads).toBe(0);
+  });
+
+  it.each([
+    {
+      name: "startedAt is not numeric",
+      corrupt: (s: SessionSummary) => ({ ...s, startedAt: "2026-06-18T10:00:00Z" }),
+    },
+    {
+      name: "unpriceable is not boolean",
+      corrupt: (s: SessionSummary) => ({ ...s, unpriceable: "false" }),
+    },
+    {
+      name: "parentFilePath is not a string",
+      corrupt: (s: SessionSummary) => ({ ...s, parentFilePath: 123 }),
+    },
+    {
+      name: "gitBranch is not a string",
+      corrupt: (s: SessionSummary) => ({ ...s, gitBranch: { name: "main" } }),
+    },
+  ])("drops a matching cache entry when the cached SessionSummary is corrupt: $name", async ({ corrupt }) => {
+    const root = await tempRoot("aireceipts-cache-corrupt-");
+    const transcript = await writeClaudeTranscript(root, "one.jsonl", 1);
+    const cachePath = path.join(root, ".aireceipts", "cache.json");
+    const adapter = new ClaudeCodeAdapter({ root });
+    const lazy = await adapter.listSessions();
+    const uncached = await adapter.listSessions({ full: true });
+    await writeCacheEntry(cachePath, transcript, corrupt(uncached[0]));
+
+    let loads = 0;
+    const repaired = await completeSummariesWithCache(lazy, {
+      cachePath,
+      stat,
+      load: async (summary) => {
+        loads++;
+        return adapter.loadSession(summary.id);
+      },
+    });
+
+    expect(repaired).toEqual(uncached);
+    expect(loads).toBe(1);
   });
 
   it("discovers a synthetic 200-file corpus by reading first lines instead of full transcript bodies", async () => {

--- a/test/receipt/templates.test.ts
+++ b/test/receipt/templates.test.ts
@@ -37,23 +37,33 @@ async function modelFor(source: string, path: string): Promise<ReceiptModel> {
   return buildReceiptModel(session);
 }
 
-/** Short display strings a block puts on both renderers verbatim (skips wrapped/centered/chrome that the layouts reflow). */
-function checkableLabels(b: Block): string[] {
+function footnoteTokens(text: string): string[] {
+  return text.split(/\s+/).filter((token) => token.length >= 8);
+}
+
+/** Value-bearing display strings a block puts on both renderers; wrapped footnotes are checked token-wise because terminal/SVG line widths differ. */
+function checkableValues(b: Block): string[] {
   switch (b.kind) {
     case "masthead":
       return [b.text];
+    case "meta":
+      return b.lines;
     case "columnHeader":
       return [b.item, b.qty, b.amt];
     case "row":
-      return b.columns ? [b.label] : [b.label, b.value];
+      return b.columns ? [b.label, b.value, b.columns.qty, b.columns.amt] : [b.label, b.value];
     case "wasteRow":
-      return [b.label];
+      return b.detail === undefined ? [b.label, b.value] : [b.label, b.value, b.detail];
     case "total":
-      return [b.label];
+      return b.columns ? [b.label, b.value, b.columns.qty, b.columns.amt] : [b.label, b.value];
     case "note":
       return [b.text];
     case "barcode":
       return [b.pattern];
+    case "footnote":
+      return footnoteTokens(b.text);
+    case "footer":
+      return [b.text];
     default:
       return [];
   }
@@ -88,6 +98,12 @@ describe("SPEC-0020 R3 — exact-wording honesty battery holds in every template
     const unpriced = await modelFor(UNPRICED.source, UNPRICED.path);
     const leaked = [...buildReceiptView(unpriced, "classic").blocks, { kind: "note", text: "sneaky $9.99" } as Block];
     expect(validateReceiptBlocks(leaked, unpriced).map((v) => v.code)).toContain("dollar-in-unpriced");
+
+    const withFakeDollar = [
+      ...buildReceiptView(priced, "classic").blocks,
+      { kind: "row", label: "fake surcharge", value: "$123,456.78" },
+    ] as Block[];
+    expect(validateReceiptBlocks(withFakeDollar, priced).map((v) => v.code)).toContain("untraced-dollar");
   });
 });
 
@@ -147,9 +163,9 @@ describe("SPEC-0020 — block parity: terminal and SVG consume the identical blo
     const terminal = renderReceipt(model, { color: false, template });
     const svg = renderReceiptSvg(model, { template });
     for (const block of blocks) {
-      for (const label of checkableLabels(block)) {
-        expect(terminal).toContain(label);
-        expect(svg).toContain(label);
+      for (const value of checkableValues(block).filter((s) => s !== "")) {
+        expect(terminal).toContain(value);
+        expect(svg).toContain(value);
       }
     }
   });


### PR DESCRIPTION
## What this adds
Closes the three post-merge Codex review findings: full SessionSummary field validation in the cache (corrupt entries rebuild instead of poisoning selectors, #31); handoff recurrence windows use full sessions, not lazy mtime summaries (#32); validateReceiptBlocks now traces priced dollars and block-parity covers every value-bearing field (#33).

## What to review, in order
1. The priced-dollar trace check (the honesty-battery hole)
2. The mtime-vs-endedAt regression test
3. Cache corruption fallback tests

## Evidence
All gates 0 — tsc/eslint/vitest 679/goldens/determinism/spec-lint/hygiene. Built + self-reviewed by Codex (review marker on the reviewed tree; commit made by lead — Codex sandbox cannot write the shared git index). Codex transcripts live in ~/.codex/sessions; dogfood receipt via the codex adapter to follow once `pr --session` supports codex paths.