### PR TITLE
docs: apply S2 critic verdicts — SPEC-0017 + SPEC-0018 reworked drafts

### DIFF
--- a/specs/SPEC-0017-context-thrash-waste.md
+++ b/specs/SPEC-0017-context-thrash-waste.md
@@ -8,82 +8,151 @@ depends: [SPEC-0001]
 
 # SPEC-0017 · Context-thrash waste detector
 
-Invariants: I1 (deterministic, transcript-only), I2 (priced only when the session
-prices), I3 (methodology of the estimate disclosed), I6 (a fact about tokens, never a
-judgment of the agent's competence).
+Invariants: I1 (deterministic, transcript-only), I2 (priced only from cited rows), I3
+(methodology discloses the estimate), I5 (goldens gate receipt bytes), I6 (a fact about
+tokens and compactions, never a judgment of the agent's competence).
 
 ## Purpose
 
-Context thrashing is real, expensive, and invisible: a session whose context refills to
-the limit shortly after each compaction burns tokens re-establishing state instead of
-working — our own build fleet lost two agents to exactly this today. Transcripts record
-compaction events, so the churn is deterministically detectable and its token cost
-priceable. This lands the third waste class beside stuck-loop and trivial-spans.
-**Kill criterion:** if the detector fires on >10% of a clean-session corpus (fixtures +
-maintainer dogfood where no thrash plausibly occurred), the thresholds are wrong — fix
-or kill before it ever ships noise (precision-1.0 discipline applies).
+Context thrash is not "a compaction happened near another compaction." It is compaction
+churn followed by the prompt-side context refilling near the pre-compact peak, meaning
+the session is paying to rebuild context instead of doing new work. This spec lands that
+measured waste class beside stuck-loop and trivial-spans. **Kill criterion:** the
+detector must produce 0 false positives on all committed clean fixtures plus a
+pre-labeled maintainer clean corpus of at least 20 sessions; if that corpus is missing
+or smaller, evidence is insufficient and the detector cannot ship.
 
 ## Requirements
 
-- **R1 — Compaction event extraction.** The claude-code adapter surfaces compaction
-  boundaries from the transcript (the summary/compact records it already contains) as
-  `Session.compactions: {turnIndex, atMs}[]`. Adapters whose format records no
-  compaction signal expose an empty array — the detector then never fires (I2-style
-  honesty: no inferred compactions).
-- **R2 — Thrash definition (exact).** A *thrash window* is ≥2 compactions where each
-  successive gap is ≤ T turns (default T=25, constant in code). One compaction alone is
-  normal long-session behavior and never fires.
-- **R3 — Cost attribution (labeled estimate).** The window's cost = the priced input
-  tokens of the K turns immediately following each non-first compaction in the window
-  (default K=5, constant) — the re-establishment burn. Rendered as a waste line:
-  `≈ context thrash: N compactions in M turns` with the window's `$`/tokens, `≈`-labeled;
-  the METHODOLOGY text gains one sentence describing this estimate.
-- **R4 — Fires everywhere waste fires.** Receipt waste section, `--handoff` block
-  (template: suggest `/clear` at task boundaries + smaller working sets), `--json`
-  under the existing waste schema, and SPEC-0008's `aggregateWaste` as class
-  `context-thrash` (SPEC-0013 standing-rule template comes free once its threshold
-  crosses).
-- **R5 — Eval corpus rows.** ≥2 new fixtures: one true-positive (3 compactions, tight
-  gaps), one true-negative (2 compactions, far apart) + existing clean fixtures must
-  stay clean (precision 1.0 gate extends automatically).
+- **R1 — Raw compaction extraction before adapter filters.** The Claude Code adapter
+  extracts compaction events before dropping `isMeta` records and before command-echo
+  filtering. The accepted raw shapes are named and finite: `isCompactSummary === true`;
+  `type` equal to `compact-summary`, `compact_boundary`, or `compact-boundary`; the
+  current `isMeta: true` user record whose text matches Claude's compact summary
+  wording such as "context compacted"; and a `<command-name>compact</command-name>`
+  command echo only when adjacent to one of those summary/boundary records. Ordinary
+  user text that mentions compacting never counts. Normalized shape:
+  `Session.compactions: { turnIndex, atMs }[]`.
+- **R2 — Compaction position is defined.** `turnIndex` is the index of the next
+  assistant turn after the raw compact record. `atMs` is the raw compact record's
+  timestamp only; if the record has no timestamp, `atMs` is absent rather than
+  synthesized. A compaction after the final assistant turn is retained with
+  `turnIndex = turns.length` for extraction tests but is ineligible for thrash because
+  it has no following turns to prove refill.
+- **R3 — Thrash requires measured refill, not proximity alone.** For each compaction,
+  `promptSide(turn) = input + cacheRead + cacheCreation` from that turn's `TokenUsage`.
+  Let `prePeak` be the maximum prompt-side tokens observed in assistant turns before
+  the compaction, and `postPeak` be the maximum prompt-side tokens in the next `K`
+  assistant turns starting at `turnIndex`. A compaction is refill-positive only when
+  `prePeak > 0` and `postPeak >= REFILL_RATIO * prePeak` (defaults: `K=5`,
+  `REFILL_RATIO=0.80`). A thrash window is a contiguous cluster of at least two
+  refill-positive compactions where each successive `turnIndex` gap is `<= T`
+  assistant turns (default `T=25`). Boundary tests pin `T=25` as included, `T=26` as
+  excluded, `K` as exactly five turns, and `0.80` as included.
+- **R4 — Thresholds are provisional and evidence-bound.** `T=25`, `K=5`, and
+  `REFILL_RATIO=0.80` are constants, not user knobs. The implementation PR must attach
+  a named corpus table justifying them from committed fixtures plus maintainer dogfood;
+  if dogfood cannot justify the constants, the detector remains draft or the constants
+  are changed before approval.
+- **R5 — Cost attribution uses sliced prompt-side `TokenUsage`.** The waste line's
+  tokens are the union of assistant turn indices in the `K`-turn post-compaction slices
+  after each non-first compaction in a fired thrash window. Unioning happens before
+  summing so overlapping slices never double-count. Each contributing turn is sliced to
+  a prompt-only `TokenUsage` preserving `input`, `cacheRead`, `cacheCreation`,
+  `cacheCreation5m`, and `cacheCreation1h`, with `output = 0`; pricing then uses the
+  existing cache-tier cost logic. `usd` is `null` unless every contributing turn has a
+  model/date and every model/date resolves to a cited price row. No partial-dollar
+  context-thrash line is rendered.
+- **R6 — Overlap is explicit and aggregate waste is non-additive when needed.** Same-class
+  context-thrash overlap is deduped by the union in R5. If any context-thrash turn also
+  belongs to stuck-loop or trivial-spans, receipt/JSON may still show both factual
+  class lines, but `aggregateWaste` must mark the affected aggregate set as
+  non-additive (for example `nonAdditive: true` plus overlap metadata) so callers do not
+  sum overlapping class costs as a session total.
+- **R7 — Output surfaces are separate contracts.** Text receipts gain an
+  `≈ context thrash: N compactions in M turns` waste line and one methodology sentence.
+  `--handoff` gains a static suggestion to clear or split context at task boundaries.
+  `--json` emits a waste row with `kind: "context-thrash"`, `compactionCount`,
+  `turnSpan`, `turnIndices`, prompt-side `tokens`, and `usd: number | null`.
+  `aggregateWaste` emits class `context-thrash` and the R6 non-additive marking when
+  overlaps exist. This spec does not claim any SPEC-0013 standing-rule template "comes
+  free"; that mapping needs its own evidence.
+- **R8 — Eval corpus rows and precision gate.** Add committed fixtures for: a true
+  positive with at least three refill-positive tight compactions; a near-compact
+  negative where prompt-side tokens do not refill; a far-apart compaction negative; an
+  after-final-turn compaction negative; and an unpriced thrash fixture. Existing clean
+  fixtures plus the pre-labeled maintainer clean corpus from the kill criterion must
+  stay clean with 0 false positives.
 
 ## Scenarios
 
-- **Given** a session with 3 compactions each ≤25 turns apart, **when** the receipt
-  renders, **then** one `≈ context thrash` line appears with the windowed cost.
-- **Given** a 2000-turn session with 2 compactions 400 turns apart, **when** it
-  renders, **then** no thrash line (normal long-session compaction).
-- **Given** a thrashy but unpriced session, **when** it renders, **then** the line
-  shows tokens only, zero `$` (I2).
-- **Given** a Codex/Cursor session (no compaction signal), **when** it renders,
-  **then** the detector never fires (R1 empty array).
+- **Given** three compact records with gaps `<=25` and prompt-side refill to at least
+  80% of the pre-compact peak within five turns, **when** the receipt renders, **then**
+  one `≈ context thrash` line appears with the unioned prompt-side cost.
+- **Given** two compact records within 25 turns but prompt-side tokens stay far below
+  the prior peak, **when** the receipt renders, **then** no thrash line appears.
+- **Given** a 2000-turn session with compact records 400 turns apart, **when** it
+  renders, **then** no thrash line appears.
+- **Given** a compact record after the final assistant turn, **when** extraction runs,
+  **then** the event is retained but the detector does not fire.
+- **Given** overlapping post-compact slices, **when** cost is computed, **then** each
+  turn contributes once to context-thrash tokens/USD.
+- **Given** a thrashy but unpriced session, **when** it renders, **then** the line shows
+  tokens only and `usd: null`.
+- **Given** a Codex/Cursor session with no compact signal, **when** the detector runs,
+  **then** it never fires.
 
 ## Non-goals
 
-Preventing thrash (a reporting tool, I1); inferring compactions where the format
-records none; per-agent-vendor thrash comparisons (I6); tuning T/K per user (constants
-until the FP log demands otherwise).
+Preventing thrash (this is a reporting tool, I1); inferring compactions where the raw
+format records none; per-agent-vendor thrash comparisons (I6); user-configurable
+thresholds before the FP log demands them; SPEC-0013 standing-rule recurrence.
 
 ## Test matrix
 
 | Case | Input | Expected |
 |---|---|---|
-| R1 extraction | fixture w/ compact records | compactions[] indices/timestamps correct |
-| R1 no signal | codex/cursor fixtures | empty array, detector inert |
-| R2 fires | 3 compactions, gaps ≤25 | one thrash line, correct window |
-| R2 negative | 2 compactions, gap 400 | no line |
-| R3 pricing | priced thrash fixture | window cost = K-turn post-compaction input tokens priced |
-| R3 unpriced | unpriced thrash fixture | tokens-only line, zero `$` bytes |
-| R4 surfaces | thrash fixture | receipt + handoff + --json + aggregateWaste all carry it |
-| R5 precision | full eval corpus | precision 1.0 holds (clean fixtures unaffected) |
+| R1 raw `isMeta` compact | Claude fixture compact summary record | compaction extracted before meta filtering |
+| R1 compact boundary shapes | `isCompactSummary` + `compact_boundary` fixtures | compactions extracted |
+| R1 command echo alone | `<command-name>compact</command-name>` without adjacent compact summary | no compaction |
+| R2 turn index | compact between assistant turns | `turnIndex` is next assistant turn |
+| R2 final compact | compact after last assistant turn | retained, detector-ineligible |
+| R3 refill fires | 3 refill-positive compactions, gaps `<=25` | one thrash line |
+| R3 proximity negative | tight compactions, no prompt-side refill | no line |
+| R3 far negative | 2 compactions, gap 400 | no line |
+| R3 boundaries | gaps 25/26, ratio 0.80/0.799, K turn edge | included/excluded exactly as specified |
+| R4 threshold evidence | implementation PR corpus table | named data justifies or changes `T`, `K`, and `REFILL_RATIO` |
+| R5 pricing | priced thrash fixture with cache tiers | prompt-only sliced `TokenUsage` priced with cache tiers preserved |
+| R5 unpriced | one contributing turn lacks cited price row | tokens-only line, `usd: null` |
+| R5 overlap | overlapping K-turn slices | unioned tokens/USD, no double-count |
+| R6 cross-class overlap | same turn also stuck-loop/trivial-spans | aggregate marked non-additive |
+| R7 receipt | thrash fixture | text line + methodology sentence |
+| R7 handoff | thrash fixture | static clear/split-context suggestion |
+| R7 JSON | thrash fixture | exact `context-thrash` key shape |
+| R7 aggregate | session set with thrash | `aggregateWaste` includes `context-thrash` row |
+| R8 precision | committed clean fixtures + labeled clean corpus `N>=20` | 0 false positives |
 
 ## Success criteria
 
-- [ ] A real thrash catch from the maintainer's own sessions attached to the PR (we
-      have known-thrashy sessions from today's builder failures — the dogfood writes
-      itself), or documented absence.
-- [ ] Unmasked gate + spec-lint green; goldens updated intentionally (new waste line).
+- [ ] Threshold justification table attached to the implementation PR, naming the
+      fixtures/dogfood corpus and showing why `T`, `K`, and `REFILL_RATIO` pass boundary
+      tests without false positives.
+- [ ] 0 false positives on all committed clean fixtures and a pre-labeled maintainer
+      clean corpus of at least 20 sessions.
+- [ ] A real thrash catch from maintainer sessions attached to the PR, or documented
+      absence with the detector still passing the precision gate.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, and `node scripts/spec-lint.mjs` all pass
+      unmasked (`echo $?`).
 
 ## Validation
 
-*(pending /validate-spec)*
+**2026-07-02 · S2 (Codex): REWORK → draft reworked.** Applied all 8 critic findings:
+raw compact shapes are named and extracted before filters; `turnIndex`/`atMs` and
+after-final behavior are defined; thrash now requires measured prompt-side refill;
+thresholds are provisional and corpus-bound; pricing uses prompt-only sliced
+`TokenUsage` with cache tiers and `usd: null` unless fully cited; same-class windows
+union turn indices and cross-class overlaps mark aggregates non-additive; output-surface
+matrix rows are split and the SPEC-0013 "comes free" claim is removed; precision is now
+0 false positives on committed clean fixtures plus a pre-labeled `N>=20` clean corpus.
+Status remains draft pending maintainer approval.

--- a/specs/SPEC-0018-cli-command-registry.md
+++ b/specs/SPEC-0018-cli-command-registry.md
@@ -8,68 +8,136 @@ depends: [SPEC-0001]
 
 # SPEC-0018 · CLI command registry
 
-Invariants: I1 (pure refactor — behavior byte-identical, goldens must not change), I5.
+Invariants: I1 (pure refactor — behavior byte-identical, no runtime network), I4
+(local-first CLI), I5 (goldens/help bytes are contracts).
 
 ## Purpose
 
-Today every new command or flag edits the same two files: `src/cli/args.ts` (one
-growing `ParsedArgs` union + one flag loop + one return-shape per command) and
-`src/cli/index.ts` (one growing HELP string + one growing dispatch switch). During the
-2026-07-02 parallel build wave, **every pair of concurrently-built specs conflicted in
-exactly these two files, and every merge re-conflicted every open PR** — hours of lead
-time spent on mechanical rebases. In an agents-build-in-parallel repo, shared-file
-growth is an architecture bug, not an inconvenience. **Kill criterion:** after this
-lands, two specs each adding a command must produce zero overlapping-file edits (proved
-by the R4 test).
+Today every new command or flag edits `src/cli/args.ts` and `src/cli/index.ts`, so
+parallel specs collide in the same parser, help string, and dispatch switch. This spec
+turns commands into package-local modules discovered deterministically, with shared
+parsing and lifecycle seams explicit enough that adding a command edits its own file and
+tests, not a central funnel. **Kill criterion:** after this lands, two branches that
+each add one command merge conflict-free and have zero overlapping production files.
 
 ## Requirements
 
-- **R1 — Self-contained command modules.** Each command lives in
-  `src/cli/commands/<name>.ts` exporting a `CommandDef`: `{ name, flags[], helpLines,
-  parse(own-args) → own typed options, run(options) → exit code }`. Adding a command =
-  adding ONE file + ONE line in `src/cli/commands/registry.ts` (a sorted import list —
-  the only shared touchpoint, one line per command, order-insensitive).
-- **R2 — Generic arg parser.** `args.ts` shrinks to a generic tokenizer that consults
-  the registry's flag declarations; the per-command option types live in the command's
-  own module (no global `ParsedArgs` union).
-- **R3 — Help is assembled.** `--help` output is generated from each module's
-  `helpLines` in registry order — byte-identical to today's help text (golden-tested).
-- **R4 — Parallel-safety proof.** A test adds two synthetic commands via two synthetic
-  modules and asserts registration works with no edits outside their own files +
-  their registry lines. This is the spec's reason to exist, tested.
-- **R5 — Migration completeness.** All existing commands (receipt, list, compare,
-  handoff, week, quota, statusline, mini, install/uninstall-hook, telemetry-show,
-  methodology, help) migrate; `main()` keeps its telemetry lifecycle wrapper; every
-  existing CLI test passes unchanged (contract preserved).
+- **R1 — Self-contained command modules with no shared registry edit.** Each command
+  lives in `src/cli/commands/<name>.ts` and exports one `CommandDef`. The command set is
+  discovered deterministically from package-local command modules in sorted filename
+  order; there is no committed `registry.ts` import list and no generated registry file
+  that feature branches edit. If the current `tsup` bundle cannot preserve that module
+  discovery in the published package, the implementation must change the CLI build
+  shape so discovery still works from installed package files, without reintroducing a
+  shared source-file touchpoint.
+- **R2 — Parser models current command selection, not just `flags[]`.** The registry
+  metadata must represent command-selecting flags (`--help`, `--methodology`,
+  `--telemetry-show`, `--check-budget`, `--quota`, `--mini`, `--list`, `--handoff`),
+  positional subcommands (`compare`, `benchmark`, `install-hook`, `uninstall-hook`,
+  `statusline`, `templates`, `week`, `pr`), and the default receipt selector. Selection
+  precedence remains byte-for-byte compatible with today's `parseArgs`: help before
+  hidden info commands, then budget/quota selectors, then positional subcommands, then
+  list/handoff/default receipt. Shared output-mode flag groups (`--json`,
+  `--csv[=session|tool]`, `--svg`, `--png`, `--theme`, `-o/--output`, `--template`) and
+  scoped options (`--since`, `--by-project`, `--handoff-threshold`, `--dry-run`,
+  `--post`, `--session`) remain accepted or ignored by the same commands as today; this
+  refactor does not add new incompatibility errors.
+- **R3 — Command modules run through an explicit context.** `CommandDef.run` receives a
+  `CommandContext` rather than reaching through globals by default:
+  `{ stdin, stdout, stderr, env, cwd, now, fs, prompt, telemetry }`, with the minimal
+  methods needed by current commands. `quota` keeps injectable stdin, hook install
+  keeps injectable prompt/filesystem seams, and commands stay unit-testable without
+  mutating process globals.
+- **R4 — Help assembly is byte-safe.** Help metadata includes `helpOrder`, `section`,
+  `hidden`, and literal `helpLines`. The current curated help layout, output-mode
+  footer, and hidden-but-parseable `telemetry-show`/`methodology` commands are preserved.
+  Add a pre-refactor `goldens/cli/help.txt`; post-refactor `aireceipts --help` must be
+  byte-identical to it.
+- **R5 — Parallel-safety proof uses git, not synthetic assertions.** Add a temp
+  git-worktree test that starts from the same baseline, creates branch A adding
+  `src/cli/commands/a.ts`, creates branch B adding `src/cli/commands/b.ts`, merges both,
+  and asserts no conflict plus the exact promised changed-file set: the two new command
+  files and their tests only, no `args.ts`, `index.ts`, registry, generated registry, or
+  central help file.
+- **R6 — Telemetry lifecycle remains one wrapper.** Parsing, command selection, command
+  execution, telemetry recording, first-run notice, and bounded flush remain owned by
+  `main()`. Lifecycle tests cover parse failure, command throw, command nonzero exit,
+  command success, and `telemetry-show`: exactly one run/error event as appropriate,
+  first-run notice skipped only for `telemetry-show`, and `flushTelemetry()` always
+  awaited.
+- **R7 — Shared helpers are allowed under common ownership.** Commands may import
+  shared CLI helpers from explicit common modules such as `src/cli/common/*` or existing
+  domain modules. The rule is not "commands never import helpers"; the rule is that a
+  new command must not edit another command's owned module or a central funnel.
+- **R8 — Preservation coverage exists before the refactor lands.** Snapshot the current
+  command inventory and add pre-refactor CLI coverage for parse precedence, help bytes,
+  stdout/stderr/exit behavior, SVG/PNG/JSON/CSV modes, compare error cases, no-session
+  cases, quota stdin, hook prompt seams, statusline stdin fallback, hidden commands, and
+  accepted-but-ignored output flags. Renderer/SVG goldens alone are not enough proof for
+  this refactor.
 
 ## Scenarios
 
-- **Given** two new sibling specs each adding a command, **when** both branches merge,
-  **then** git reports no conflicting files (registry lines merge cleanly — different
-  lines).
-- **Given** the migration, **when** goldens + CLI tests run, **then** all byte-identical
-  / green with zero test edits.
+- **Given** two sibling specs each adding a command module, **when** both branches merge
+  into the baseline, **then** git reports no conflicts and no overlapping production
+  file edits.
+- **Given** `aireceipts --help`, **when** help is assembled from modules, **then** the
+  bytes match `goldens/cli/help.txt` exactly and hidden commands stay hidden.
+- **Given** `aireceipts compare a b --svg -o compare.svg`, **when** parsing runs through
+  registry metadata, **then** command selection and output-mode options match today's
+  `parseArgs` result.
+- **Given** `aireceipts --telemetry-show`, **when** `main()` runs, **then** no first-run
+  notice is printed, no telemetry is sent, and the payload is printed as today.
+- **Given** a command throws, returns 1, or succeeds, **when** `main()` exits, **then**
+  telemetry is recorded/flushed exactly as the current lifecycle contract requires.
 
 ## Non-goals
 
-New CLI behavior of any kind; plugin loading from outside the package (the registry is
-static, I1); changing flag spellings.
+New CLI behavior of any kind; plugin loading from outside the package; runtime network
+discovery; changing flag spellings; banning shared helpers; changing telemetry payload
+schema; changing receipt/compare/rendering output.
 
 ## Test matrix
 
 | Case | Input | Expected |
 |---|---|---|
-| R1 module shape | each migrated command | exports CommandDef, no imports from other commands |
-| R2 parser | existing CLI test suite | passes unchanged |
-| R3 help | --help | byte-identical to pre-refactor golden |
-| R4 parallel proof | two synthetic command modules | both registered, zero shared-file edits beyond one registry line each |
-| R5 goldens | full corpus | byte-identical |
+| R1 discovery | installed-package command directory | deterministic sorted command set |
+| R1 no shared file | branch adds one command | production diff excludes parser/dispatcher/registry funnels |
+| R2 selectors | all command-selecting flags + subcommands | same selected command as pre-refactor |
+| R2 precedence | conflicting selectors such as `--help --quota compare a b` | same precedence as current parser |
+| R2 shared flags | `--svg`, `--png`, `--theme`, `-o`, `--json`, `--csv`, `--template` | same accept/ignore/error behavior by command |
+| R3 context | quota stdin, hook prompt/fs, statusline stdin | injectable seams, no process-global-only tests |
+| R4 help bytes | `--help` | byte-identical to `goldens/cli/help.txt` |
+| R4 hidden commands | `--telemetry-show`, `--methodology` | parseable but absent from help |
+| R5 git proof | two temp branches adding commands | conflict-free merge, exact changed-file set |
+| R6 parse failure | malformed argv | error recorded, flush awaited |
+| R6 command throw | test command throws | error recorded once, stderr written, flush awaited |
+| R6 nonzero/success | commands return 1 / 0 | run recorded once with `ok` false/true |
+| R6 telemetry-show | `--telemetry-show` | first-run notice skipped, payload printed, no send |
+| R7 helpers | command imports common helper | allowed |
+| R7 cross-command edit | command edits sibling command module | test/review gate rejects |
+| R8 preservation | CLI coverage suite | stdout/stderr/exit/goldens unchanged |
 
 ## Success criteria
 
-- [ ] `git log --stat` for the two specs merged after this shows no overlapping files.
-- [ ] Unmasked gate green; goldens byte-identical (I1 refactor proof).
+- [ ] Pre-refactor CLI snapshots and tests from R8 are committed before the registry
+      migration diff, so behavior drift is visible.
+- [ ] The R5 temp git-worktree test proves two independently added commands merge with
+      zero overlapping production files.
+- [ ] `git log --stat` for the first two command-adding specs after this shows no
+      overlapping production files.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, and `node scripts/spec-lint.mjs` all pass
+      unmasked (`echo $?`), with receipt/help bytes intentionally unchanged.
 
 ## Validation
 
-*(pending /validate-spec)*
+**2026-07-02 · S2 (Codex): REWORK → draft reworked.** Applied all 8 critic findings:
+removed the shared registry touchpoint via deterministic package-local discovery;
+modeled selector flags, positional subcommands, shared output flags, precedence, and
+accepted-but-ignored compatibility; added `CommandContext`; made help assembly
+byte-safe with order/section/hidden metadata and a help golden; replaced the synthetic
+parallel proof with a temp git-worktree merge test; required telemetry lifecycle tests
+for parse failure, throws, nonzero exits, success, and `telemetry-show`; allowed shared
+helpers while forbidding cross-command ownership edits; and required pre-refactor CLI
+coverage beyond renderer goldens. Status remains draft pending maintainer approval.


### PR DESCRIPTION
## What this adds
The two stalled drafts, reworked per their stored independent-critic verdicts and ready for maintainer approval:
- SPEC-0017 (context-thrash waste): thrash now requires a measured context-REFILL signal (prompt-side tokens returning near pre-compact peak), never compaction proximity alone; exact anchor/turnIndex definitions; sliced cache-tier pricing, null unless cited; non-double-counting union windows; measurable kill criterion.
- SPEC-0018 (CLI command registry): all verdict findings applied — the merge-funnel killer, sized for the next build wave.

## What to review
Both Validation sections (verdict → rework recorded); both stay status: draft — your approval flips them.

## Evidence
spec-lint 22 OK · hygiene OK (docs-only change; code gates N/A). Reworked by Codex offline; published by lead (sandbox had no network).