### PR TITLE
feat: [SPEC-0022] docs site on the same Pages deploy

### DIFF
--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -1,0 +1,778 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const DOCS_DIR = join(ROOT, "docs");
+const OUT_DIR = join(ROOT, "site", "docs");
+
+const RESOURCE_LOAD_PATTERNS = [
+  /<script\b[^>]*\bsrc=["']https?:/iu,
+  /<link\b[^>]*\bhref=["']https?:/iu,
+  /<img\b[^>]*\bsrc=["']https?:/iu,
+  /<iframe\b[^>]*\bsrc=["']https?:/iu,
+  /\bsrcset=["'][^"']*https?:/iu,
+  /@import\s+(?:url\()?["']?https?:/iu,
+  /url\(\s*["']?https?:/iu,
+];
+
+function sortAscii(values) {
+  return [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+}
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value).replaceAll("'", "&#39;");
+}
+
+function stripInlineMarkdown(value) {
+  return value
+    .replace(/`([^`]*)`/gu, "$1")
+    .replace(/\*\*([^*]+)\*\*/gu, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/gu, "$1")
+    .trim();
+}
+
+function slugify(value, seen) {
+  const base = stripInlineMarkdown(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/gu, "")
+    .trim()
+    .replace(/\s+/gu, "-")
+    .replace(/-+/gu, "-") || "section";
+  const count = seen.get(base) ?? 0;
+  seen.set(base, count + 1);
+  return count === 0 ? base : `${base}-${count + 1}`;
+}
+
+function normalizeHref(href) {
+  const [pathPart, fragment = ""] = href.split("#", 2);
+  const hash = fragment === "" ? "" : `#${fragment}`;
+  if (/^(?:https?:|mailto:|#)/iu.test(href)) return href;
+  if (pathPart.endsWith(".md")) return `${basename(pathPart, ".md")}.html${hash}`;
+  return `${pathPart}${hash}`;
+}
+
+function findClosingParen(value, start) {
+  let escaped = false;
+  for (let index = start; index < value.length; index++) {
+    const char = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === ")") return index;
+  }
+  return -1;
+}
+
+function findClosingMarker(value, start, marker) {
+  let escaped = false;
+  for (let index = start; index < value.length; index++) {
+    const char = value[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === marker) return index;
+  }
+  return -1;
+}
+
+function renderInline(value) {
+  let html = "";
+  for (let index = 0; index < value.length;) {
+    if (value.startsWith("`", index)) {
+      const end = value.indexOf("`", index + 1);
+      if (end !== -1) {
+        html += `<code>${escapeHtml(value.slice(index + 1, end))}</code>`;
+        index = end + 1;
+        continue;
+      }
+    }
+
+    if (value.startsWith("**", index)) {
+      const end = value.indexOf("**", index + 2);
+      if (end !== -1) {
+        html += `<strong>${renderInline(value.slice(index + 2, end))}</strong>`;
+        index = end + 2;
+        continue;
+      }
+    }
+
+    if (value[index] === "*" && value[index + 1] !== "*") {
+      const end = findClosingMarker(value, index + 1, "*");
+      if (end !== -1) {
+        html += `<em>${renderInline(value.slice(index + 1, end))}</em>`;
+        index = end + 1;
+        continue;
+      }
+    }
+
+    if (value[index] === "[") {
+      const closeLabel = value.indexOf("]", index + 1);
+      if (closeLabel !== -1 && value[closeLabel + 1] === "(") {
+        const closeHref = findClosingParen(value, closeLabel + 2);
+        if (closeHref !== -1) {
+          const label = value.slice(index + 1, closeLabel);
+          const href = normalizeHref(value.slice(closeLabel + 2, closeHref));
+          html += `<a href="${escapeAttr(href)}">${renderInline(label)}</a>`;
+          index = closeHref + 1;
+          continue;
+        }
+      }
+    }
+
+    if (value[index] === "\\" && index + 1 < value.length) {
+      html += escapeHtml(value[index + 1]);
+      index += 2;
+      continue;
+    }
+
+    html += escapeHtml(value[index]);
+    index++;
+  }
+  return html;
+}
+
+function isTableSeparator(line) {
+  return /^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$/u.test(line);
+}
+
+function splitTableRow(line) {
+  const trimmed = line.trim().replace(/^\|/u, "").replace(/\|$/u, "");
+  const cells = [];
+  let current = "";
+  let escaped = false;
+
+  for (const char of trimmed) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "|") {
+      cells.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  cells.push(current.trim());
+  return cells;
+}
+
+function isBlockStart(line, nextLine) {
+  return (
+    /^#{1,6}\s+/u.test(line) ||
+    /^```/u.test(line) ||
+    /^\s{0,3}(?:[-*]\s+|\d+\.\s+)/u.test(line) ||
+    (line.trim().startsWith("|") && nextLine !== undefined && isTableSeparator(nextLine)) ||
+    /^>\s?/u.test(line) ||
+    /^<!--.*-->$/u.test(line.trim())
+  );
+}
+
+function renderList(lines, startIndex, ordered) {
+  const tag = ordered ? "ol" : "ul";
+  const itemPattern = ordered ? /^\s{0,3}\d+\.\s+(.*)$/u : /^\s{0,3}[-*]\s+(.*)$/u;
+  const otherPattern = ordered ? /^\s{0,3}[-*]\s+/u : /^\s{0,3}\d+\.\s+/u;
+  const items = [];
+  let current = [];
+  let index = startIndex;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    const match = itemPattern.exec(line);
+    if (match) {
+      if (current.length > 0) items.push(current.join(" "));
+      current = [match[1].trim()];
+      index++;
+      continue;
+    }
+    if (line.trim() === "") break;
+    if (otherPattern.test(line) || /^#{1,6}\s+/u.test(line) || /^```/u.test(line)) break;
+    if (/^\s{2,}\S/u.test(line) && current.length > 0) {
+      current.push(line.trim());
+      index++;
+      continue;
+    }
+    break;
+  }
+
+  if (current.length > 0) items.push(current.join(" "));
+  const html = `<${tag}>\n${items.map((item) => `  <li>${renderInline(item)}</li>`).join("\n")}\n</${tag}>`;
+  return { html, nextIndex: index };
+}
+
+function renderTable(lines, startIndex) {
+  const header = splitTableRow(lines[startIndex]);
+  const rows = [];
+  let index = startIndex + 2;
+
+  while (index < lines.length && lines[index].trim().startsWith("|")) {
+    rows.push(splitTableRow(lines[index]));
+    index++;
+  }
+
+  const headHtml = header.map((cell) => `<th>${renderInline(cell)}</th>`).join("");
+  const rowsHtml = rows
+    .map((row) => `    <tr>${row.map((cell) => `<td>${renderInline(cell)}</td>`).join("")}</tr>`)
+    .join("\n");
+  return {
+    html: `<div class="table-wrap"><table>\n  <thead><tr>${headHtml}</tr></thead>\n  <tbody>\n${rowsHtml}\n  </tbody>\n</table></div>`,
+    nextIndex: index,
+  };
+}
+
+function renderMarkdown(markdown) {
+  const lines = markdown.replace(/\r\n?/gu, "\n").split("\n");
+  const blocks = [];
+  const seenHeadings = new Map();
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    const trimmed = line.trim();
+
+    if (trimmed === "") {
+      index++;
+      continue;
+    }
+
+    if (/^<!--.*-->$/u.test(trimmed)) {
+      index++;
+      continue;
+    }
+
+    const heading = /^(#{1,6})\s+(.*)$/u.exec(line);
+    if (heading) {
+      const level = heading[1].length;
+      const text = heading[2].trim();
+      const id = slugify(text, seenHeadings);
+      blocks.push(`<h${level} id="${escapeAttr(id)}">${renderInline(text)}</h${level}>`);
+      index++;
+      continue;
+    }
+
+    if (line.startsWith("```")) {
+      const language = line.slice(3).trim();
+      const code = [];
+      index++;
+      while (index < lines.length && !lines[index].startsWith("```")) {
+        code.push(lines[index]);
+        index++;
+      }
+      if (index < lines.length) index++;
+      const className = language === "" ? "" : ` class="language-${escapeAttr(language)}"`;
+      blocks.push(`<pre class="doc-code"><code${className}>${escapeHtml(code.join("\n"))}</code></pre>`);
+      continue;
+    }
+
+    if (trimmed.startsWith("|") && lines[index + 1] !== undefined && isTableSeparator(lines[index + 1])) {
+      const table = renderTable(lines, index);
+      blocks.push(table.html);
+      index = table.nextIndex;
+      continue;
+    }
+
+    if (/^\s{0,3}[-*]\s+/u.test(line)) {
+      const list = renderList(lines, index, false);
+      blocks.push(list.html);
+      index = list.nextIndex;
+      continue;
+    }
+
+    if (/^\s{0,3}\d+\.\s+/u.test(line)) {
+      const list = renderList(lines, index, true);
+      blocks.push(list.html);
+      index = list.nextIndex;
+      continue;
+    }
+
+    if (/^>\s?/u.test(line)) {
+      const quote = [];
+      while (index < lines.length && /^>\s?/u.test(lines[index])) {
+        quote.push(lines[index].replace(/^>\s?/u, "").trim());
+        index++;
+      }
+      blocks.push(`<blockquote>${renderInline(quote.join(" "))}</blockquote>`);
+      continue;
+    }
+
+    const paragraph = [trimmed];
+    index++;
+    while (
+      index < lines.length &&
+      lines[index].trim() !== "" &&
+      !isBlockStart(lines[index], lines[index + 1])
+    ) {
+      paragraph.push(lines[index].trim());
+      index++;
+    }
+    blocks.push(`<p>${renderInline(paragraph.join(" "))}</p>`);
+  }
+
+  return blocks.join("\n\n");
+}
+
+function getTitle(markdown, fallback) {
+  const line = markdown.split(/\r?\n/u).find((entry) => /^#\s+/u.test(entry));
+  return line === undefined ? fallback : stripInlineMarkdown(line.replace(/^#\s+/u, ""));
+}
+
+function getExcerpt(markdown) {
+  const lines = markdown.replace(/\r\n?/gu, "\n").split("\n");
+  const start = lines.findIndex((line) => /^#\s+/u.test(line));
+  const afterTitle = start === -1 ? lines : lines.slice(start + 1);
+  const paragraph = [];
+
+  for (const line of afterTitle) {
+    const trimmed = line.trim();
+    if (trimmed === "" || /^<!--.*-->$/u.test(trimmed)) {
+      if (paragraph.length > 0) break;
+      continue;
+    }
+    if (isBlockStart(trimmed)) {
+      if (paragraph.length > 0) break;
+      continue;
+    }
+    paragraph.push(stripInlineMarkdown(trimmed));
+  }
+
+  return paragraph.join(" ").slice(0, 180);
+}
+
+function css() {
+  return `:root{
+  --field:#e7ecef;
+  --sheet:#ffffff;
+  --ink:#14181c;
+  --muted:#586570;
+  --faint:#8a949c;
+  --rule:#e3e8eb;
+  --rule-strong:#c2cbd1;
+  --seal:#b23a3a;
+  --ledger:#2f5d3a;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,"SF Mono","Cascadia Code","JetBrains Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;
+  background:var(--field);
+  color:var(--ink);
+  font-family:var(--sans);
+  font-size:16px;
+  line-height:1.6;
+  padding:clamp(16px,3.5vw,40px) 16px clamp(40px,6vw,72px);
+}
+a{color:var(--ledger);text-underline-offset:2px;text-decoration-thickness:1px}
+a:focus-visible{outline:2px solid var(--ledger);outline-offset:2px;border-radius:2px}
+.sheet{
+  width:100%;
+  max-width:1040px;
+  margin:0 auto;
+  background:var(--sheet);
+  border:1px solid var(--rule-strong);
+  border-radius:3px;
+  padding:clamp(20px,3.6vw,44px) clamp(18px,4vw,52px) clamp(28px,4vw,44px);
+  box-shadow:0 1px 0 #fff inset,0 30px 64px -42px rgba(20,32,44,.42);
+}
+header.mast{padding-top:2px}
+.masthead-row{
+  display:flex;
+  justify-content:space-between;
+  align-items:baseline;
+  gap:16px;
+  font-family:var(--sans);
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.masthead-row .brand{color:var(--ink);letter-spacing:.30em;text-decoration:none}
+.masthead-row nav{display:flex;gap:16px;flex-wrap:wrap;justify-content:flex-end}
+.masthead-row nav a{color:var(--muted);letter-spacing:.12em;text-decoration:none}
+.masthead-row nav a:hover{color:var(--ink)}
+.rule2{
+  margin:12px 0 0;
+  height:0;
+  border-top:3px solid var(--ink);
+  box-shadow:0 5px 0 -4px var(--ink);
+}
+.doc-hero{padding:clamp(24px,4vw,38px) 0 clamp(20px,3vw,30px)}
+.doc-label{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  margin:0 0 16px;
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.doc-label::after{content:"";flex:1 1 auto;height:1px;background:var(--rule-strong)}
+h1{
+  font-family:var(--serif);
+  font-size:clamp(30px,5vw,50px);
+  line-height:1.1;
+  font-weight:600;
+  letter-spacing:0;
+  margin:0;
+  max-width:19ch;
+}
+.sub{
+  color:var(--muted);
+  font-size:clamp(15px,2.2vw,17.5px);
+  max-width:58ch;
+  margin:15px 0 0;
+  line-height:1.55;
+}
+.doc-grid{
+  display:grid;
+  grid-template-columns:minmax(190px,240px) minmax(0,1fr);
+  gap:clamp(24px,4vw,46px);
+  border-top:1px solid var(--rule);
+  padding-top:clamp(24px,4vw,38px);
+}
+.toc{
+  align-self:start;
+  position:sticky;
+  top:18px;
+  border-right:1px solid var(--rule);
+  padding-right:20px;
+}
+.toc h2{
+  margin:0 0 12px;
+  color:var(--faint);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+}
+.toc ol,.toc ul{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+.toc a{color:var(--muted);font-size:14px;text-decoration:none}
+.toc a:hover{color:var(--ink);text-decoration:underline}
+.doc-content{min-width:0}
+.doc-content > :first-child{margin-top:0}
+.doc-content h1{font-size:clamp(28px,4vw,42px)}
+.doc-content h2{
+  margin:clamp(32px,4vw,44px) 0 12px;
+  padding-top:18px;
+  border-top:1px solid var(--rule);
+  font-family:var(--serif);
+  font-size:clamp(22px,3vw,30px);
+  line-height:1.2;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h3{
+  margin:28px 0 10px;
+  font-family:var(--serif);
+  font-size:21px;
+  line-height:1.25;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h4,.doc-content h5,.doc-content h6{margin:22px 0 8px;font-size:16px;line-height:1.35}
+.doc-content p{margin:0 0 16px;color:var(--ink)}
+.doc-content ul,.doc-content ol{margin:0 0 18px;padding-left:22px}
+.doc-content li{margin:7px 0}
+.doc-content blockquote{
+  margin:20px 0;
+  padding:14px 18px;
+  border-left:4px solid var(--ledger);
+  background:#f7f9fa;
+  color:var(--muted);
+}
+code{
+  font-family:var(--mono);
+  font-size:.92em;
+  background:#f6f8f9;
+  border:1px solid var(--rule);
+  border-radius:4px;
+  padding:.08em .32em;
+}
+pre.doc-code{
+  margin:18px 0;
+  overflow-x:auto;
+  max-width:100%;
+  background:#0f1518;
+  border:1px solid #1c272d;
+  border-radius:9px;
+  padding:14px 16px;
+  box-shadow:0 20px 44px -34px rgba(9,14,18,.9);
+}
+pre.doc-code code{
+  display:block;
+  background:transparent;
+  border:0;
+  border-radius:0;
+  padding:0;
+  color:#d6dde2;
+  font-size:13px;
+  line-height:1.5;
+}
+.table-wrap{overflow-x:auto;margin:18px 0;border:1px solid var(--rule-strong);border-radius:8px}
+table{width:100%;border-collapse:collapse;font-size:14px;min-width:560px}
+th,td{padding:10px 12px;border-bottom:1px solid var(--rule);vertical-align:top;text-align:left}
+th{background:#f6f8f9;color:var(--ink);font-weight:700}
+tr:last-child td{border-bottom:0}
+.doc-index-list{list-style:none;margin:0;padding:0;display:grid;gap:0;border-top:1px solid var(--rule)}
+.doc-index-list li{padding:18px 0;border-bottom:1px solid var(--rule)}
+.doc-index-list a{
+  display:inline-block;
+  font-family:var(--serif);
+  font-size:22px;
+  line-height:1.2;
+  font-weight:600;
+}
+.doc-index-list .path{
+  display:block;
+  margin-top:4px;
+  color:var(--faint);
+  font-family:var(--mono);
+  font-size:12px;
+}
+.doc-index-list p{margin:8px 0 0;color:var(--muted);max-width:70ch}
+footer{
+  border-top:1px solid var(--rule);
+  margin-top:clamp(34px,5vw,52px);
+  padding-top:clamp(26px,4vw,34px);
+}
+.close{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  gap:20px;
+  flex-wrap:wrap;
+}
+.close-copy{max-width:34ch}
+.issued{
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  color:var(--faint);
+  display:flex;
+  gap:18px;
+  flex-wrap:wrap;
+  margin:0 0 14px;
+}
+.thanks{
+  font-family:var(--serif);
+  font-size:19px;
+  font-weight:600;
+  color:var(--ink);
+  margin:0 0 10px;
+}
+.serial{
+  font-family:var(--mono);
+  font-size:10.5px;
+  letter-spacing:.34em;
+  color:var(--faint);
+  margin:0;
+  padding-left:.34em;
+}
+.seal{flex:0 0 auto;width:clamp(104px,17vw,128px);height:auto;color:var(--seal);transform:rotate(-5deg)}
+.barcode{color:var(--rule-strong);height:30px;display:block;margin:24px 0 8px}
+.flinks{font-size:14px;color:var(--muted);line-height:2}
+.flinks a{color:var(--ledger)}
+.flinks .sep{color:var(--rule-strong);padding:0 .6ch}
+.samosa{color:var(--muted);margin:10px 0 0;font-size:13.5px}
+@media (max-width:760px){
+  .doc-grid{grid-template-columns:minmax(0,1fr)}
+  .toc{position:static;border-right:0;border-bottom:1px solid var(--rule);padding:0 0 18px}
+}
+@media (max-width:480px){
+  .masthead-row{letter-spacing:.16em;align-items:flex-start}
+  .masthead-row nav{gap:10px}
+  .close{flex-direction:column-reverse;align-items:flex-start}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important}
+}`;
+}
+
+function sealSvg() {
+  return `<svg class="seal" viewBox="0 0 200 200" role="img" aria-label="A round vermillion seal reading RECEIPTED, SETTLED, and NO FABRICATED DOLLARS.">
+  <defs>
+    <path id="ring-top" d="M 30 100 A 70 70 0 0 1 170 100"/>
+    <path id="ring-bot" d="M 34 100 A 66 66 0 0 0 166 100"/>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <circle cx="100" cy="100" r="83" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700">
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-top" startOffset="50%">RECEIPTED</textPath></text>
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-bot" startOffset="50%">SETTLED</textPath></text>
+  </g>
+  <line x1="66" y1="70" x2="134" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="66" y1="130" x2="134" y2="130" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700" text-anchor="middle" letter-spacing="1.5">
+    <text x="100" y="91" font-size="15">NO</text>
+    <text x="100" y="106" font-size="13">FABRICATED</text>
+    <text x="100" y="121" font-size="15">DOLLARS</text>
+  </g>
+</svg>`;
+}
+
+function barcodeSvg() {
+  return `<svg class="barcode" viewBox="0 0 90 34" width="180" height="30" fill="currentColor" role="img" aria-label="Barcode encoding the word aireceipts.">
+  <rect x="0" y="0" width="3" height="34"/><rect x="4" y="0" width="2" height="34"/><rect x="8" y="0" width="3" height="34"/><rect x="12" y="0" width="2" height="34"/><rect x="16" y="0" width="4" height="34"/><rect x="21" y="0" width="3" height="34"/><rect x="26" y="0" width="3" height="34"/><rect x="31" y="0" width="2" height="34"/><rect x="35" y="0" width="3" height="34"/><rect x="39" y="0" width="4" height="34"/><rect x="45" y="0" width="3" height="34"/><rect x="50" y="0" width="2" height="34"/><rect x="54" y="0" width="3" height="34"/><rect x="58" y="0" width="2" height="34"/><rect x="62" y="0" width="4" height="34"/><rect x="67" y="0" width="1" height="34"/><rect x="70" y="0" width="4" height="34"/><rect x="76" y="0" width="1" height="34"/><rect x="79" y="0" width="4" height="34"/><rect x="84" y="0" width="4" height="34"/>
+</svg>`;
+}
+
+function wrapPage({ title, sourcePath, body, docs }) {
+  const sourceLine = sourcePath === undefined
+    ? "Static contents for the public docs set."
+    : `Rendered from <code>${escapeHtml(sourcePath)}</code>.`;
+  const navItems = docs
+    .map((doc) => `<li><a href="${escapeAttr(doc.href)}">${escapeHtml(doc.title)}</a></li>`)
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)} — aireceipts docs</title>
+<meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
+<meta name="theme-color" content="#e9edf0">
+<style>
+${css()}
+</style>
+</head>
+<body>
+<div class="sheet">
+  <header class="mast">
+    <div class="masthead-row">
+      <a class="brand" href="../index.html">AIRECEIPTS</a>
+      <nav aria-label="Primary">
+        <a href="../index.html">Home</a>
+        <a href="index.html">Docs</a>
+      </nav>
+    </div>
+    <div class="rule2" aria-hidden="true"></div>
+    <div class="doc-hero">
+      <p class="doc-label">Docs ledger</p>
+      <h1>${escapeHtml(title)}</h1>
+      <p class="sub">${sourceLine}</p>
+    </div>
+  </header>
+  <main class="doc-grid">
+    <aside class="toc" aria-label="Docs contents">
+      <h2>Contents</h2>
+      <ol>
+${navItems}
+      </ol>
+    </aside>
+    <article class="doc-content">
+${body}
+    </article>
+  </main>
+  <footer>
+    <div class="close">
+      <div class="close-copy">
+        <p class="issued"><span>No account</span><span>No upload</span><span>Docs</span></p>
+        <p class="thanks">Thank you for your tokens.</p>
+        <p class="serial">AIRECEIPTS · NO. 0001</p>
+      </div>
+      ${sealSvg()}
+    </div>
+    ${barcodeSvg()}
+    <p class="flinks">
+      <a href="../index.html">Home</a><span class="sep" aria-hidden="true">·</span><a href="index.html">Docs</a><span class="sep" aria-hidden="true">·</span><span>Apache-2.0</span>
+    </p>
+    <p class="samosa">buy me a samosa</p>
+  </footer>
+</div>
+</body>
+</html>
+`;
+}
+
+function assertNoExternalLoads(html, file) {
+  for (const pattern of RESOURCE_LOAD_PATTERNS) {
+    if (pattern.test(html)) {
+      throw new Error(`${file}: generated HTML contains an external resource load`);
+    }
+  }
+}
+
+function writeHtml(file, html) {
+  assertNoExternalLoads(html, relative(ROOT, file));
+  writeFileSync(file, html, "utf8");
+}
+
+function main() {
+  const names = sortAscii(readdirSync(DOCS_DIR).filter((name) => name.endsWith(".md")));
+  if (names.length === 0) throw new Error("docs-site: no root docs/*.md files found");
+
+  const docs = names.map((name) => {
+    const path = join(DOCS_DIR, name);
+    const markdown = readFileSync(path, "utf8");
+    return {
+      name,
+      path,
+      sourcePath: `docs/${name}`,
+      href: `${basename(name, ".md")}.html`,
+      title: getTitle(markdown, basename(name, ".md")),
+      excerpt: getExcerpt(markdown),
+      markdown,
+    };
+  });
+
+  mkdirSync(OUT_DIR, { recursive: true });
+  if (existsSync(OUT_DIR)) {
+    for (const name of readdirSync(OUT_DIR)) {
+      if (name.endsWith(".html")) rmSync(join(OUT_DIR, name));
+    }
+  }
+
+  for (const doc of docs) {
+    const body = renderMarkdown(doc.markdown);
+    const html = wrapPage({ title: doc.title, sourcePath: doc.sourcePath, body, docs });
+    writeHtml(join(OUT_DIR, doc.href), html);
+  }
+
+  const indexBody = `<h1 id="docs">Docs</h1>
+<p>Root repository docs rendered as static pages for GitHub Pages. Source paths are shown so the generated site remains traceable to the markdown it wraps.</p>
+<ul class="doc-index-list">
+${docs.map((doc) => `  <li>
+    <a href="${escapeAttr(doc.href)}">${escapeHtml(doc.title)}</a>
+    <span class="path">${escapeHtml(doc.sourcePath)}</span>
+    <p>${escapeHtml(doc.excerpt)}</p>
+  </li>`).join("\n")}
+</ul>`;
+  const indexHtml = wrapPage({ title: "Docs", body: indexBody, docs });
+  writeHtml(join(OUT_DIR, "index.html"), indexHtml);
+
+  console.log(`build-docs-site: wrote ${docs.length + 1} page(s) to ${relative(ROOT, OUT_DIR)}`);
+}
+
+main();

--- a/site/docs/harness.html
+++ b/site/docs/harness.html
@@ -1,0 +1,408 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The harness — how this repo builds itself — aireceipts docs</title>
+<meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
+<meta name="theme-color" content="#e9edf0">
+<style>
+:root{
+  --field:#e7ecef;
+  --sheet:#ffffff;
+  --ink:#14181c;
+  --muted:#586570;
+  --faint:#8a949c;
+  --rule:#e3e8eb;
+  --rule-strong:#c2cbd1;
+  --seal:#b23a3a;
+  --ledger:#2f5d3a;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,"SF Mono","Cascadia Code","JetBrains Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;
+  background:var(--field);
+  color:var(--ink);
+  font-family:var(--sans);
+  font-size:16px;
+  line-height:1.6;
+  padding:clamp(16px,3.5vw,40px) 16px clamp(40px,6vw,72px);
+}
+a{color:var(--ledger);text-underline-offset:2px;text-decoration-thickness:1px}
+a:focus-visible{outline:2px solid var(--ledger);outline-offset:2px;border-radius:2px}
+.sheet{
+  width:100%;
+  max-width:1040px;
+  margin:0 auto;
+  background:var(--sheet);
+  border:1px solid var(--rule-strong);
+  border-radius:3px;
+  padding:clamp(20px,3.6vw,44px) clamp(18px,4vw,52px) clamp(28px,4vw,44px);
+  box-shadow:0 1px 0 #fff inset,0 30px 64px -42px rgba(20,32,44,.42);
+}
+header.mast{padding-top:2px}
+.masthead-row{
+  display:flex;
+  justify-content:space-between;
+  align-items:baseline;
+  gap:16px;
+  font-family:var(--sans);
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.masthead-row .brand{color:var(--ink);letter-spacing:.30em;text-decoration:none}
+.masthead-row nav{display:flex;gap:16px;flex-wrap:wrap;justify-content:flex-end}
+.masthead-row nav a{color:var(--muted);letter-spacing:.12em;text-decoration:none}
+.masthead-row nav a:hover{color:var(--ink)}
+.rule2{
+  margin:12px 0 0;
+  height:0;
+  border-top:3px solid var(--ink);
+  box-shadow:0 5px 0 -4px var(--ink);
+}
+.doc-hero{padding:clamp(24px,4vw,38px) 0 clamp(20px,3vw,30px)}
+.doc-label{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  margin:0 0 16px;
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.doc-label::after{content:"";flex:1 1 auto;height:1px;background:var(--rule-strong)}
+h1{
+  font-family:var(--serif);
+  font-size:clamp(30px,5vw,50px);
+  line-height:1.1;
+  font-weight:600;
+  letter-spacing:0;
+  margin:0;
+  max-width:19ch;
+}
+.sub{
+  color:var(--muted);
+  font-size:clamp(15px,2.2vw,17.5px);
+  max-width:58ch;
+  margin:15px 0 0;
+  line-height:1.55;
+}
+.doc-grid{
+  display:grid;
+  grid-template-columns:minmax(190px,240px) minmax(0,1fr);
+  gap:clamp(24px,4vw,46px);
+  border-top:1px solid var(--rule);
+  padding-top:clamp(24px,4vw,38px);
+}
+.toc{
+  align-self:start;
+  position:sticky;
+  top:18px;
+  border-right:1px solid var(--rule);
+  padding-right:20px;
+}
+.toc h2{
+  margin:0 0 12px;
+  color:var(--faint);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+}
+.toc ol,.toc ul{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+.toc a{color:var(--muted);font-size:14px;text-decoration:none}
+.toc a:hover{color:var(--ink);text-decoration:underline}
+.doc-content{min-width:0}
+.doc-content > :first-child{margin-top:0}
+.doc-content h1{font-size:clamp(28px,4vw,42px)}
+.doc-content h2{
+  margin:clamp(32px,4vw,44px) 0 12px;
+  padding-top:18px;
+  border-top:1px solid var(--rule);
+  font-family:var(--serif);
+  font-size:clamp(22px,3vw,30px);
+  line-height:1.2;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h3{
+  margin:28px 0 10px;
+  font-family:var(--serif);
+  font-size:21px;
+  line-height:1.25;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h4,.doc-content h5,.doc-content h6{margin:22px 0 8px;font-size:16px;line-height:1.35}
+.doc-content p{margin:0 0 16px;color:var(--ink)}
+.doc-content ul,.doc-content ol{margin:0 0 18px;padding-left:22px}
+.doc-content li{margin:7px 0}
+.doc-content blockquote{
+  margin:20px 0;
+  padding:14px 18px;
+  border-left:4px solid var(--ledger);
+  background:#f7f9fa;
+  color:var(--muted);
+}
+code{
+  font-family:var(--mono);
+  font-size:.92em;
+  background:#f6f8f9;
+  border:1px solid var(--rule);
+  border-radius:4px;
+  padding:.08em .32em;
+}
+pre.doc-code{
+  margin:18px 0;
+  overflow-x:auto;
+  max-width:100%;
+  background:#0f1518;
+  border:1px solid #1c272d;
+  border-radius:9px;
+  padding:14px 16px;
+  box-shadow:0 20px 44px -34px rgba(9,14,18,.9);
+}
+pre.doc-code code{
+  display:block;
+  background:transparent;
+  border:0;
+  border-radius:0;
+  padding:0;
+  color:#d6dde2;
+  font-size:13px;
+  line-height:1.5;
+}
+.table-wrap{overflow-x:auto;margin:18px 0;border:1px solid var(--rule-strong);border-radius:8px}
+table{width:100%;border-collapse:collapse;font-size:14px;min-width:560px}
+th,td{padding:10px 12px;border-bottom:1px solid var(--rule);vertical-align:top;text-align:left}
+th{background:#f6f8f9;color:var(--ink);font-weight:700}
+tr:last-child td{border-bottom:0}
+.doc-index-list{list-style:none;margin:0;padding:0;display:grid;gap:0;border-top:1px solid var(--rule)}
+.doc-index-list li{padding:18px 0;border-bottom:1px solid var(--rule)}
+.doc-index-list a{
+  display:inline-block;
+  font-family:var(--serif);
+  font-size:22px;
+  line-height:1.2;
+  font-weight:600;
+}
+.doc-index-list .path{
+  display:block;
+  margin-top:4px;
+  color:var(--faint);
+  font-family:var(--mono);
+  font-size:12px;
+}
+.doc-index-list p{margin:8px 0 0;color:var(--muted);max-width:70ch}
+footer{
+  border-top:1px solid var(--rule);
+  margin-top:clamp(34px,5vw,52px);
+  padding-top:clamp(26px,4vw,34px);
+}
+.close{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  gap:20px;
+  flex-wrap:wrap;
+}
+.close-copy{max-width:34ch}
+.issued{
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  color:var(--faint);
+  display:flex;
+  gap:18px;
+  flex-wrap:wrap;
+  margin:0 0 14px;
+}
+.thanks{
+  font-family:var(--serif);
+  font-size:19px;
+  font-weight:600;
+  color:var(--ink);
+  margin:0 0 10px;
+}
+.serial{
+  font-family:var(--mono);
+  font-size:10.5px;
+  letter-spacing:.34em;
+  color:var(--faint);
+  margin:0;
+  padding-left:.34em;
+}
+.seal{flex:0 0 auto;width:clamp(104px,17vw,128px);height:auto;color:var(--seal);transform:rotate(-5deg)}
+.barcode{color:var(--rule-strong);height:30px;display:block;margin:24px 0 8px}
+.flinks{font-size:14px;color:var(--muted);line-height:2}
+.flinks a{color:var(--ledger)}
+.flinks .sep{color:var(--rule-strong);padding:0 .6ch}
+.samosa{color:var(--muted);margin:10px 0 0;font-size:13.5px}
+@media (max-width:760px){
+  .doc-grid{grid-template-columns:minmax(0,1fr)}
+  .toc{position:static;border-right:0;border-bottom:1px solid var(--rule);padding:0 0 18px}
+}
+@media (max-width:480px){
+  .masthead-row{letter-spacing:.16em;align-items:flex-start}
+  .masthead-row nav{gap:10px}
+  .close{flex-direction:column-reverse;align-items:flex-start}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important}
+}
+</style>
+</head>
+<body>
+<div class="sheet">
+  <header class="mast">
+    <div class="masthead-row">
+      <a class="brand" href="../index.html">AIRECEIPTS</a>
+      <nav aria-label="Primary">
+        <a href="../index.html">Home</a>
+        <a href="index.html">Docs</a>
+      </nav>
+    </div>
+    <div class="rule2" aria-hidden="true"></div>
+    <div class="doc-hero">
+      <p class="doc-label">Docs ledger</p>
+      <h1>The harness — how this repo builds itself</h1>
+      <p class="sub">Rendered from <code>docs/harness.md</code>.</p>
+    </div>
+  </header>
+  <main class="doc-grid">
+    <aside class="toc" aria-label="Docs contents">
+      <h2>Contents</h2>
+      <ol>
+<li><a href="harness.html">The harness — how this repo builds itself</a></li>
+<li><a href="hygiene-fp-log.html">Hygiene False-Positive Log</a></li>
+<li><a href="json-schema.html">Export schema (--json / --csv)</a></li>
+<li><a href="pr-receipts.html">PR receipts — attach the building session's receipt to a PR</a></li>
+<li><a href="statusline.html">Statusline</a></li>
+<li><a href="telemetry.html">Diagnostics telemetry</a></li>
+      </ol>
+    </aside>
+    <article class="doc-content">
+<h1 id="the-harness-how-this-repo-builds-itself">The harness — how this repo builds itself</h1>
+
+<p>aireceipts is designed, implemented, and maintained mostly by AI coding agents. That is not a stunt; it is the constraint the whole repository is engineered around. This document explains the machinery (the &quot;harness&quot;), how a change flows through it, and why each piece exists. The maintainer's standing job is four buttons — everything else is supposed to run under gates that don't trust anyone, human or model.</p>
+
+<h2 id="motivation">Motivation</h2>
+
+<p>Agent-written code fails in patterned, well-documented ways, and every structure here maps to one of those patterns:</p>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Failure pattern</th><th>Counter-structure</th></tr></thead>
+  <tbody>
+    <tr><td>Agents over-build on vague asks (&quot;over-eagerness&quot;)</td><td>Interview gate before any spec is drafted</td></tr>
+    <tr><td>Specs and code drift apart</td><td>Spec-under-git is the post-merge truth; <code>spec-lint</code> in CI</td></tr>
+    <tr><td>Plausible-but-wrong specs survive to implementation</td><td>S1–S4 validation, incl. an independent critic, <strong>before</strong> approval</td></tr>
+    <tr><td>Agents game test coverage (assertions weakened to pass)</td><td>Mutation testing on the money paths — coverage is advisory, mutation score gates</td></tr>
+    <tr><td>A model approves its own work (shared blind spots)</td><td>Generator ≠ critic, different model families, review recorded</td></tr>
+    <tr><td>Fabricated facts (prices, dollars, claims)</td><td>Hooks + CI reject uncited price data mechanically; invariant I2 bans fallback dollars</td></tr>
+    <tr><td>Output drift nobody notices</td><td>Golden receipts, byte-compared, re-run N× under a frozen environment</td></tr>
+    <tr><td>Bloated agent context degrades work</td><td>AGENTS.md hard-capped at 150 lines; reference, never duplicate</td></tr>
+    <tr><td>Docs rot behind the code</td><td>Docs ride in the feature PR; a two-lens docs panel blocks releases</td></tr>
+  </tbody>
+</table></div>
+
+<p>The through-line: <strong>never rely on an agent remembering a rule when the rule can be a gate.</strong> Discipline that lives in prose gets skipped under pressure; discipline that lives in an exit code doesn't.</p>
+
+<h2 id="the-pieces">The pieces</h2>
+
+<p><strong>The constitution — <code>AGENTS.md</code>.</strong> One file, ≤150 lines (CI-enforced), holding the mission, the verification commands (identical to CI, so &quot;passed locally&quot; means &quot;passes CI&quot;), the file-ownership map, and invariants <strong>I1–I6</strong> (deterministic &amp; offline-complete; never fabricate a dollar; every number traceable; diagnostics-only telemetry, disclosed and escapable; byte-stable output; facts, never rankings). The invariants are restated in every spec and skill — repetition is the point; it is what keeps dozens of independent agent sessions from drifting.</p>
+
+<p><strong>The spec system — <code>specs/</code>.</strong> Every change starts as a spec: machine-readable frontmatter (<code>status: draft|approved|building|shipped|rejected|superseded</code>), numbered testable requirements, Given/When/Then scenarios, a test matrix (every requirement must have rows — <code>scripts/spec-lint.mjs</code> fails the build otherwise), success criteria, and a kill criterion. Rejected specs are kept as tombstones with their reasoning: the harness treats a well-evidenced <em>no</em> as an artifact worth as much as a yes.</p>
+
+<p><strong>Validation — S1–S4, before approval.</strong> A draft cannot reach the maintainer without a recorded validation: <strong>S1</strong> self-audit (is every promised line computable from local data? no predictions, no judgment calls dressed as facts), <strong>S2</strong> an independent critic in a different model family attacking measurability, feasibility against real code, and scope, <strong>S3</strong> a value-gate dry run against the kill criterion, <strong>S4</strong> mechanical lint. In this repo's first week the critic returned REWORK on 7 of 13 drafts — every one a real catch (wrong quota semantics, an unpriceable adapter claim, a network call hiding in an export spec). Approval means approving a spec that already survived attack.</p>
+
+<p><strong>Skills — one per task type, maintainer-curated.</strong> <code>.claude/skills/</code> holds the operating procedures: <code>write-spec</code>, <code>validate-spec</code>, <code>build-spec</code>, <code>review-pr</code>, <code>review-docs</code>, <code>release</code>, <code>fix-issue</code>, <code>ci-fix</code>, <code>improve</code>, plus the extension-surface guides (<code>add-vendor-adapter</code>, <code>add-waste-check</code>, <code>update-prices</code>, <code>use-aireceipts</code>). Agents cannot add or edit skills — curating this surface is one of the four buttons.</p>
+
+<p><strong>Milestone builds — agent teams with directory ownership.</strong> Large specs (M-files) embed their own team plan: roles own <em>directories</em>, never features (no write conflicts); work is sliced into dependency waves with one named critical path; shared files have exactly one owner. Model assignment is part of the plan: the lead (frontier-tier) authors all design/UX artifacts and makes judgment calls; critical-path code runs on the strongest coding model; mechanical work may run lighter; deep review runs in a different model family. Agents write files but never commit — the lead runs the gate and commits at wave boundaries.</p>
+
+<p><strong>Quality gates — layered, and hostile by design.</strong> Typecheck → lint → tests → golden receipts (byte-equal) → property tests → <strong>mutation testing</strong> on <code>src/pricing/**</code> (fail-closed: pricing code without a mutation config fails CI) → determinism harness (goldens re-run ×20 under frozen <code>NO_COLOR</code>/TZ/locale) → an eval corpus asserting <strong>precision 1.0</strong> for the waste detectors (any false positive fails the build) → independent PR review, recorded. Data has its own gates: every price row must carry a cited source (a Claude Code hook blocks uncited writes at the tool level; a CI job is the authoritative check — the hook is UX, the exit code is law).</p>
+
+<p><strong>The docs loop.</strong> Any user-visible change updates the docs in the same PR (<code>build-spec</code> refuses &quot;docs later&quot;). Before a release, <code>review-docs</code> runs a two-lens panel: a cold reader who has never seen the repo must succeed with the README alone (simplicity), and a separate auditor executes every documented command and traces every claim to code (correctness). Docs that overclaim are treated as bugs.</p>
+
+<p><strong>Maintenance loops.</strong> Scheduled work runs on cadences with hard ceilings: daily price freshness (one cited PR per vendor), weekly dependency hygiene, label-triggered issue→PR runs, and a capped self-improvement loop that must survive an external value gate before anything lands. Telemetry's <code>parse_failure</code> event is the format-drift sensor: when an agent vendor changes its transcript format in the wild, the maintenance loop hears about it.</p>
+
+<p><strong>The dispatcher — orchestration must not live in anyone's attention.</strong> The costliest failure mode we hit was not bad code but <em>idle finished work</em>: builders completed, and their output sat unpublished until someone remembered to look. Three mechanisms close it:</p>
+
+<ol>
+  <li><strong>Queue in the repo, not in a head.</strong> Work that is ready to build is marked as GitHub state (approved specs; issues labeled <code>build-ready</code>) — visible, durable, and pollable by machinery. A label, not a memory, is the dispatch signal.</li>
+  <li><strong>A heartbeat sweep</strong> (a scheduled prompt, ~10 min): publish any worktree with committed-but-unpushed work; collect finished builder reports; dispatch idle capacity against the queue; stay silent when there is nothing to do. The sweep is dumb on purpose — judgment happens in review, not in dispatch.</li>
+  <li><strong>Self-publishing builders.</strong> A builder's brief ends with: self-review the diff (independent-model pass), write the review marker, push, open the PR through the template. The lead reviews <em>opened PRs</em>, never ferries work — the courier role is abolished.</li>
+</ol>
+
+<p>Enforcement backstop: a PreToolUse hook blocks <code>gh pr create</code>, <code>gh pr merge</code>, and feature-branch <code>git push</code> unless a review marker exists for the exact HEAD sha — so speed can never quietly drop the review step (it was dropped twice under deadline pressure before this hook existed; hence the hook).</p>
+
+<h2 id="how-a-feature-flows">How a feature flows</h2>
+
+<pre class="doc-code"><code>idea/issue
+  → write-spec      (interview gate → draft, status: draft)
+  → validate-spec   (S1 self-audit → S2 independent critic → S3 value gate → S4 lint;
+                     record appended; REWORK loops back)
+  → maintainer      (button 1: approve — or don't)
+  → build-spec      (branch; design artifact from the lead if user-visible;
+                     solo or team-waves; gates at every boundary; docs in the same PR)
+  → review-pr       (independent deep review, different model family, recorded)
+  → CI              (the full gate stack incl. mutation + cite-check + spec-lint)
+  → maintainer      (merge)
+  → release         (tag-matches-manifest guard → changelog → docs panel, blocking →
+                     button 4: publish; only this step flips specs to `shipped`)</code></pre>
+
+<h2 id="the-human-surface">The human surface</h2>
+
+<p>Four buttons, deliberately few: <strong>(1)</strong> approve or reject validated specs, <strong>(2)</strong> one-click cited price-table PRs, <strong>(3)</strong> curate the skill surface, <strong>(4)</strong> cut releases. Everything else — building, testing, reviewing, doc-keeping, dependency hygiene, price freshness — is the harness's job. When the harness catches its own operator skipping a step (it has), that is the system working.</p>
+
+<h2 id="lineage">Lineage</h2>
+
+<p>The design distills two working ancestors — a spec-driven repo where agents shipped ~130 specs under similar invariants, and a milestone/agent-team build system — plus the 2025–26 evidence on spec-driven development, agent context budgets, mutation testing versus coverage, and generator/critic separation. The shortest honest summary of all of it: <em>make the harness, not the promises.</em></p>
+    </article>
+  </main>
+  <footer>
+    <div class="close">
+      <div class="close-copy">
+        <p class="issued"><span>No account</span><span>No upload</span><span>Docs</span></p>
+        <p class="thanks">Thank you for your tokens.</p>
+        <p class="serial">AIRECEIPTS · NO. 0001</p>
+      </div>
+      <svg class="seal" viewBox="0 0 200 200" role="img" aria-label="A round vermillion seal reading RECEIPTED, SETTLED, and NO FABRICATED DOLLARS.">
+  <defs>
+    <path id="ring-top" d="M 30 100 A 70 70 0 0 1 170 100"/>
+    <path id="ring-bot" d="M 34 100 A 66 66 0 0 0 166 100"/>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <circle cx="100" cy="100" r="83" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700">
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-top" startOffset="50%">RECEIPTED</textPath></text>
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-bot" startOffset="50%">SETTLED</textPath></text>
+  </g>
+  <line x1="66" y1="70" x2="134" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="66" y1="130" x2="134" y2="130" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700" text-anchor="middle" letter-spacing="1.5">
+    <text x="100" y="91" font-size="15">NO</text>
+    <text x="100" y="106" font-size="13">FABRICATED</text>
+    <text x="100" y="121" font-size="15">DOLLARS</text>
+  </g>
+</svg>
+    </div>
+    <svg class="barcode" viewBox="0 0 90 34" width="180" height="30" fill="currentColor" role="img" aria-label="Barcode encoding the word aireceipts.">
+  <rect x="0" y="0" width="3" height="34"/><rect x="4" y="0" width="2" height="34"/><rect x="8" y="0" width="3" height="34"/><rect x="12" y="0" width="2" height="34"/><rect x="16" y="0" width="4" height="34"/><rect x="21" y="0" width="3" height="34"/><rect x="26" y="0" width="3" height="34"/><rect x="31" y="0" width="2" height="34"/><rect x="35" y="0" width="3" height="34"/><rect x="39" y="0" width="4" height="34"/><rect x="45" y="0" width="3" height="34"/><rect x="50" y="0" width="2" height="34"/><rect x="54" y="0" width="3" height="34"/><rect x="58" y="0" width="2" height="34"/><rect x="62" y="0" width="4" height="34"/><rect x="67" y="0" width="1" height="34"/><rect x="70" y="0" width="4" height="34"/><rect x="76" y="0" width="1" height="34"/><rect x="79" y="0" width="4" height="34"/><rect x="84" y="0" width="4" height="34"/>
+</svg>
+    <p class="flinks">
+      <a href="../index.html">Home</a><span class="sep" aria-hidden="true">·</span><a href="index.html">Docs</a><span class="sep" aria-hidden="true">·</span><span>Apache-2.0</span>
+    </p>
+    <p class="samosa">buy me a samosa</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/site/docs/hygiene-fp-log.html
+++ b/site/docs/hygiene-fp-log.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hygiene False-Positive Log — aireceipts docs</title>
+<meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
+<meta name="theme-color" content="#e9edf0">
+<style>
+:root{
+  --field:#e7ecef;
+  --sheet:#ffffff;
+  --ink:#14181c;
+  --muted:#586570;
+  --faint:#8a949c;
+  --rule:#e3e8eb;
+  --rule-strong:#c2cbd1;
+  --seal:#b23a3a;
+  --ledger:#2f5d3a;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,"SF Mono","Cascadia Code","JetBrains Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;
+  background:var(--field);
+  color:var(--ink);
+  font-family:var(--sans);
+  font-size:16px;
+  line-height:1.6;
+  padding:clamp(16px,3.5vw,40px) 16px clamp(40px,6vw,72px);
+}
+a{color:var(--ledger);text-underline-offset:2px;text-decoration-thickness:1px}
+a:focus-visible{outline:2px solid var(--ledger);outline-offset:2px;border-radius:2px}
+.sheet{
+  width:100%;
+  max-width:1040px;
+  margin:0 auto;
+  background:var(--sheet);
+  border:1px solid var(--rule-strong);
+  border-radius:3px;
+  padding:clamp(20px,3.6vw,44px) clamp(18px,4vw,52px) clamp(28px,4vw,44px);
+  box-shadow:0 1px 0 #fff inset,0 30px 64px -42px rgba(20,32,44,.42);
+}
+header.mast{padding-top:2px}
+.masthead-row{
+  display:flex;
+  justify-content:space-between;
+  align-items:baseline;
+  gap:16px;
+  font-family:var(--sans);
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.masthead-row .brand{color:var(--ink);letter-spacing:.30em;text-decoration:none}
+.masthead-row nav{display:flex;gap:16px;flex-wrap:wrap;justify-content:flex-end}
+.masthead-row nav a{color:var(--muted);letter-spacing:.12em;text-decoration:none}
+.masthead-row nav a:hover{color:var(--ink)}
+.rule2{
+  margin:12px 0 0;
+  height:0;
+  border-top:3px solid var(--ink);
+  box-shadow:0 5px 0 -4px var(--ink);
+}
+.doc-hero{padding:clamp(24px,4vw,38px) 0 clamp(20px,3vw,30px)}
+.doc-label{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  margin:0 0 16px;
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.doc-label::after{content:"";flex:1 1 auto;height:1px;background:var(--rule-strong)}
+h1{
+  font-family:var(--serif);
+  font-size:clamp(30px,5vw,50px);
+  line-height:1.1;
+  font-weight:600;
+  letter-spacing:0;
+  margin:0;
+  max-width:19ch;
+}
+.sub{
+  color:var(--muted);
+  font-size:clamp(15px,2.2vw,17.5px);
+  max-width:58ch;
+  margin:15px 0 0;
+  line-height:1.55;
+}
+.doc-grid{
+  display:grid;
+  grid-template-columns:minmax(190px,240px) minmax(0,1fr);
+  gap:clamp(24px,4vw,46px);
+  border-top:1px solid var(--rule);
+  padding-top:clamp(24px,4vw,38px);
+}
+.toc{
+  align-self:start;
+  position:sticky;
+  top:18px;
+  border-right:1px solid var(--rule);
+  padding-right:20px;
+}
+.toc h2{
+  margin:0 0 12px;
+  color:var(--faint);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+}
+.toc ol,.toc ul{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+.toc a{color:var(--muted);font-size:14px;text-decoration:none}
+.toc a:hover{color:var(--ink);text-decoration:underline}
+.doc-content{min-width:0}
+.doc-content > :first-child{margin-top:0}
+.doc-content h1{font-size:clamp(28px,4vw,42px)}
+.doc-content h2{
+  margin:clamp(32px,4vw,44px) 0 12px;
+  padding-top:18px;
+  border-top:1px solid var(--rule);
+  font-family:var(--serif);
+  font-size:clamp(22px,3vw,30px);
+  line-height:1.2;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h3{
+  margin:28px 0 10px;
+  font-family:var(--serif);
+  font-size:21px;
+  line-height:1.25;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h4,.doc-content h5,.doc-content h6{margin:22px 0 8px;font-size:16px;line-height:1.35}
+.doc-content p{margin:0 0 16px;color:var(--ink)}
+.doc-content ul,.doc-content ol{margin:0 0 18px;padding-left:22px}
+.doc-content li{margin:7px 0}
+.doc-content blockquote{
+  margin:20px 0;
+  padding:14px 18px;
+  border-left:4px solid var(--ledger);
+  background:#f7f9fa;
+  color:var(--muted);
+}
+code{
+  font-family:var(--mono);
+  font-size:.92em;
+  background:#f6f8f9;
+  border:1px solid var(--rule);
+  border-radius:4px;
+  padding:.08em .32em;
+}
+pre.doc-code{
+  margin:18px 0;
+  overflow-x:auto;
+  max-width:100%;
+  background:#0f1518;
+  border:1px solid #1c272d;
+  border-radius:9px;
+  padding:14px 16px;
+  box-shadow:0 20px 44px -34px rgba(9,14,18,.9);
+}
+pre.doc-code code{
+  display:block;
+  background:transparent;
+  border:0;
+  border-radius:0;
+  padding:0;
+  color:#d6dde2;
+  font-size:13px;
+  line-height:1.5;
+}
+.table-wrap{overflow-x:auto;margin:18px 0;border:1px solid var(--rule-strong);border-radius:8px}
+table{width:100%;border-collapse:collapse;font-size:14px;min-width:560px}
+th,td{padding:10px 12px;border-bottom:1px solid var(--rule);vertical-align:top;text-align:left}
+th{background:#f6f8f9;color:var(--ink);font-weight:700}
+tr:last-child td{border-bottom:0}
+.doc-index-list{list-style:none;margin:0;padding:0;display:grid;gap:0;border-top:1px solid var(--rule)}
+.doc-index-list li{padding:18px 0;border-bottom:1px solid var(--rule)}
+.doc-index-list a{
+  display:inline-block;
+  font-family:var(--serif);
+  font-size:22px;
+  line-height:1.2;
+  font-weight:600;
+}
+.doc-index-list .path{
+  display:block;
+  margin-top:4px;
+  color:var(--faint);
+  font-family:var(--mono);
+  font-size:12px;
+}
+.doc-index-list p{margin:8px 0 0;color:var(--muted);max-width:70ch}
+footer{
+  border-top:1px solid var(--rule);
+  margin-top:clamp(34px,5vw,52px);
+  padding-top:clamp(26px,4vw,34px);
+}
+.close{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  gap:20px;
+  flex-wrap:wrap;
+}
+.close-copy{max-width:34ch}
+.issued{
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  color:var(--faint);
+  display:flex;
+  gap:18px;
+  flex-wrap:wrap;
+  margin:0 0 14px;
+}
+.thanks{
+  font-family:var(--serif);
+  font-size:19px;
+  font-weight:600;
+  color:var(--ink);
+  margin:0 0 10px;
+}
+.serial{
+  font-family:var(--mono);
+  font-size:10.5px;
+  letter-spacing:.34em;
+  color:var(--faint);
+  margin:0;
+  padding-left:.34em;
+}
+.seal{flex:0 0 auto;width:clamp(104px,17vw,128px);height:auto;color:var(--seal);transform:rotate(-5deg)}
+.barcode{color:var(--rule-strong);height:30px;display:block;margin:24px 0 8px}
+.flinks{font-size:14px;color:var(--muted);line-height:2}
+.flinks a{color:var(--ledger)}
+.flinks .sep{color:var(--rule-strong);padding:0 .6ch}
+.samosa{color:var(--muted);margin:10px 0 0;font-size:13.5px}
+@media (max-width:760px){
+  .doc-grid{grid-template-columns:minmax(0,1fr)}
+  .toc{position:static;border-right:0;border-bottom:1px solid var(--rule);padding:0 0 18px}
+}
+@media (max-width:480px){
+  .masthead-row{letter-spacing:.16em;align-items:flex-start}
+  .masthead-row nav{gap:10px}
+  .close{flex-direction:column-reverse;align-items:flex-start}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important}
+}
+</style>
+</head>
+<body>
+<div class="sheet">
+  <header class="mast">
+    <div class="masthead-row">
+      <a class="brand" href="../index.html">AIRECEIPTS</a>
+      <nav aria-label="Primary">
+        <a href="../index.html">Home</a>
+        <a href="index.html">Docs</a>
+      </nav>
+    </div>
+    <div class="rule2" aria-hidden="true"></div>
+    <div class="doc-hero">
+      <p class="doc-label">Docs ledger</p>
+      <h1>Hygiene False-Positive Log</h1>
+      <p class="sub">Rendered from <code>docs/hygiene-fp-log.md</code>.</p>
+    </div>
+  </header>
+  <main class="doc-grid">
+    <aside class="toc" aria-label="Docs contents">
+      <h2>Contents</h2>
+      <ol>
+<li><a href="harness.html">The harness — how this repo builds itself</a></li>
+<li><a href="hygiene-fp-log.html">Hygiene False-Positive Log</a></li>
+<li><a href="json-schema.html">Export schema (--json / --csv)</a></li>
+<li><a href="pr-receipts.html">PR receipts — attach the building session's receipt to a PR</a></li>
+<li><a href="statusline.html">Statusline</a></li>
+<li><a href="telemetry.html">Diagnostics telemetry</a></li>
+      </ol>
+    </aside>
+    <article class="doc-content">
+<h1 id="hygiene-false-positive-log">Hygiene False-Positive Log</h1>
+
+<p>Any false or intentionally overridden hygiene finding is appended here. The kill criterion from SPEC-0016 is mechanical: two false positives in a month means the gate is fixed or deleted.</p>
+
+<p>Format:</p>
+
+<p><code>YYYY-MM-DD · gate · cause · action</code></p>
+
+<h2 id="log">Log</h2>
+
+<p>_No entries._</p>
+    </article>
+  </main>
+  <footer>
+    <div class="close">
+      <div class="close-copy">
+        <p class="issued"><span>No account</span><span>No upload</span><span>Docs</span></p>
+        <p class="thanks">Thank you for your tokens.</p>
+        <p class="serial">AIRECEIPTS · NO. 0001</p>
+      </div>
+      <svg class="seal" viewBox="0 0 200 200" role="img" aria-label="A round vermillion seal reading RECEIPTED, SETTLED, and NO FABRICATED DOLLARS.">
+  <defs>
+    <path id="ring-top" d="M 30 100 A 70 70 0 0 1 170 100"/>
+    <path id="ring-bot" d="M 34 100 A 66 66 0 0 0 166 100"/>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <circle cx="100" cy="100" r="83" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700">
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-top" startOffset="50%">RECEIPTED</textPath></text>
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-bot" startOffset="50%">SETTLED</textPath></text>
+  </g>
+  <line x1="66" y1="70" x2="134" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="66" y1="130" x2="134" y2="130" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700" text-anchor="middle" letter-spacing="1.5">
+    <text x="100" y="91" font-size="15">NO</text>
+    <text x="100" y="106" font-size="13">FABRICATED</text>
+    <text x="100" y="121" font-size="15">DOLLARS</text>
+  </g>
+</svg>
+    </div>
+    <svg class="barcode" viewBox="0 0 90 34" width="180" height="30" fill="currentColor" role="img" aria-label="Barcode encoding the word aireceipts.">
+  <rect x="0" y="0" width="3" height="34"/><rect x="4" y="0" width="2" height="34"/><rect x="8" y="0" width="3" height="34"/><rect x="12" y="0" width="2" height="34"/><rect x="16" y="0" width="4" height="34"/><rect x="21" y="0" width="3" height="34"/><rect x="26" y="0" width="3" height="34"/><rect x="31" y="0" width="2" height="34"/><rect x="35" y="0" width="3" height="34"/><rect x="39" y="0" width="4" height="34"/><rect x="45" y="0" width="3" height="34"/><rect x="50" y="0" width="2" height="34"/><rect x="54" y="0" width="3" height="34"/><rect x="58" y="0" width="2" height="34"/><rect x="62" y="0" width="4" height="34"/><rect x="67" y="0" width="1" height="34"/><rect x="70" y="0" width="4" height="34"/><rect x="76" y="0" width="1" height="34"/><rect x="79" y="0" width="4" height="34"/><rect x="84" y="0" width="4" height="34"/>
+</svg>
+    <p class="flinks">
+      <a href="../index.html">Home</a><span class="sep" aria-hidden="true">·</span><a href="index.html">Docs</a><span class="sep" aria-hidden="true">·</span><span>Apache-2.0</span>
+    </p>
+    <p class="samosa">buy me a samosa</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Docs — aireceipts docs</title>
+<meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
+<meta name="theme-color" content="#e9edf0">
+<style>
+:root{
+  --field:#e7ecef;
+  --sheet:#ffffff;
+  --ink:#14181c;
+  --muted:#586570;
+  --faint:#8a949c;
+  --rule:#e3e8eb;
+  --rule-strong:#c2cbd1;
+  --seal:#b23a3a;
+  --ledger:#2f5d3a;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,"SF Mono","Cascadia Code","JetBrains Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;
+  background:var(--field);
+  color:var(--ink);
+  font-family:var(--sans);
+  font-size:16px;
+  line-height:1.6;
+  padding:clamp(16px,3.5vw,40px) 16px clamp(40px,6vw,72px);
+}
+a{color:var(--ledger);text-underline-offset:2px;text-decoration-thickness:1px}
+a:focus-visible{outline:2px solid var(--ledger);outline-offset:2px;border-radius:2px}
+.sheet{
+  width:100%;
+  max-width:1040px;
+  margin:0 auto;
+  background:var(--sheet);
+  border:1px solid var(--rule-strong);
+  border-radius:3px;
+  padding:clamp(20px,3.6vw,44px) clamp(18px,4vw,52px) clamp(28px,4vw,44px);
+  box-shadow:0 1px 0 #fff inset,0 30px 64px -42px rgba(20,32,44,.42);
+}
+header.mast{padding-top:2px}
+.masthead-row{
+  display:flex;
+  justify-content:space-between;
+  align-items:baseline;
+  gap:16px;
+  font-family:var(--sans);
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.masthead-row .brand{color:var(--ink);letter-spacing:.30em;text-decoration:none}
+.masthead-row nav{display:flex;gap:16px;flex-wrap:wrap;justify-content:flex-end}
+.masthead-row nav a{color:var(--muted);letter-spacing:.12em;text-decoration:none}
+.masthead-row nav a:hover{color:var(--ink)}
+.rule2{
+  margin:12px 0 0;
+  height:0;
+  border-top:3px solid var(--ink);
+  box-shadow:0 5px 0 -4px var(--ink);
+}
+.doc-hero{padding:clamp(24px,4vw,38px) 0 clamp(20px,3vw,30px)}
+.doc-label{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  margin:0 0 16px;
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.doc-label::after{content:"";flex:1 1 auto;height:1px;background:var(--rule-strong)}
+h1{
+  font-family:var(--serif);
+  font-size:clamp(30px,5vw,50px);
+  line-height:1.1;
+  font-weight:600;
+  letter-spacing:0;
+  margin:0;
+  max-width:19ch;
+}
+.sub{
+  color:var(--muted);
+  font-size:clamp(15px,2.2vw,17.5px);
+  max-width:58ch;
+  margin:15px 0 0;
+  line-height:1.55;
+}
+.doc-grid{
+  display:grid;
+  grid-template-columns:minmax(190px,240px) minmax(0,1fr);
+  gap:clamp(24px,4vw,46px);
+  border-top:1px solid var(--rule);
+  padding-top:clamp(24px,4vw,38px);
+}
+.toc{
+  align-self:start;
+  position:sticky;
+  top:18px;
+  border-right:1px solid var(--rule);
+  padding-right:20px;
+}
+.toc h2{
+  margin:0 0 12px;
+  color:var(--faint);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+}
+.toc ol,.toc ul{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+.toc a{color:var(--muted);font-size:14px;text-decoration:none}
+.toc a:hover{color:var(--ink);text-decoration:underline}
+.doc-content{min-width:0}
+.doc-content > :first-child{margin-top:0}
+.doc-content h1{font-size:clamp(28px,4vw,42px)}
+.doc-content h2{
+  margin:clamp(32px,4vw,44px) 0 12px;
+  padding-top:18px;
+  border-top:1px solid var(--rule);
+  font-family:var(--serif);
+  font-size:clamp(22px,3vw,30px);
+  line-height:1.2;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h3{
+  margin:28px 0 10px;
+  font-family:var(--serif);
+  font-size:21px;
+  line-height:1.25;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h4,.doc-content h5,.doc-content h6{margin:22px 0 8px;font-size:16px;line-height:1.35}
+.doc-content p{margin:0 0 16px;color:var(--ink)}
+.doc-content ul,.doc-content ol{margin:0 0 18px;padding-left:22px}
+.doc-content li{margin:7px 0}
+.doc-content blockquote{
+  margin:20px 0;
+  padding:14px 18px;
+  border-left:4px solid var(--ledger);
+  background:#f7f9fa;
+  color:var(--muted);
+}
+code{
+  font-family:var(--mono);
+  font-size:.92em;
+  background:#f6f8f9;
+  border:1px solid var(--rule);
+  border-radius:4px;
+  padding:.08em .32em;
+}
+pre.doc-code{
+  margin:18px 0;
+  overflow-x:auto;
+  max-width:100%;
+  background:#0f1518;
+  border:1px solid #1c272d;
+  border-radius:9px;
+  padding:14px 16px;
+  box-shadow:0 20px 44px -34px rgba(9,14,18,.9);
+}
+pre.doc-code code{
+  display:block;
+  background:transparent;
+  border:0;
+  border-radius:0;
+  padding:0;
+  color:#d6dde2;
+  font-size:13px;
+  line-height:1.5;
+}
+.table-wrap{overflow-x:auto;margin:18px 0;border:1px solid var(--rule-strong);border-radius:8px}
+table{width:100%;border-collapse:collapse;font-size:14px;min-width:560px}
+th,td{padding:10px 12px;border-bottom:1px solid var(--rule);vertical-align:top;text-align:left}
+th{background:#f6f8f9;color:var(--ink);font-weight:700}
+tr:last-child td{border-bottom:0}
+.doc-index-list{list-style:none;margin:0;padding:0;display:grid;gap:0;border-top:1px solid var(--rule)}
+.doc-index-list li{padding:18px 0;border-bottom:1px solid var(--rule)}
+.doc-index-list a{
+  display:inline-block;
+  font-family:var(--serif);
+  font-size:22px;
+  line-height:1.2;
+  font-weight:600;
+}
+.doc-index-list .path{
+  display:block;
+  margin-top:4px;
+  color:var(--faint);
+  font-family:var(--mono);
+  font-size:12px;
+}
+.doc-index-list p{margin:8px 0 0;color:var(--muted);max-width:70ch}
+footer{
+  border-top:1px solid var(--rule);
+  margin-top:clamp(34px,5vw,52px);
+  padding-top:clamp(26px,4vw,34px);
+}
+.close{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  gap:20px;
+  flex-wrap:wrap;
+}
+.close-copy{max-width:34ch}
+.issued{
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  color:var(--faint);
+  display:flex;
+  gap:18px;
+  flex-wrap:wrap;
+  margin:0 0 14px;
+}
+.thanks{
+  font-family:var(--serif);
+  font-size:19px;
+  font-weight:600;
+  color:var(--ink);
+  margin:0 0 10px;
+}
+.serial{
+  font-family:var(--mono);
+  font-size:10.5px;
+  letter-spacing:.34em;
+  color:var(--faint);
+  margin:0;
+  padding-left:.34em;
+}
+.seal{flex:0 0 auto;width:clamp(104px,17vw,128px);height:auto;color:var(--seal);transform:rotate(-5deg)}
+.barcode{color:var(--rule-strong);height:30px;display:block;margin:24px 0 8px}
+.flinks{font-size:14px;color:var(--muted);line-height:2}
+.flinks a{color:var(--ledger)}
+.flinks .sep{color:var(--rule-strong);padding:0 .6ch}
+.samosa{color:var(--muted);margin:10px 0 0;font-size:13.5px}
+@media (max-width:760px){
+  .doc-grid{grid-template-columns:minmax(0,1fr)}
+  .toc{position:static;border-right:0;border-bottom:1px solid var(--rule);padding:0 0 18px}
+}
+@media (max-width:480px){
+  .masthead-row{letter-spacing:.16em;align-items:flex-start}
+  .masthead-row nav{gap:10px}
+  .close{flex-direction:column-reverse;align-items:flex-start}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important}
+}
+</style>
+</head>
+<body>
+<div class="sheet">
+  <header class="mast">
+    <div class="masthead-row">
+      <a class="brand" href="../index.html">AIRECEIPTS</a>
+      <nav aria-label="Primary">
+        <a href="../index.html">Home</a>
+        <a href="index.html">Docs</a>
+      </nav>
+    </div>
+    <div class="rule2" aria-hidden="true"></div>
+    <div class="doc-hero">
+      <p class="doc-label">Docs ledger</p>
+      <h1>Docs</h1>
+      <p class="sub">Static contents for the public docs set.</p>
+    </div>
+  </header>
+  <main class="doc-grid">
+    <aside class="toc" aria-label="Docs contents">
+      <h2>Contents</h2>
+      <ol>
+<li><a href="harness.html">The harness — how this repo builds itself</a></li>
+<li><a href="hygiene-fp-log.html">Hygiene False-Positive Log</a></li>
+<li><a href="json-schema.html">Export schema (--json / --csv)</a></li>
+<li><a href="pr-receipts.html">PR receipts — attach the building session's receipt to a PR</a></li>
+<li><a href="statusline.html">Statusline</a></li>
+<li><a href="telemetry.html">Diagnostics telemetry</a></li>
+      </ol>
+    </aside>
+    <article class="doc-content">
+<h1 id="docs">Docs</h1>
+<p>Root repository docs rendered as static pages for GitHub Pages. Source paths are shown so the generated site remains traceable to the markdown it wraps.</p>
+<ul class="doc-index-list">
+  <li>
+    <a href="harness.html">The harness — how this repo builds itself</a>
+    <span class="path">docs/harness.md</span>
+    <p>aireceipts is designed, implemented, and maintained mostly by AI coding agents. That is not a stunt; it is the constraint the whole repository is engineered around. This document e</p>
+  </li>
+  <li>
+    <a href="hygiene-fp-log.html">Hygiene False-Positive Log</a>
+    <span class="path">docs/hygiene-fp-log.md</span>
+    <p>Any false or intentionally overridden hygiene finding is appended here. The kill criterion from SPEC-0016 is mechanical: two false positives in a month means the gate is fixed or d</p>
+  </li>
+  <li>
+    <a href="json-schema.html">Export schema (--json / --csv)</a>
+    <span class="path">docs/json-schema.md</span>
+    <p>aireceipts can emit a session receipt as machine-readable JSON (--json) or CSV (--csv) instead of the text receipt, for FinOps tooling and spreadsheet ingestion. This document is t</p>
+  </li>
+  <li>
+    <a href="pr-receipts.html">PR receipts — attach the building session's receipt to a PR</a>
+    <span class="path">docs/pr-receipts.md</span>
+    <p>aireceipts pr attaches the cost receipt of the AI-agent session that built a branch to that branch's pull request, as a single marked comment that stays current across pushes. Tran</p>
+  </li>
+  <li>
+    <a href="statusline.html">Statusline</a>
+    <span class="path">docs/statusline.md</span>
+    <p>aireceipts statusline prints one line — the last-completed session's cost (or tokens, if unpriced) plus a waste flag if one fired — meant for Claude Code's statusLine command confi</p>
+  </li>
+  <li>
+    <a href="telemetry.html">Diagnostics telemetry</a>
+    <span class="path">docs/telemetry.md</span>
+    <p>aireceipts can send small, anonymous, content-free diagnostics events to help us find bugs and understand which agent formats and CLI paths are actually used in the wild. This docu</p>
+  </li>
+</ul>
+    </article>
+  </main>
+  <footer>
+    <div class="close">
+      <div class="close-copy">
+        <p class="issued"><span>No account</span><span>No upload</span><span>Docs</span></p>
+        <p class="thanks">Thank you for your tokens.</p>
+        <p class="serial">AIRECEIPTS · NO. 0001</p>
+      </div>
+      <svg class="seal" viewBox="0 0 200 200" role="img" aria-label="A round vermillion seal reading RECEIPTED, SETTLED, and NO FABRICATED DOLLARS.">
+  <defs>
+    <path id="ring-top" d="M 30 100 A 70 70 0 0 1 170 100"/>
+    <path id="ring-bot" d="M 34 100 A 66 66 0 0 0 166 100"/>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <circle cx="100" cy="100" r="83" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700">
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-top" startOffset="50%">RECEIPTED</textPath></text>
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-bot" startOffset="50%">SETTLED</textPath></text>
+  </g>
+  <line x1="66" y1="70" x2="134" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="66" y1="130" x2="134" y2="130" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700" text-anchor="middle" letter-spacing="1.5">
+    <text x="100" y="91" font-size="15">NO</text>
+    <text x="100" y="106" font-size="13">FABRICATED</text>
+    <text x="100" y="121" font-size="15">DOLLARS</text>
+  </g>
+</svg>
+    </div>
+    <svg class="barcode" viewBox="0 0 90 34" width="180" height="30" fill="currentColor" role="img" aria-label="Barcode encoding the word aireceipts.">
+  <rect x="0" y="0" width="3" height="34"/><rect x="4" y="0" width="2" height="34"/><rect x="8" y="0" width="3" height="34"/><rect x="12" y="0" width="2" height="34"/><rect x="16" y="0" width="4" height="34"/><rect x="21" y="0" width="3" height="34"/><rect x="26" y="0" width="3" height="34"/><rect x="31" y="0" width="2" height="34"/><rect x="35" y="0" width="3" height="34"/><rect x="39" y="0" width="4" height="34"/><rect x="45" y="0" width="3" height="34"/><rect x="50" y="0" width="2" height="34"/><rect x="54" y="0" width="3" height="34"/><rect x="58" y="0" width="2" height="34"/><rect x="62" y="0" width="4" height="34"/><rect x="67" y="0" width="1" height="34"/><rect x="70" y="0" width="4" height="34"/><rect x="76" y="0" width="1" height="34"/><rect x="79" y="0" width="4" height="34"/><rect x="84" y="0" width="4" height="34"/>
+</svg>
+    <p class="flinks">
+      <a href="../index.html">Home</a><span class="sep" aria-hidden="true">·</span><a href="index.html">Docs</a><span class="sep" aria-hidden="true">·</span><span>Apache-2.0</span>
+    </p>
+    <p class="samosa">buy me a samosa</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/site/docs/json-schema.html
+++ b/site/docs/json-schema.html
@@ -1,0 +1,512 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Export schema (--json / --csv) — aireceipts docs</title>
+<meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
+<meta name="theme-color" content="#e9edf0">
+<style>
+:root{
+  --field:#e7ecef;
+  --sheet:#ffffff;
+  --ink:#14181c;
+  --muted:#586570;
+  --faint:#8a949c;
+  --rule:#e3e8eb;
+  --rule-strong:#c2cbd1;
+  --seal:#b23a3a;
+  --ledger:#2f5d3a;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,"SF Mono","Cascadia Code","JetBrains Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;
+  background:var(--field);
+  color:var(--ink);
+  font-family:var(--sans);
+  font-size:16px;
+  line-height:1.6;
+  padding:clamp(16px,3.5vw,40px) 16px clamp(40px,6vw,72px);
+}
+a{color:var(--ledger);text-underline-offset:2px;text-decoration-thickness:1px}
+a:focus-visible{outline:2px solid var(--ledger);outline-offset:2px;border-radius:2px}
+.sheet{
+  width:100%;
+  max-width:1040px;
+  margin:0 auto;
+  background:var(--sheet);
+  border:1px solid var(--rule-strong);
+  border-radius:3px;
+  padding:clamp(20px,3.6vw,44px) clamp(18px,4vw,52px) clamp(28px,4vw,44px);
+  box-shadow:0 1px 0 #fff inset,0 30px 64px -42px rgba(20,32,44,.42);
+}
+header.mast{padding-top:2px}
+.masthead-row{
+  display:flex;
+  justify-content:space-between;
+  align-items:baseline;
+  gap:16px;
+  font-family:var(--sans);
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.masthead-row .brand{color:var(--ink);letter-spacing:.30em;text-decoration:none}
+.masthead-row nav{display:flex;gap:16px;flex-wrap:wrap;justify-content:flex-end}
+.masthead-row nav a{color:var(--muted);letter-spacing:.12em;text-decoration:none}
+.masthead-row nav a:hover{color:var(--ink)}
+.rule2{
+  margin:12px 0 0;
+  height:0;
+  border-top:3px solid var(--ink);
+  box-shadow:0 5px 0 -4px var(--ink);
+}
+.doc-hero{padding:clamp(24px,4vw,38px) 0 clamp(20px,3vw,30px)}
+.doc-label{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  margin:0 0 16px;
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.doc-label::after{content:"";flex:1 1 auto;height:1px;background:var(--rule-strong)}
+h1{
+  font-family:var(--serif);
+  font-size:clamp(30px,5vw,50px);
+  line-height:1.1;
+  font-weight:600;
+  letter-spacing:0;
+  margin:0;
+  max-width:19ch;
+}
+.sub{
+  color:var(--muted);
+  font-size:clamp(15px,2.2vw,17.5px);
+  max-width:58ch;
+  margin:15px 0 0;
+  line-height:1.55;
+}
+.doc-grid{
+  display:grid;
+  grid-template-columns:minmax(190px,240px) minmax(0,1fr);
+  gap:clamp(24px,4vw,46px);
+  border-top:1px solid var(--rule);
+  padding-top:clamp(24px,4vw,38px);
+}
+.toc{
+  align-self:start;
+  position:sticky;
+  top:18px;
+  border-right:1px solid var(--rule);
+  padding-right:20px;
+}
+.toc h2{
+  margin:0 0 12px;
+  color:var(--faint);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+}
+.toc ol,.toc ul{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+.toc a{color:var(--muted);font-size:14px;text-decoration:none}
+.toc a:hover{color:var(--ink);text-decoration:underline}
+.doc-content{min-width:0}
+.doc-content > :first-child{margin-top:0}
+.doc-content h1{font-size:clamp(28px,4vw,42px)}
+.doc-content h2{
+  margin:clamp(32px,4vw,44px) 0 12px;
+  padding-top:18px;
+  border-top:1px solid var(--rule);
+  font-family:var(--serif);
+  font-size:clamp(22px,3vw,30px);
+  line-height:1.2;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h3{
+  margin:28px 0 10px;
+  font-family:var(--serif);
+  font-size:21px;
+  line-height:1.25;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h4,.doc-content h5,.doc-content h6{margin:22px 0 8px;font-size:16px;line-height:1.35}
+.doc-content p{margin:0 0 16px;color:var(--ink)}
+.doc-content ul,.doc-content ol{margin:0 0 18px;padding-left:22px}
+.doc-content li{margin:7px 0}
+.doc-content blockquote{
+  margin:20px 0;
+  padding:14px 18px;
+  border-left:4px solid var(--ledger);
+  background:#f7f9fa;
+  color:var(--muted);
+}
+code{
+  font-family:var(--mono);
+  font-size:.92em;
+  background:#f6f8f9;
+  border:1px solid var(--rule);
+  border-radius:4px;
+  padding:.08em .32em;
+}
+pre.doc-code{
+  margin:18px 0;
+  overflow-x:auto;
+  max-width:100%;
+  background:#0f1518;
+  border:1px solid #1c272d;
+  border-radius:9px;
+  padding:14px 16px;
+  box-shadow:0 20px 44px -34px rgba(9,14,18,.9);
+}
+pre.doc-code code{
+  display:block;
+  background:transparent;
+  border:0;
+  border-radius:0;
+  padding:0;
+  color:#d6dde2;
+  font-size:13px;
+  line-height:1.5;
+}
+.table-wrap{overflow-x:auto;margin:18px 0;border:1px solid var(--rule-strong);border-radius:8px}
+table{width:100%;border-collapse:collapse;font-size:14px;min-width:560px}
+th,td{padding:10px 12px;border-bottom:1px solid var(--rule);vertical-align:top;text-align:left}
+th{background:#f6f8f9;color:var(--ink);font-weight:700}
+tr:last-child td{border-bottom:0}
+.doc-index-list{list-style:none;margin:0;padding:0;display:grid;gap:0;border-top:1px solid var(--rule)}
+.doc-index-list li{padding:18px 0;border-bottom:1px solid var(--rule)}
+.doc-index-list a{
+  display:inline-block;
+  font-family:var(--serif);
+  font-size:22px;
+  line-height:1.2;
+  font-weight:600;
+}
+.doc-index-list .path{
+  display:block;
+  margin-top:4px;
+  color:var(--faint);
+  font-family:var(--mono);
+  font-size:12px;
+}
+.doc-index-list p{margin:8px 0 0;color:var(--muted);max-width:70ch}
+footer{
+  border-top:1px solid var(--rule);
+  margin-top:clamp(34px,5vw,52px);
+  padding-top:clamp(26px,4vw,34px);
+}
+.close{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  gap:20px;
+  flex-wrap:wrap;
+}
+.close-copy{max-width:34ch}
+.issued{
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  color:var(--faint);
+  display:flex;
+  gap:18px;
+  flex-wrap:wrap;
+  margin:0 0 14px;
+}
+.thanks{
+  font-family:var(--serif);
+  font-size:19px;
+  font-weight:600;
+  color:var(--ink);
+  margin:0 0 10px;
+}
+.serial{
+  font-family:var(--mono);
+  font-size:10.5px;
+  letter-spacing:.34em;
+  color:var(--faint);
+  margin:0;
+  padding-left:.34em;
+}
+.seal{flex:0 0 auto;width:clamp(104px,17vw,128px);height:auto;color:var(--seal);transform:rotate(-5deg)}
+.barcode{color:var(--rule-strong);height:30px;display:block;margin:24px 0 8px}
+.flinks{font-size:14px;color:var(--muted);line-height:2}
+.flinks a{color:var(--ledger)}
+.flinks .sep{color:var(--rule-strong);padding:0 .6ch}
+.samosa{color:var(--muted);margin:10px 0 0;font-size:13.5px}
+@media (max-width:760px){
+  .doc-grid{grid-template-columns:minmax(0,1fr)}
+  .toc{position:static;border-right:0;border-bottom:1px solid var(--rule);padding:0 0 18px}
+}
+@media (max-width:480px){
+  .masthead-row{letter-spacing:.16em;align-items:flex-start}
+  .masthead-row nav{gap:10px}
+  .close{flex-direction:column-reverse;align-items:flex-start}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important}
+}
+</style>
+</head>
+<body>
+<div class="sheet">
+  <header class="mast">
+    <div class="masthead-row">
+      <a class="brand" href="../index.html">AIRECEIPTS</a>
+      <nav aria-label="Primary">
+        <a href="../index.html">Home</a>
+        <a href="index.html">Docs</a>
+      </nav>
+    </div>
+    <div class="rule2" aria-hidden="true"></div>
+    <div class="doc-hero">
+      <p class="doc-label">Docs ledger</p>
+      <h1>Export schema (--json / --csv)</h1>
+      <p class="sub">Rendered from <code>docs/json-schema.md</code>.</p>
+    </div>
+  </header>
+  <main class="doc-grid">
+    <aside class="toc" aria-label="Docs contents">
+      <h2>Contents</h2>
+      <ol>
+<li><a href="harness.html">The harness — how this repo builds itself</a></li>
+<li><a href="hygiene-fp-log.html">Hygiene False-Positive Log</a></li>
+<li><a href="json-schema.html">Export schema (--json / --csv)</a></li>
+<li><a href="pr-receipts.html">PR receipts — attach the building session's receipt to a PR</a></li>
+<li><a href="statusline.html">Statusline</a></li>
+<li><a href="telemetry.html">Diagnostics telemetry</a></li>
+      </ol>
+    </aside>
+    <article class="doc-content">
+<h1 id="export-schema-json-csv">Export schema (<code>--json</code> / <code>--csv</code>)</h1>
+
+<p><code>aireceipts</code> can emit a session receipt as machine-readable JSON (<code>--json</code>) or CSV (<code>--csv</code>) instead of the text receipt, for FinOps tooling and spreadsheet ingestion. This document is the authoritative, field-by-field description of those shapes.</p>
+
+<p>The <strong>single source of truth</strong> is the <code>zod</code> schema in <code>src/receipt/exportSchema.ts</code> (<code>receiptJsonSchema</code> / <code>compareJsonSchema</code>). This document mirrors it, and an automated parity test (<code>test/receipt/json-schema-parity.test.ts</code>) fails the build if the two ever disagree — every documented field name must equal the schema's field names, and the version below must equal the schema's <code>SCHEMA_VERSION</code>. If you find a discrepancy, it's a bug; please open an issue.</p>
+
+<p>The current schema version is <strong>1</strong>. It appears as <code>schemaVersion</code> on the root of every JSON export.</p>
+
+<h2 id="invariants-this-schema-upholds">Invariants this schema upholds</h2>
+
+<ul>
+  <li><strong>I2 — never a fabricated dollar.</strong> A <code>usd</code>/<code>totalUsd</code>/<code>actualUsd</code> field is <code>null</code> (JSON) or an empty cell (CSV) whenever nothing priced; it is never <code>0</code> standing in for &quot;unknown&quot;. Token fields are always populated.</li>
+  <li><strong>I5 — byte-stable contract.</strong> Key order is fixed; the exporters build objects by hand rather than routing through <code>zod</code>, so output is deterministic.</li>
+  <li><strong>I6 — facts, not rankings.</strong> <code>compare</code> carries a factual <code>delta</code> line only — never a better/worse field.</li>
+</ul>
+
+<h2 id="json">JSON</h2>
+
+<p><code>aireceipts &lt;selector&gt; --json</code> prints one <code>receiptJsonSchema</code> object. <code>aireceipts compare &lt;a&gt; &lt;b&gt; --json</code> prints one <code>compareJsonSchema</code> object.</p>
+
+<h3 id="root-object-receiptjsonschema">Root object (<code>receiptJsonSchema</code>)</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>schemaVersion</code></td><td>number (literal <code>1</code>)</td><td>This schema's major version. Bumped only on a breaking change.</td></tr>
+    <tr><td><code>agentLabel</code></td><td>string</td><td>Human label for the agent, e.g. &quot;Claude Code&quot;.</td></tr>
+    <tr><td><code>source</code></td><td>enum</td><td>One of <code>claude-code</code>, <code>codex</code>, <code>cursor</code>.</td></tr>
+    <tr><td><code>sessionId</code></td><td>string</td><td>Adapter-local id (an absolute file path for file-based adapters).</td></tr>
+    <tr><td><code>title</code></td><td>string | null</td><td>Session title, or null when the adapter reports none.</td></tr>
+    <tr><td><code>startedAtMs</code></td><td>number | null</td><td>Session start, epoch milliseconds, or null.</td></tr>
+    <tr><td><code>durationMs</code></td><td>number | null</td><td>Wall-clock duration in milliseconds, or null.</td></tr>
+    <tr><td><code>unpriceable</code></td><td>boolean</td><td>True for degraded sources (Cursor) with no per-turn usage/model.</td></tr>
+    <tr><td><code>modelMix</code></td><td>array</td><td>Per-model token breakdown; see ModelMix entry. Empty when no turn carries a model.</td></tr>
+    <tr><td><code>toolRows</code></td><td>array</td><td>Per-tool cost/token rows; see ToolRow.</td></tr>
+    <tr><td><code>totalUsd</code></td><td>number | null</td><td>Total attributed cost, or null when nothing priced (I2).</td></tr>
+    <tr><td><code>totalTokens</code></td><td>TokenUsage</td><td>Attributed token totals.</td></tr>
+    <tr><td><code>sessionTotalTokens</code></td><td>TokenUsage</td><td>Adapter-reported session totals (the only real number for Cursor).</td></tr>
+    <tr><td><code>wasteLines</code></td><td>array</td><td>Fired waste findings; see WasteLine.</td></tr>
+    <tr><td><code>budget</code></td><td>array (optional)</td><td>Advisory budget lines (SPEC-0009); present only when <code>~/.aireceipts/budget.json</code> is configured.</td></tr>
+    <tr><td><code>priceDelta</code></td><td>PriceDelta | null</td><td>Cheapest-current-model arithmetic, or null in tokens-only mode.</td></tr>
+    <tr><td><code>methodology</code></td><td>string</td><td>The attribution methodology string (I3).</td></tr>
+    <tr><td><code>priceRowsUsed</code></td><td>array</td><td>Every dated price row consulted; see PriceRowUsed.</td></tr>
+  </tbody>
+</table></div>
+
+<h3 id="tokenusage-object">TokenUsage object</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>input</code></td><td>number</td><td>Input tokens.</td></tr>
+    <tr><td><code>output</code></td><td>number</td><td>Output tokens.</td></tr>
+    <tr><td><code>cacheRead</code></td><td>number</td><td>Tokens served from the prompt cache.</td></tr>
+    <tr><td><code>cacheCreation</code></td><td>number</td><td>Tokens written to the prompt cache (all TTL tiers).</td></tr>
+    <tr><td><code>cacheCreation5m</code></td><td>number | null</td><td>Subset billed at the 5-minute tier, or null when the transcript doesn't split it.</td></tr>
+    <tr><td><code>cacheCreation1h</code></td><td>number | null</td><td>Subset billed at the 1-hour tier, or null when unsplit.</td></tr>
+    <tr><td><code>total</code></td><td>number</td><td>Sum of all token classes.</td></tr>
+  </tbody>
+</table></div>
+
+<h3 id="modelmix-entry">ModelMix entry</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>model</code></td><td>string</td><td>Model id that served these tokens.</td></tr>
+    <tr><td><code>tokens</code></td><td>TokenUsage</td><td>Tokens attributed to this model.</td></tr>
+    <tr><td><code>tokenShare</code></td><td>number</td><td>0..1 share of the session's total tokens.</td></tr>
+  </tbody>
+</table></div>
+
+<h3 id="toolrow">ToolRow</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>tool</code></td><td>string</td><td>Tool name, or &quot;(thinking/reply)&quot; for tool-free turns.</td></tr>
+    <tr><td><code>usd</code></td><td>number | null</td><td>Cost attributed to this tool, or null when its turns never priced (I2).</td></tr>
+    <tr><td><code>callCount</code></td><td>number</td><td>Number of calls to this tool.</td></tr>
+  </tbody>
+</table></div>
+
+<h3 id="wasteline-discriminated-on-kind">WasteLine (discriminated on <code>kind</code>)</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>kind</code></td><td>enum</td><td><code>stuck-loop</code> or <code>trivial-spans</code>.</td></tr>
+    <tr><td><code>runLength</code></td><td>number</td><td>(stuck-loop) Consecutive identical calls.</td></tr>
+    <tr><td><code>wallClockMs</code></td><td>number | null</td><td>(stuck-loop) Wall-clock spent in the loop, or null.</td></tr>
+    <tr><td><code>eligibleTurnCount</code></td><td>number</td><td>(trivial-spans) Turns that could have used a cheaper model.</td></tr>
+    <tr><td><code>cheaperModel</code></td><td>string</td><td>(trivial-spans) The cheaper model the arithmetic used.</td></tr>
+  </tbody>
+</table></div>
+
+<p>Each variant also carries a <code>tool</code>/<code>usd</code>/<code>tokens</code> field as documented above.</p>
+
+<h3 id="pricedelta">PriceDelta</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>actualUsd</code></td><td>number</td><td>The session's real attributed cost.</td></tr>
+  </tbody>
+</table></div>
+
+<p>Also carries <code>cheaperModel</code> (the cheapest current model) and <code>usd</code> (the re-priced total).</p>
+
+<h3 id="pricerowused">PriceRowUsed</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>vendor</code></td><td>string</td><td>Price-table vendor.</td></tr>
+    <tr><td><code>input_cached</code></td><td>number | null</td><td>Cache-hit rate (USD per MTok), or null when the row cites none.</td></tr>
+    <tr><td><code>input_cache_write_5m</code></td><td>number | null</td><td>5-minute cache-write rate, or null.</td></tr>
+    <tr><td><code>input_cache_write_1h</code></td><td>number | null</td><td>1-hour cache-write rate, or null.</td></tr>
+    <tr><td><code>from_date</code></td><td>string</td><td>ISO date the row takes effect.</td></tr>
+    <tr><td><code>to_date</code></td><td>string | null</td><td>ISO date the row expires, or null when still current.</td></tr>
+    <tr><td><code>sources</code></td><td>array</td><td>Cited price sources; see PriceSource.</td></tr>
+  </tbody>
+</table></div>
+
+<p>Also carries <code>model</code>, <code>input</code>, and <code>output</code> (rates in USD per MTok) as documented above.</p>
+
+<h3 id="pricesource">PriceSource</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>url</code></td><td>string</td><td>Source URL.</td></tr>
+    <tr><td><code>observed_at</code></td><td>string | null</td><td>ISO date the price was observed, or null.</td></tr>
+    <tr><td><code>excerpt</code></td><td>string | null</td><td>Cited excerpt, or null.</td></tr>
+  </tbody>
+</table></div>
+
+<h3 id="compare-envelope-comparejsonschema">Compare envelope (<code>compareJsonSchema</code>)</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>a</code></td><td>Root body</td><td>First session's receipt body (Root object minus <code>schemaVersion</code>).</td></tr>
+    <tr><td><code>b</code></td><td>Root body</td><td>Second session's receipt body.</td></tr>
+    <tr><td><code>delta</code></td><td>string</td><td>Factual delta line — a cost/token ratio, never a ranking (I6).</td></tr>
+  </tbody>
+</table></div>
+
+<p><code>compare</code> also carries <code>schemaVersion</code> on its root.</p>
+
+<h2 id="csv">CSV</h2>
+
+<p>CSV is a flat projection of the same model for spreadsheets. <code>$</code> cells are an empty string when unpriced (never <code>0</code>); token cells are always populated. RFC 4180 quoting is applied (a cell containing <code>&quot;</code>, <code>,</code>, CR, or LF is quoted, embedded quotes doubled). Records are LF-terminated. Columns are <strong>additive-only</strong> within a schema major version — never reordered or removed. Every row's first column is <code>schemaVersion</code>.</p>
+
+<h3 id="-csvsession-default-and-compare-csv"><code>--csv=session</code> (default) and <code>compare --csv</code></h3>
+
+<p>One summary row per session. Columns:</p>
+
+<p><code>schemaVersion, sessionId, agent, title, startedAt, durationMs, primaryModel, totalUsd, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, totalTokens</code></p>
+
+<p><code>compare --csv</code> emits exactly two such rows plus a trailing <code>delta</code> column carrying the factual delta line on the first row (empty on the second) — <code>compare</code> accepts <code>--csv=session</code> only.</p>
+
+<h3 id="-csvtool"><code>--csv=tool</code></h3>
+
+<p>One row per tool line. Columns:</p>
+
+<p><code>schemaVersion, sessionId, agent, tool, usd, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, totalTokens, callCount</code></p>
+
+<h2 id="versioning-semver-discipline-r4">Versioning (semver discipline, R4)</h2>
+
+<ul>
+  <li>Any <strong>breaking</strong> change to a JSON shape (renamed/removed field, changed type or meaning) bumps <code>SCHEMA_VERSION</code>, and this document must be updated in the same change or the parity test fails the build.</li>
+  <li><strong>Additive</strong> changes (a new field, a new CSV column appended) do not bump the version.</li>
+  <li>CSV columns are additive-only within a major version.</li>
+</ul>
+
+<h2 id="weekly-digest-spec-0008-integration-point">Weekly digest (SPEC-0008 integration point)</h2>
+
+<p><code>week --json</code> (SPEC-0008's weekly digest) is not yet implemented on this branch. When it lands, it MUST wrap its payload with the same <code>schemaVersion</code> constant (<code>SCHEMA_VERSION</code> from <code>src/receipt/exportSchema.ts</code>) rather than inventing a second, undocumented shape (R5, single-source-of-truth). Add a <code>weekJsonSchema</code> alongside the existing schemas, document its fields inside the <code>json-fields</code> markers above, and the parity test will hold it to the same contract automatically.</p>
+    </article>
+  </main>
+  <footer>
+    <div class="close">
+      <div class="close-copy">
+        <p class="issued"><span>No account</span><span>No upload</span><span>Docs</span></p>
+        <p class="thanks">Thank you for your tokens.</p>
+        <p class="serial">AIRECEIPTS · NO. 0001</p>
+      </div>
+      <svg class="seal" viewBox="0 0 200 200" role="img" aria-label="A round vermillion seal reading RECEIPTED, SETTLED, and NO FABRICATED DOLLARS.">
+  <defs>
+    <path id="ring-top" d="M 30 100 A 70 70 0 0 1 170 100"/>
+    <path id="ring-bot" d="M 34 100 A 66 66 0 0 0 166 100"/>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <circle cx="100" cy="100" r="83" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700">
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-top" startOffset="50%">RECEIPTED</textPath></text>
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-bot" startOffset="50%">SETTLED</textPath></text>
+  </g>
+  <line x1="66" y1="70" x2="134" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="66" y1="130" x2="134" y2="130" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700" text-anchor="middle" letter-spacing="1.5">
+    <text x="100" y="91" font-size="15">NO</text>
+    <text x="100" y="106" font-size="13">FABRICATED</text>
+    <text x="100" y="121" font-size="15">DOLLARS</text>
+  </g>
+</svg>
+    </div>
+    <svg class="barcode" viewBox="0 0 90 34" width="180" height="30" fill="currentColor" role="img" aria-label="Barcode encoding the word aireceipts.">
+  <rect x="0" y="0" width="3" height="34"/><rect x="4" y="0" width="2" height="34"/><rect x="8" y="0" width="3" height="34"/><rect x="12" y="0" width="2" height="34"/><rect x="16" y="0" width="4" height="34"/><rect x="21" y="0" width="3" height="34"/><rect x="26" y="0" width="3" height="34"/><rect x="31" y="0" width="2" height="34"/><rect x="35" y="0" width="3" height="34"/><rect x="39" y="0" width="4" height="34"/><rect x="45" y="0" width="3" height="34"/><rect x="50" y="0" width="2" height="34"/><rect x="54" y="0" width="3" height="34"/><rect x="58" y="0" width="2" height="34"/><rect x="62" y="0" width="4" height="34"/><rect x="67" y="0" width="1" height="34"/><rect x="70" y="0" width="4" height="34"/><rect x="76" y="0" width="1" height="34"/><rect x="79" y="0" width="4" height="34"/><rect x="84" y="0" width="4" height="34"/>
+</svg>
+    <p class="flinks">
+      <a href="../index.html">Home</a><span class="sep" aria-hidden="true">·</span><a href="index.html">Docs</a><span class="sep" aria-hidden="true">·</span><span>Apache-2.0</span>
+    </p>
+    <p class="samosa">buy me a samosa</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/site/docs/pr-receipts.html
+++ b/site/docs/pr-receipts.html
@@ -1,0 +1,376 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PR receipts — attach the building session's receipt to a PR — aireceipts docs</title>
+<meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
+<meta name="theme-color" content="#e9edf0">
+<style>
+:root{
+  --field:#e7ecef;
+  --sheet:#ffffff;
+  --ink:#14181c;
+  --muted:#586570;
+  --faint:#8a949c;
+  --rule:#e3e8eb;
+  --rule-strong:#c2cbd1;
+  --seal:#b23a3a;
+  --ledger:#2f5d3a;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,"SF Mono","Cascadia Code","JetBrains Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;
+  background:var(--field);
+  color:var(--ink);
+  font-family:var(--sans);
+  font-size:16px;
+  line-height:1.6;
+  padding:clamp(16px,3.5vw,40px) 16px clamp(40px,6vw,72px);
+}
+a{color:var(--ledger);text-underline-offset:2px;text-decoration-thickness:1px}
+a:focus-visible{outline:2px solid var(--ledger);outline-offset:2px;border-radius:2px}
+.sheet{
+  width:100%;
+  max-width:1040px;
+  margin:0 auto;
+  background:var(--sheet);
+  border:1px solid var(--rule-strong);
+  border-radius:3px;
+  padding:clamp(20px,3.6vw,44px) clamp(18px,4vw,52px) clamp(28px,4vw,44px);
+  box-shadow:0 1px 0 #fff inset,0 30px 64px -42px rgba(20,32,44,.42);
+}
+header.mast{padding-top:2px}
+.masthead-row{
+  display:flex;
+  justify-content:space-between;
+  align-items:baseline;
+  gap:16px;
+  font-family:var(--sans);
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.masthead-row .brand{color:var(--ink);letter-spacing:.30em;text-decoration:none}
+.masthead-row nav{display:flex;gap:16px;flex-wrap:wrap;justify-content:flex-end}
+.masthead-row nav a{color:var(--muted);letter-spacing:.12em;text-decoration:none}
+.masthead-row nav a:hover{color:var(--ink)}
+.rule2{
+  margin:12px 0 0;
+  height:0;
+  border-top:3px solid var(--ink);
+  box-shadow:0 5px 0 -4px var(--ink);
+}
+.doc-hero{padding:clamp(24px,4vw,38px) 0 clamp(20px,3vw,30px)}
+.doc-label{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  margin:0 0 16px;
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.doc-label::after{content:"";flex:1 1 auto;height:1px;background:var(--rule-strong)}
+h1{
+  font-family:var(--serif);
+  font-size:clamp(30px,5vw,50px);
+  line-height:1.1;
+  font-weight:600;
+  letter-spacing:0;
+  margin:0;
+  max-width:19ch;
+}
+.sub{
+  color:var(--muted);
+  font-size:clamp(15px,2.2vw,17.5px);
+  max-width:58ch;
+  margin:15px 0 0;
+  line-height:1.55;
+}
+.doc-grid{
+  display:grid;
+  grid-template-columns:minmax(190px,240px) minmax(0,1fr);
+  gap:clamp(24px,4vw,46px);
+  border-top:1px solid var(--rule);
+  padding-top:clamp(24px,4vw,38px);
+}
+.toc{
+  align-self:start;
+  position:sticky;
+  top:18px;
+  border-right:1px solid var(--rule);
+  padding-right:20px;
+}
+.toc h2{
+  margin:0 0 12px;
+  color:var(--faint);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+}
+.toc ol,.toc ul{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+.toc a{color:var(--muted);font-size:14px;text-decoration:none}
+.toc a:hover{color:var(--ink);text-decoration:underline}
+.doc-content{min-width:0}
+.doc-content > :first-child{margin-top:0}
+.doc-content h1{font-size:clamp(28px,4vw,42px)}
+.doc-content h2{
+  margin:clamp(32px,4vw,44px) 0 12px;
+  padding-top:18px;
+  border-top:1px solid var(--rule);
+  font-family:var(--serif);
+  font-size:clamp(22px,3vw,30px);
+  line-height:1.2;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h3{
+  margin:28px 0 10px;
+  font-family:var(--serif);
+  font-size:21px;
+  line-height:1.25;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h4,.doc-content h5,.doc-content h6{margin:22px 0 8px;font-size:16px;line-height:1.35}
+.doc-content p{margin:0 0 16px;color:var(--ink)}
+.doc-content ul,.doc-content ol{margin:0 0 18px;padding-left:22px}
+.doc-content li{margin:7px 0}
+.doc-content blockquote{
+  margin:20px 0;
+  padding:14px 18px;
+  border-left:4px solid var(--ledger);
+  background:#f7f9fa;
+  color:var(--muted);
+}
+code{
+  font-family:var(--mono);
+  font-size:.92em;
+  background:#f6f8f9;
+  border:1px solid var(--rule);
+  border-radius:4px;
+  padding:.08em .32em;
+}
+pre.doc-code{
+  margin:18px 0;
+  overflow-x:auto;
+  max-width:100%;
+  background:#0f1518;
+  border:1px solid #1c272d;
+  border-radius:9px;
+  padding:14px 16px;
+  box-shadow:0 20px 44px -34px rgba(9,14,18,.9);
+}
+pre.doc-code code{
+  display:block;
+  background:transparent;
+  border:0;
+  border-radius:0;
+  padding:0;
+  color:#d6dde2;
+  font-size:13px;
+  line-height:1.5;
+}
+.table-wrap{overflow-x:auto;margin:18px 0;border:1px solid var(--rule-strong);border-radius:8px}
+table{width:100%;border-collapse:collapse;font-size:14px;min-width:560px}
+th,td{padding:10px 12px;border-bottom:1px solid var(--rule);vertical-align:top;text-align:left}
+th{background:#f6f8f9;color:var(--ink);font-weight:700}
+tr:last-child td{border-bottom:0}
+.doc-index-list{list-style:none;margin:0;padding:0;display:grid;gap:0;border-top:1px solid var(--rule)}
+.doc-index-list li{padding:18px 0;border-bottom:1px solid var(--rule)}
+.doc-index-list a{
+  display:inline-block;
+  font-family:var(--serif);
+  font-size:22px;
+  line-height:1.2;
+  font-weight:600;
+}
+.doc-index-list .path{
+  display:block;
+  margin-top:4px;
+  color:var(--faint);
+  font-family:var(--mono);
+  font-size:12px;
+}
+.doc-index-list p{margin:8px 0 0;color:var(--muted);max-width:70ch}
+footer{
+  border-top:1px solid var(--rule);
+  margin-top:clamp(34px,5vw,52px);
+  padding-top:clamp(26px,4vw,34px);
+}
+.close{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  gap:20px;
+  flex-wrap:wrap;
+}
+.close-copy{max-width:34ch}
+.issued{
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  color:var(--faint);
+  display:flex;
+  gap:18px;
+  flex-wrap:wrap;
+  margin:0 0 14px;
+}
+.thanks{
+  font-family:var(--serif);
+  font-size:19px;
+  font-weight:600;
+  color:var(--ink);
+  margin:0 0 10px;
+}
+.serial{
+  font-family:var(--mono);
+  font-size:10.5px;
+  letter-spacing:.34em;
+  color:var(--faint);
+  margin:0;
+  padding-left:.34em;
+}
+.seal{flex:0 0 auto;width:clamp(104px,17vw,128px);height:auto;color:var(--seal);transform:rotate(-5deg)}
+.barcode{color:var(--rule-strong);height:30px;display:block;margin:24px 0 8px}
+.flinks{font-size:14px;color:var(--muted);line-height:2}
+.flinks a{color:var(--ledger)}
+.flinks .sep{color:var(--rule-strong);padding:0 .6ch}
+.samosa{color:var(--muted);margin:10px 0 0;font-size:13.5px}
+@media (max-width:760px){
+  .doc-grid{grid-template-columns:minmax(0,1fr)}
+  .toc{position:static;border-right:0;border-bottom:1px solid var(--rule);padding:0 0 18px}
+}
+@media (max-width:480px){
+  .masthead-row{letter-spacing:.16em;align-items:flex-start}
+  .masthead-row nav{gap:10px}
+  .close{flex-direction:column-reverse;align-items:flex-start}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important}
+}
+</style>
+</head>
+<body>
+<div class="sheet">
+  <header class="mast">
+    <div class="masthead-row">
+      <a class="brand" href="../index.html">AIRECEIPTS</a>
+      <nav aria-label="Primary">
+        <a href="../index.html">Home</a>
+        <a href="index.html">Docs</a>
+      </nav>
+    </div>
+    <div class="rule2" aria-hidden="true"></div>
+    <div class="doc-hero">
+      <p class="doc-label">Docs ledger</p>
+      <h1>PR receipts — attach the building session's receipt to a PR</h1>
+      <p class="sub">Rendered from <code>docs/pr-receipts.md</code>.</p>
+    </div>
+  </header>
+  <main class="doc-grid">
+    <aside class="toc" aria-label="Docs contents">
+      <h2>Contents</h2>
+      <ol>
+<li><a href="harness.html">The harness — how this repo builds itself</a></li>
+<li><a href="hygiene-fp-log.html">Hygiene False-Positive Log</a></li>
+<li><a href="json-schema.html">Export schema (--json / --csv)</a></li>
+<li><a href="pr-receipts.html">PR receipts — attach the building session's receipt to a PR</a></li>
+<li><a href="statusline.html">Statusline</a></li>
+<li><a href="telemetry.html">Diagnostics telemetry</a></li>
+      </ol>
+    </aside>
+    <article class="doc-content">
+<h1 id="pr-receipts-attach-the-building-sessions-receipt-to-a-pr">PR receipts — attach the building session's receipt to a PR</h1>
+
+<p><code>aireceipts pr</code> attaches the cost receipt of the AI-agent session that built a branch to that branch's pull request, as a single marked comment that stays current across pushes. Transcripts live on the developer's machine, never on the CI runner — so generation is local, and CI only <em>notices</em> when a PR is missing its receipt.</p>
+
+<h2 id="for-contributors-30-seconds">For contributors (30 seconds)</h2>
+
+<p>From your checkout (or worktree) with the PR branch checked out:</p>
+
+<pre class="doc-code"><code class="language-sh">npx aireceipts pr            # dry-run: prints the exact comment body to stdout
+npx aireceipts pr --post     # upserts the receipt comment on the PR via gh</code></pre>
+
+<p><code>--post</code> requires the <a href="https://cli.github.com/"><code>gh</code> CLI</a> authenticated to your repo (<code>gh auth login</code>); no other tokens or servers are involved. Re-running after more commits edits the same comment in place — no comment spam. If auto-selection finds more than one matching session (or you want a specific one), pass <code>--session &lt;id&gt;</code> (an id from <code>aireceipts --list</code>).</p>
+
+<p>Prefer a git alias so it runs itself:</p>
+
+<pre class="doc-code"><code class="language-sh">git config alias.receipt '!npx aireceipts pr --post'
+git receipt                  # after pushing your branch</code></pre>
+
+<p>The receipt always prints to stdout first, so even with no <code>gh</code> or no PR yet you can copy the body straight into a comment.</p>
+
+<h2 id="for-maintainers-repo-integration-5-minutes">For maintainers (repo integration, 5 minutes)</h2>
+
+<ol>
+  <li>Copy one workflow file into your repo: <code>.github/workflows/pr-receipt-check.yml</code> (the thin caller that runs <code>scripts/check-pr-receipt.mjs</code> — copy that script too).</li>
+  <li>Add one line to <code>CONTRIBUTING.md</code>:</li>
+</ol>
+
+<p>&gt; Before opening a PR, run <code>npx aireceipts pr --post</code> to attach your build receipt.</p>
+
+<p>That's it. The workflow emits a neutral <code>::notice</code> when a PR has no receipt comment and <strong>never fails the build</strong> — external contributors have no local sessions and must not be blocked.</p>
+
+<h2 id="what-the-comment-contains">What the comment contains</h2>
+
+<ul>
+  <li>A marker line (<code>&lt;!-- aireceipts-dogfood --&gt;</code>) so the upsert and the CI check can find exactly one comment to keep current.</li>
+  <li>A <code>🧾 aireceipts — session &lt;id&gt;</code> header and a fenced receipt.</li>
+  <li>A slice header: <code>session slice: turns A–B of N</code> when the PR's work is isolated to a commit window, or <code>entire session (slice unavailable)</code> when it can't be cut cleanly (ambiguity is labeled, never presented as PR cost).</li>
+  <li>A <code>SUBAGENTS</code> section rolling up any subagent sessions the PR's work launched, with a combined total.</li>
+</ul>
+
+<h2 id="how-a-session-is-matched-to-a-pr">How a session is matched to a PR</h2>
+
+<p>Auto-selection (no <code>--session</code>) picks the session whose working directory is inside one of this repo's worktrees <strong>and</strong> whose time window overlaps the branch's commit window. Zero matches or more than one → <code>aireceipts pr</code> refuses to guess and asks for <code>--session &lt;id&gt;</code>. The <code>cwd</code>/branch used for matching are attribution-only: they never enter the rendered receipt, <code>--json</code>/<code>--csv</code>, or telemetry.</p>
+    </article>
+  </main>
+  <footer>
+    <div class="close">
+      <div class="close-copy">
+        <p class="issued"><span>No account</span><span>No upload</span><span>Docs</span></p>
+        <p class="thanks">Thank you for your tokens.</p>
+        <p class="serial">AIRECEIPTS · NO. 0001</p>
+      </div>
+      <svg class="seal" viewBox="0 0 200 200" role="img" aria-label="A round vermillion seal reading RECEIPTED, SETTLED, and NO FABRICATED DOLLARS.">
+  <defs>
+    <path id="ring-top" d="M 30 100 A 70 70 0 0 1 170 100"/>
+    <path id="ring-bot" d="M 34 100 A 66 66 0 0 0 166 100"/>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <circle cx="100" cy="100" r="83" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700">
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-top" startOffset="50%">RECEIPTED</textPath></text>
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-bot" startOffset="50%">SETTLED</textPath></text>
+  </g>
+  <line x1="66" y1="70" x2="134" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="66" y1="130" x2="134" y2="130" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700" text-anchor="middle" letter-spacing="1.5">
+    <text x="100" y="91" font-size="15">NO</text>
+    <text x="100" y="106" font-size="13">FABRICATED</text>
+    <text x="100" y="121" font-size="15">DOLLARS</text>
+  </g>
+</svg>
+    </div>
+    <svg class="barcode" viewBox="0 0 90 34" width="180" height="30" fill="currentColor" role="img" aria-label="Barcode encoding the word aireceipts.">
+  <rect x="0" y="0" width="3" height="34"/><rect x="4" y="0" width="2" height="34"/><rect x="8" y="0" width="3" height="34"/><rect x="12" y="0" width="2" height="34"/><rect x="16" y="0" width="4" height="34"/><rect x="21" y="0" width="3" height="34"/><rect x="26" y="0" width="3" height="34"/><rect x="31" y="0" width="2" height="34"/><rect x="35" y="0" width="3" height="34"/><rect x="39" y="0" width="4" height="34"/><rect x="45" y="0" width="3" height="34"/><rect x="50" y="0" width="2" height="34"/><rect x="54" y="0" width="3" height="34"/><rect x="58" y="0" width="2" height="34"/><rect x="62" y="0" width="4" height="34"/><rect x="67" y="0" width="1" height="34"/><rect x="70" y="0" width="4" height="34"/><rect x="76" y="0" width="1" height="34"/><rect x="79" y="0" width="4" height="34"/><rect x="84" y="0" width="4" height="34"/>
+</svg>
+    <p class="flinks">
+      <a href="../index.html">Home</a><span class="sep" aria-hidden="true">·</span><a href="index.html">Docs</a><span class="sep" aria-hidden="true">·</span><span>Apache-2.0</span>
+    </p>
+    <p class="samosa">buy me a samosa</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/site/docs/statusline.html
+++ b/site/docs/statusline.html
@@ -1,0 +1,370 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Statusline — aireceipts docs</title>
+<meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
+<meta name="theme-color" content="#e9edf0">
+<style>
+:root{
+  --field:#e7ecef;
+  --sheet:#ffffff;
+  --ink:#14181c;
+  --muted:#586570;
+  --faint:#8a949c;
+  --rule:#e3e8eb;
+  --rule-strong:#c2cbd1;
+  --seal:#b23a3a;
+  --ledger:#2f5d3a;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,"SF Mono","Cascadia Code","JetBrains Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;
+  background:var(--field);
+  color:var(--ink);
+  font-family:var(--sans);
+  font-size:16px;
+  line-height:1.6;
+  padding:clamp(16px,3.5vw,40px) 16px clamp(40px,6vw,72px);
+}
+a{color:var(--ledger);text-underline-offset:2px;text-decoration-thickness:1px}
+a:focus-visible{outline:2px solid var(--ledger);outline-offset:2px;border-radius:2px}
+.sheet{
+  width:100%;
+  max-width:1040px;
+  margin:0 auto;
+  background:var(--sheet);
+  border:1px solid var(--rule-strong);
+  border-radius:3px;
+  padding:clamp(20px,3.6vw,44px) clamp(18px,4vw,52px) clamp(28px,4vw,44px);
+  box-shadow:0 1px 0 #fff inset,0 30px 64px -42px rgba(20,32,44,.42);
+}
+header.mast{padding-top:2px}
+.masthead-row{
+  display:flex;
+  justify-content:space-between;
+  align-items:baseline;
+  gap:16px;
+  font-family:var(--sans);
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.masthead-row .brand{color:var(--ink);letter-spacing:.30em;text-decoration:none}
+.masthead-row nav{display:flex;gap:16px;flex-wrap:wrap;justify-content:flex-end}
+.masthead-row nav a{color:var(--muted);letter-spacing:.12em;text-decoration:none}
+.masthead-row nav a:hover{color:var(--ink)}
+.rule2{
+  margin:12px 0 0;
+  height:0;
+  border-top:3px solid var(--ink);
+  box-shadow:0 5px 0 -4px var(--ink);
+}
+.doc-hero{padding:clamp(24px,4vw,38px) 0 clamp(20px,3vw,30px)}
+.doc-label{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  margin:0 0 16px;
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.doc-label::after{content:"";flex:1 1 auto;height:1px;background:var(--rule-strong)}
+h1{
+  font-family:var(--serif);
+  font-size:clamp(30px,5vw,50px);
+  line-height:1.1;
+  font-weight:600;
+  letter-spacing:0;
+  margin:0;
+  max-width:19ch;
+}
+.sub{
+  color:var(--muted);
+  font-size:clamp(15px,2.2vw,17.5px);
+  max-width:58ch;
+  margin:15px 0 0;
+  line-height:1.55;
+}
+.doc-grid{
+  display:grid;
+  grid-template-columns:minmax(190px,240px) minmax(0,1fr);
+  gap:clamp(24px,4vw,46px);
+  border-top:1px solid var(--rule);
+  padding-top:clamp(24px,4vw,38px);
+}
+.toc{
+  align-self:start;
+  position:sticky;
+  top:18px;
+  border-right:1px solid var(--rule);
+  padding-right:20px;
+}
+.toc h2{
+  margin:0 0 12px;
+  color:var(--faint);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+}
+.toc ol,.toc ul{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+.toc a{color:var(--muted);font-size:14px;text-decoration:none}
+.toc a:hover{color:var(--ink);text-decoration:underline}
+.doc-content{min-width:0}
+.doc-content > :first-child{margin-top:0}
+.doc-content h1{font-size:clamp(28px,4vw,42px)}
+.doc-content h2{
+  margin:clamp(32px,4vw,44px) 0 12px;
+  padding-top:18px;
+  border-top:1px solid var(--rule);
+  font-family:var(--serif);
+  font-size:clamp(22px,3vw,30px);
+  line-height:1.2;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h3{
+  margin:28px 0 10px;
+  font-family:var(--serif);
+  font-size:21px;
+  line-height:1.25;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h4,.doc-content h5,.doc-content h6{margin:22px 0 8px;font-size:16px;line-height:1.35}
+.doc-content p{margin:0 0 16px;color:var(--ink)}
+.doc-content ul,.doc-content ol{margin:0 0 18px;padding-left:22px}
+.doc-content li{margin:7px 0}
+.doc-content blockquote{
+  margin:20px 0;
+  padding:14px 18px;
+  border-left:4px solid var(--ledger);
+  background:#f7f9fa;
+  color:var(--muted);
+}
+code{
+  font-family:var(--mono);
+  font-size:.92em;
+  background:#f6f8f9;
+  border:1px solid var(--rule);
+  border-radius:4px;
+  padding:.08em .32em;
+}
+pre.doc-code{
+  margin:18px 0;
+  overflow-x:auto;
+  max-width:100%;
+  background:#0f1518;
+  border:1px solid #1c272d;
+  border-radius:9px;
+  padding:14px 16px;
+  box-shadow:0 20px 44px -34px rgba(9,14,18,.9);
+}
+pre.doc-code code{
+  display:block;
+  background:transparent;
+  border:0;
+  border-radius:0;
+  padding:0;
+  color:#d6dde2;
+  font-size:13px;
+  line-height:1.5;
+}
+.table-wrap{overflow-x:auto;margin:18px 0;border:1px solid var(--rule-strong);border-radius:8px}
+table{width:100%;border-collapse:collapse;font-size:14px;min-width:560px}
+th,td{padding:10px 12px;border-bottom:1px solid var(--rule);vertical-align:top;text-align:left}
+th{background:#f6f8f9;color:var(--ink);font-weight:700}
+tr:last-child td{border-bottom:0}
+.doc-index-list{list-style:none;margin:0;padding:0;display:grid;gap:0;border-top:1px solid var(--rule)}
+.doc-index-list li{padding:18px 0;border-bottom:1px solid var(--rule)}
+.doc-index-list a{
+  display:inline-block;
+  font-family:var(--serif);
+  font-size:22px;
+  line-height:1.2;
+  font-weight:600;
+}
+.doc-index-list .path{
+  display:block;
+  margin-top:4px;
+  color:var(--faint);
+  font-family:var(--mono);
+  font-size:12px;
+}
+.doc-index-list p{margin:8px 0 0;color:var(--muted);max-width:70ch}
+footer{
+  border-top:1px solid var(--rule);
+  margin-top:clamp(34px,5vw,52px);
+  padding-top:clamp(26px,4vw,34px);
+}
+.close{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  gap:20px;
+  flex-wrap:wrap;
+}
+.close-copy{max-width:34ch}
+.issued{
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  color:var(--faint);
+  display:flex;
+  gap:18px;
+  flex-wrap:wrap;
+  margin:0 0 14px;
+}
+.thanks{
+  font-family:var(--serif);
+  font-size:19px;
+  font-weight:600;
+  color:var(--ink);
+  margin:0 0 10px;
+}
+.serial{
+  font-family:var(--mono);
+  font-size:10.5px;
+  letter-spacing:.34em;
+  color:var(--faint);
+  margin:0;
+  padding-left:.34em;
+}
+.seal{flex:0 0 auto;width:clamp(104px,17vw,128px);height:auto;color:var(--seal);transform:rotate(-5deg)}
+.barcode{color:var(--rule-strong);height:30px;display:block;margin:24px 0 8px}
+.flinks{font-size:14px;color:var(--muted);line-height:2}
+.flinks a{color:var(--ledger)}
+.flinks .sep{color:var(--rule-strong);padding:0 .6ch}
+.samosa{color:var(--muted);margin:10px 0 0;font-size:13.5px}
+@media (max-width:760px){
+  .doc-grid{grid-template-columns:minmax(0,1fr)}
+  .toc{position:static;border-right:0;border-bottom:1px solid var(--rule);padding:0 0 18px}
+}
+@media (max-width:480px){
+  .masthead-row{letter-spacing:.16em;align-items:flex-start}
+  .masthead-row nav{gap:10px}
+  .close{flex-direction:column-reverse;align-items:flex-start}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important}
+}
+</style>
+</head>
+<body>
+<div class="sheet">
+  <header class="mast">
+    <div class="masthead-row">
+      <a class="brand" href="../index.html">AIRECEIPTS</a>
+      <nav aria-label="Primary">
+        <a href="../index.html">Home</a>
+        <a href="index.html">Docs</a>
+      </nav>
+    </div>
+    <div class="rule2" aria-hidden="true"></div>
+    <div class="doc-hero">
+      <p class="doc-label">Docs ledger</p>
+      <h1>Statusline</h1>
+      <p class="sub">Rendered from <code>docs/statusline.md</code>.</p>
+    </div>
+  </header>
+  <main class="doc-grid">
+    <aside class="toc" aria-label="Docs contents">
+      <h2>Contents</h2>
+      <ol>
+<li><a href="harness.html">The harness — how this repo builds itself</a></li>
+<li><a href="hygiene-fp-log.html">Hygiene False-Positive Log</a></li>
+<li><a href="json-schema.html">Export schema (--json / --csv)</a></li>
+<li><a href="pr-receipts.html">PR receipts — attach the building session's receipt to a PR</a></li>
+<li><a href="statusline.html">Statusline</a></li>
+<li><a href="telemetry.html">Diagnostics telemetry</a></li>
+      </ol>
+    </aside>
+    <article class="doc-content">
+<h1 id="statusline">Statusline</h1>
+
+<p><code>aireceipts statusline</code> prints one line — the last-completed session's cost (or tokens, if unpriced) plus a waste flag if one fired — meant for Claude Code's <code>statusLine</code> command config, so a number is visible on every prompt without running <code>aireceipts</code> manually.</p>
+
+<h2 id="setup">Setup</h2>
+
+<p>Add a <code>statusLine</code> entry to your Claude Code <code>settings.json</code> (global: <code>~/.claude/settings.json</code>, or project-local: <code>.claude/settings.json</code>):</p>
+
+<pre class="doc-code"><code class="language-json">{
+  &quot;statusLine&quot;: {
+    &quot;type&quot;: &quot;command&quot;,
+    &quot;command&quot;: &quot;aireceipts statusline&quot;
+  }
+}</code></pre>
+
+<p>Claude Code invokes this command on its own schedule and pipes a JSON payload (including <code>transcript_path</code> for the active session) on stdin. <code>aireceipts</code> reads that payload, loads the referenced transcript directly, and prints one line — no polling, no background process, no daemon.</p>
+
+<p>If <code>aireceipts</code> isn't on your <code>PATH</code>, use an absolute path to the binary instead of <code>aireceipts</code> in the <code>command</code> field (for example, the output of <code>which aireceipts</code>).</p>
+
+<h2 id="output">Output</h2>
+
+<pre class="doc-code"><code>[Claude Code] $1.23 · 12k tok
+[Claude Code] $2.50 · 20k tok · ⚠ Bash loop ×5
+[Cursor] 8k tok</code></pre>
+
+<ul>
+  <li><code>$X.XX · Nk tok</code> when the session's cost is priced; <code>Nk tok</code> only when it isn't (never a fabricated <code>$</code> amount).</li>
+  <li>The waste flag (<code>⚠ ...</code>) appears only when a waste detector actually fired on the session — its absence is not itself a claim that nothing was found.</li>
+  <li>Outside a piped invocation (or when stdin carries no usable payload), <code>aireceipts statusline</code> falls back to the most-recently-ended session found on disk. If no sessions are detected at all, it prints a neutral placeholder line rather than an error, so the statusline layout never breaks.</li>
+</ul>
+
+<h2 id="notes">Notes</h2>
+
+<ul>
+  <li>One line, one on-disk read per invocation — this is a snapshot, not a live view. Nothing streams mid-session (see the CLI's non-goals).</li>
+  <li>Sessions that can't be priced (missing price rows) render tokens-only — <code>aireceipts</code> never estimates a dollar figure it can't source to a price row.</li>
+</ul>
+    </article>
+  </main>
+  <footer>
+    <div class="close">
+      <div class="close-copy">
+        <p class="issued"><span>No account</span><span>No upload</span><span>Docs</span></p>
+        <p class="thanks">Thank you for your tokens.</p>
+        <p class="serial">AIRECEIPTS · NO. 0001</p>
+      </div>
+      <svg class="seal" viewBox="0 0 200 200" role="img" aria-label="A round vermillion seal reading RECEIPTED, SETTLED, and NO FABRICATED DOLLARS.">
+  <defs>
+    <path id="ring-top" d="M 30 100 A 70 70 0 0 1 170 100"/>
+    <path id="ring-bot" d="M 34 100 A 66 66 0 0 0 166 100"/>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <circle cx="100" cy="100" r="83" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700">
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-top" startOffset="50%">RECEIPTED</textPath></text>
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-bot" startOffset="50%">SETTLED</textPath></text>
+  </g>
+  <line x1="66" y1="70" x2="134" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="66" y1="130" x2="134" y2="130" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700" text-anchor="middle" letter-spacing="1.5">
+    <text x="100" y="91" font-size="15">NO</text>
+    <text x="100" y="106" font-size="13">FABRICATED</text>
+    <text x="100" y="121" font-size="15">DOLLARS</text>
+  </g>
+</svg>
+    </div>
+    <svg class="barcode" viewBox="0 0 90 34" width="180" height="30" fill="currentColor" role="img" aria-label="Barcode encoding the word aireceipts.">
+  <rect x="0" y="0" width="3" height="34"/><rect x="4" y="0" width="2" height="34"/><rect x="8" y="0" width="3" height="34"/><rect x="12" y="0" width="2" height="34"/><rect x="16" y="0" width="4" height="34"/><rect x="21" y="0" width="3" height="34"/><rect x="26" y="0" width="3" height="34"/><rect x="31" y="0" width="2" height="34"/><rect x="35" y="0" width="3" height="34"/><rect x="39" y="0" width="4" height="34"/><rect x="45" y="0" width="3" height="34"/><rect x="50" y="0" width="2" height="34"/><rect x="54" y="0" width="3" height="34"/><rect x="58" y="0" width="2" height="34"/><rect x="62" y="0" width="4" height="34"/><rect x="67" y="0" width="1" height="34"/><rect x="70" y="0" width="4" height="34"/><rect x="76" y="0" width="1" height="34"/><rect x="79" y="0" width="4" height="34"/><rect x="84" y="0" width="4" height="34"/>
+</svg>
+    <p class="flinks">
+      <a href="../index.html">Home</a><span class="sep" aria-hidden="true">·</span><a href="index.html">Docs</a><span class="sep" aria-hidden="true">·</span><span>Apache-2.0</span>
+    </p>
+    <p class="samosa">buy me a samosa</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -1,0 +1,451 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Diagnostics telemetry — aireceipts docs</title>
+<meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
+<meta name="theme-color" content="#e9edf0">
+<style>
+:root{
+  --field:#e7ecef;
+  --sheet:#ffffff;
+  --ink:#14181c;
+  --muted:#586570;
+  --faint:#8a949c;
+  --rule:#e3e8eb;
+  --rule-strong:#c2cbd1;
+  --seal:#b23a3a;
+  --ledger:#2f5d3a;
+  --serif:"Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,"Times New Roman",serif;
+  --sans:system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  --mono:ui-monospace,"SF Mono","Cascadia Code","JetBrains Mono",Menlo,Consolas,monospace;
+}
+*{box-sizing:border-box}
+html{-webkit-text-size-adjust:100%}
+body{
+  margin:0;
+  background:var(--field);
+  color:var(--ink);
+  font-family:var(--sans);
+  font-size:16px;
+  line-height:1.6;
+  padding:clamp(16px,3.5vw,40px) 16px clamp(40px,6vw,72px);
+}
+a{color:var(--ledger);text-underline-offset:2px;text-decoration-thickness:1px}
+a:focus-visible{outline:2px solid var(--ledger);outline-offset:2px;border-radius:2px}
+.sheet{
+  width:100%;
+  max-width:1040px;
+  margin:0 auto;
+  background:var(--sheet);
+  border:1px solid var(--rule-strong);
+  border-radius:3px;
+  padding:clamp(20px,3.6vw,44px) clamp(18px,4vw,52px) clamp(28px,4vw,44px);
+  box-shadow:0 1px 0 #fff inset,0 30px 64px -42px rgba(20,32,44,.42);
+}
+header.mast{padding-top:2px}
+.masthead-row{
+  display:flex;
+  justify-content:space-between;
+  align-items:baseline;
+  gap:16px;
+  font-family:var(--sans);
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.26em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.masthead-row .brand{color:var(--ink);letter-spacing:.30em;text-decoration:none}
+.masthead-row nav{display:flex;gap:16px;flex-wrap:wrap;justify-content:flex-end}
+.masthead-row nav a{color:var(--muted);letter-spacing:.12em;text-decoration:none}
+.masthead-row nav a:hover{color:var(--ink)}
+.rule2{
+  margin:12px 0 0;
+  height:0;
+  border-top:3px solid var(--ink);
+  box-shadow:0 5px 0 -4px var(--ink);
+}
+.doc-hero{padding:clamp(24px,4vw,38px) 0 clamp(20px,3vw,30px)}
+.doc-label{
+  display:flex;
+  align-items:center;
+  gap:14px;
+  margin:0 0 16px;
+  font-size:11.5px;
+  font-weight:700;
+  letter-spacing:.22em;
+  text-transform:uppercase;
+  color:var(--faint);
+}
+.doc-label::after{content:"";flex:1 1 auto;height:1px;background:var(--rule-strong)}
+h1{
+  font-family:var(--serif);
+  font-size:clamp(30px,5vw,50px);
+  line-height:1.1;
+  font-weight:600;
+  letter-spacing:0;
+  margin:0;
+  max-width:19ch;
+}
+.sub{
+  color:var(--muted);
+  font-size:clamp(15px,2.2vw,17.5px);
+  max-width:58ch;
+  margin:15px 0 0;
+  line-height:1.55;
+}
+.doc-grid{
+  display:grid;
+  grid-template-columns:minmax(190px,240px) minmax(0,1fr);
+  gap:clamp(24px,4vw,46px);
+  border-top:1px solid var(--rule);
+  padding-top:clamp(24px,4vw,38px);
+}
+.toc{
+  align-self:start;
+  position:sticky;
+  top:18px;
+  border-right:1px solid var(--rule);
+  padding-right:20px;
+}
+.toc h2{
+  margin:0 0 12px;
+  color:var(--faint);
+  font-size:11px;
+  letter-spacing:.18em;
+  text-transform:uppercase;
+}
+.toc ol,.toc ul{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+.toc a{color:var(--muted);font-size:14px;text-decoration:none}
+.toc a:hover{color:var(--ink);text-decoration:underline}
+.doc-content{min-width:0}
+.doc-content > :first-child{margin-top:0}
+.doc-content h1{font-size:clamp(28px,4vw,42px)}
+.doc-content h2{
+  margin:clamp(32px,4vw,44px) 0 12px;
+  padding-top:18px;
+  border-top:1px solid var(--rule);
+  font-family:var(--serif);
+  font-size:clamp(22px,3vw,30px);
+  line-height:1.2;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h3{
+  margin:28px 0 10px;
+  font-family:var(--serif);
+  font-size:21px;
+  line-height:1.25;
+  font-weight:600;
+  letter-spacing:0;
+}
+.doc-content h4,.doc-content h5,.doc-content h6{margin:22px 0 8px;font-size:16px;line-height:1.35}
+.doc-content p{margin:0 0 16px;color:var(--ink)}
+.doc-content ul,.doc-content ol{margin:0 0 18px;padding-left:22px}
+.doc-content li{margin:7px 0}
+.doc-content blockquote{
+  margin:20px 0;
+  padding:14px 18px;
+  border-left:4px solid var(--ledger);
+  background:#f7f9fa;
+  color:var(--muted);
+}
+code{
+  font-family:var(--mono);
+  font-size:.92em;
+  background:#f6f8f9;
+  border:1px solid var(--rule);
+  border-radius:4px;
+  padding:.08em .32em;
+}
+pre.doc-code{
+  margin:18px 0;
+  overflow-x:auto;
+  max-width:100%;
+  background:#0f1518;
+  border:1px solid #1c272d;
+  border-radius:9px;
+  padding:14px 16px;
+  box-shadow:0 20px 44px -34px rgba(9,14,18,.9);
+}
+pre.doc-code code{
+  display:block;
+  background:transparent;
+  border:0;
+  border-radius:0;
+  padding:0;
+  color:#d6dde2;
+  font-size:13px;
+  line-height:1.5;
+}
+.table-wrap{overflow-x:auto;margin:18px 0;border:1px solid var(--rule-strong);border-radius:8px}
+table{width:100%;border-collapse:collapse;font-size:14px;min-width:560px}
+th,td{padding:10px 12px;border-bottom:1px solid var(--rule);vertical-align:top;text-align:left}
+th{background:#f6f8f9;color:var(--ink);font-weight:700}
+tr:last-child td{border-bottom:0}
+.doc-index-list{list-style:none;margin:0;padding:0;display:grid;gap:0;border-top:1px solid var(--rule)}
+.doc-index-list li{padding:18px 0;border-bottom:1px solid var(--rule)}
+.doc-index-list a{
+  display:inline-block;
+  font-family:var(--serif);
+  font-size:22px;
+  line-height:1.2;
+  font-weight:600;
+}
+.doc-index-list .path{
+  display:block;
+  margin-top:4px;
+  color:var(--faint);
+  font-family:var(--mono);
+  font-size:12px;
+}
+.doc-index-list p{margin:8px 0 0;color:var(--muted);max-width:70ch}
+footer{
+  border-top:1px solid var(--rule);
+  margin-top:clamp(34px,5vw,52px);
+  padding-top:clamp(26px,4vw,34px);
+}
+.close{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-end;
+  gap:20px;
+  flex-wrap:wrap;
+}
+.close-copy{max-width:34ch}
+.issued{
+  font-size:11px;
+  font-weight:700;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  color:var(--faint);
+  display:flex;
+  gap:18px;
+  flex-wrap:wrap;
+  margin:0 0 14px;
+}
+.thanks{
+  font-family:var(--serif);
+  font-size:19px;
+  font-weight:600;
+  color:var(--ink);
+  margin:0 0 10px;
+}
+.serial{
+  font-family:var(--mono);
+  font-size:10.5px;
+  letter-spacing:.34em;
+  color:var(--faint);
+  margin:0;
+  padding-left:.34em;
+}
+.seal{flex:0 0 auto;width:clamp(104px,17vw,128px);height:auto;color:var(--seal);transform:rotate(-5deg)}
+.barcode{color:var(--rule-strong);height:30px;display:block;margin:24px 0 8px}
+.flinks{font-size:14px;color:var(--muted);line-height:2}
+.flinks a{color:var(--ledger)}
+.flinks .sep{color:var(--rule-strong);padding:0 .6ch}
+.samosa{color:var(--muted);margin:10px 0 0;font-size:13.5px}
+@media (max-width:760px){
+  .doc-grid{grid-template-columns:minmax(0,1fr)}
+  .toc{position:static;border-right:0;border-bottom:1px solid var(--rule);padding:0 0 18px}
+}
+@media (max-width:480px){
+  .masthead-row{letter-spacing:.16em;align-items:flex-start}
+  .masthead-row nav{gap:10px}
+  .close{flex-direction:column-reverse;align-items:flex-start}
+}
+@media (prefers-reduced-motion:reduce){
+  *{transition:none!important;animation:none!important}
+}
+</style>
+</head>
+<body>
+<div class="sheet">
+  <header class="mast">
+    <div class="masthead-row">
+      <a class="brand" href="../index.html">AIRECEIPTS</a>
+      <nav aria-label="Primary">
+        <a href="../index.html">Home</a>
+        <a href="index.html">Docs</a>
+      </nav>
+    </div>
+    <div class="rule2" aria-hidden="true"></div>
+    <div class="doc-hero">
+      <p class="doc-label">Docs ledger</p>
+      <h1>Diagnostics telemetry</h1>
+      <p class="sub">Rendered from <code>docs/telemetry.md</code>.</p>
+    </div>
+  </header>
+  <main class="doc-grid">
+    <aside class="toc" aria-label="Docs contents">
+      <h2>Contents</h2>
+      <ol>
+<li><a href="harness.html">The harness — how this repo builds itself</a></li>
+<li><a href="hygiene-fp-log.html">Hygiene False-Positive Log</a></li>
+<li><a href="json-schema.html">Export schema (--json / --csv)</a></li>
+<li><a href="pr-receipts.html">PR receipts — attach the building session's receipt to a PR</a></li>
+<li><a href="statusline.html">Statusline</a></li>
+<li><a href="telemetry.html">Diagnostics telemetry</a></li>
+      </ol>
+    </aside>
+    <article class="doc-content">
+<h1 id="diagnostics-telemetry">Diagnostics telemetry</h1>
+
+<p><code>aireceipts</code> can send small, anonymous, content-free diagnostics events to help us find bugs and understand which agent formats and CLI paths are actually used in the wild. This document is the full, authoritative description of what is sent, when, and how to turn it off. If anything here ever disagrees with the code in <code>src/telemetry/</code>, that's a bug — please file an issue.</p>
+
+<h2 id="tldr">tl;dr</h2>
+
+<ul>
+  <li><strong>On by default</strong>, but every event is one of exactly three fixed-shape records — never transcript content, prompts, file paths, repo names, hostnames, usernames, session IDs, dollar amounts, or raw model strings.</li>
+  <li><strong>Disable anytime</strong>: <code>AIRECEIPTS_TELEMETRY=off</code> (or <code>0</code>/<code>false</code>) or <code>DO_NOT_TRACK=1</code>. Either one results in <strong>zero network calls</strong> — not &quot;send less,&quot; zero.</li>
+  <li><strong>Inspect before you decide</strong>: <code>aireceipts --telemetry-show</code> prints exactly what the current run would send, and sends nothing.</li>
+  <li><strong>Bounded and fail-safe</strong>: sending is capped at 300ms and can never throw, hang the CLI, or change its exit code. A slow or failed network call is simply abandoned.</li>
+  <li><strong>First-run notice</strong>: the very first time you run <code>aireceipts</code>, it prints a one-line disclosure pointing here. It never prints again after that.</li>
+</ul>
+
+<h2 id="what-is-sent">What is sent</h2>
+
+<p>There are exactly three event types. Nothing else is ever recorded.</p>
+
+<h3 id="clirun-one-per-cli-invocation"><code>cli_run</code> — one per CLI invocation</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Values</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>cliVersion</code></td><td>string</td><td>semver, e.g. <code>&quot;0.3.1&quot;</code></td><td>From this package's own <code>package.json</code>.</td></tr>
+    <tr><td><code>os</code></td><td>enum</td><td><code>darwin</code> | <code>linux</code> | <code>win32</code> | <code>other</code></td><td><code>process.platform</code>, collapsed to a closed set — never the raw platform string.</td></tr>
+    <tr><td><code>nodeMajor</code></td><td>integer</td><td>e.g. <code>22</code></td><td>Major Node version only.</td></tr>
+    <tr><td><code>commandClass</code></td><td>enum</td><td><code>receipt</code> | <code>compare</code> | <code>other</code></td><td>Which subcommand ran — never the raw argv or any flag values.</td></tr>
+    <tr><td><code>agentType</code></td><td>enum</td><td><code>claude-code</code> | <code>codex</code> | <code>cursor</code> | <code>unknown</code></td><td>Which agent format was parsed, if known.</td></tr>
+    <tr><td><code>durationBucket</code></td><td>enum</td><td><code>&lt;100ms</code> | <code>100-500ms</code> | <code>500ms-2s</code> | <code>2-10s</code> | <code>&gt;10s</code></td><td>Coarse bucket — never the raw millisecond count.</td></tr>
+    <tr><td><code>ok</code></td><td>boolean</td><td></td><td>Whether the run succeeded.</td></tr>
+  </tbody>
+</table></div>
+
+<h3 id="clierror-one-per-uncaught-error-at-the-clis-top-level"><code>cli_error</code> — one per uncaught error at the CLI's top level</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Values</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>errorClass</code></td><td>enum</td><td><code>parse_error</code> | <code>io_error</code> | <code>network_error</code> | <code>validation_error</code> | <code>unknown_error</code></td><td>A small fixed taxonomy derived from the error's constructor name or a well-known Node error code — <strong>never <code>error.message</code></strong>, which can contain a file path or other identifying text.</td></tr>
+    <tr><td><code>command</code></td><td>enum</td><td><code>receipt</code> | <code>compare</code> | <code>other</code></td><td>Same closed taxonomy as <code>cli_run.commandClass</code>.</td></tr>
+    <tr><td><code>agentType</code></td><td>enum</td><td><code>claude-code</code> | <code>codex</code> | <code>cursor</code> | <code>unknown</code></td><td></td></tr>
+    <tr><td><code>inPackage</code></td><td>boolean</td><td></td><td>Whether the error's top stack frame originated inside <code>aireceipts</code>'s own installed code (helps us tell &quot;our bug&quot; from &quot;your environment&quot;) — the stack trace text itself is inspected internally and never leaves the process.</td></tr>
+  </tbody>
+</table></div>
+
+<h3 id="parsefailure-one-per-transcript-parsing-failure"><code>parse_failure</code> — one per transcript-parsing failure</h3>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Values</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>agentType</code></td><td>enum</td><td><code>claude-code</code> | <code>codex</code> | <code>cursor</code></td><td></td></tr>
+    <tr><td><code>adapterVersion</code></td><td>string</td><td>short opaque token, e.g. <code>&quot;1&quot;</code></td><td>An internal per-adapter constant, not anything read from a transcript.</td></tr>
+    <tr><td><code>signatureHash</code></td><td>string</td><td>64-character sha256 hex digest</td><td>A hash of a content-free description of <em>where</em> parsing broke (e.g. <code>&quot;claude-code:turn.usage.missing&quot;</code>). The raw description is hashed before it ever reaches a payload — you cannot recover it from the hash, and it never contains transcript content.</td></tr>
+  </tbody>
+</table></div>
+
+<p>Every field above is validated against a <code>zod</code> schema in <code>.strict()</code> mode before it's ever queued (<code>src/telemetry/schemas.ts</code>). <code>.strict()</code> rejects any payload carrying an extra, unlisted key, so a bug elsewhere in the codebase cannot silently smuggle a new field (a path, a prompt, a dollar amount) into a payload — it would have to be added here, deliberately, and reviewed.</p>
+
+<h2 id="what-is-never-sent">What is never sent</h2>
+
+<p>Permanently, structurally banned — there is no field for any of these anywhere in the schema, and adding one would require an explicit, reviewed change to this document and to <code>src/telemetry/schemas.ts</code>:</p>
+
+<ul>
+  <li>Transcript content or any excerpt of it</li>
+  <li>Prompts or any user/assistant message text</li>
+  <li>File paths (yours or the CLI's own, beyond the fixed <code>inPackage</code> boolean)</li>
+  <li>Repo names or URLs</li>
+  <li>Hostnames</li>
+  <li>Usernames</li>
+  <li>Session IDs</li>
+  <li>Dollar amounts or any cost/pricing data</li>
+  <li>Raw model strings (only the coarse <code>agentType</code> enum is sent)</li>
+</ul>
+
+<h2 id="kill-switches">Kill switches</h2>
+
+<p>Either of the following disables telemetry completely. When disabled, <code>flushTelemetry()</code> returns immediately without making any network call — this is verified by tests that stub the network layer and assert it is never invoked.</p>
+
+<pre class="doc-code"><code class="language-bash">AIRECEIPTS_TELEMETRY=off aireceipts receipt ...
+# or: AIRECEIPTS_TELEMETRY=0 / AIRECEIPTS_TELEMETRY=false (case-insensitive)
+
+DO_NOT_TRACK=1 aireceipts receipt ...</code></pre>
+
+<p>To disable permanently, export one of these in your shell profile.</p>
+
+<h2 id="inspecting-what-would-be-sent">Inspecting what would be sent</h2>
+
+<pre class="doc-code"><code class="language-bash">aireceipts --telemetry-show</code></pre>
+
+<p>This prints whether telemetry is currently enabled and the exact events queued for the current run — the same objects that would be sent — without sending anything.</p>
+
+<h2 id="how-sending-works">How sending works</h2>
+
+<ul>
+  <li>Events are queued in-process as they occur and sent as a single batched request at CLI shutdown.</li>
+  <li>The send is bounded to <strong>300ms</strong> via <code>Promise.race</code> against a timeout. If the network call is slow or hangs, it is abandoned in place; the CLI does not wait for it, and nothing is retried in the background.</li>
+  <li>Every failure mode — telemetry disabled, an invalid event, a network error, a timeout — is swallowed inside the telemetry module. Telemetry can never throw, never block the CLI, and never change its exit code.</li>
+  <li>The transport is Azure Application Insights, reached via a connection string (<code>InstrumentationKey=...;IngestionEndpoint=https://.../</code>) POSTed to <code>&lt;ingestionEndpoint&gt;/v2/track</code>.</li>
+</ul>
+
+<h2 id="connection-string-honesty">Connection-string honesty</h2>
+
+<p>This section exists so the code and this document can never quietly disagree.</p>
+
+<ul>
+  <li>The ingestion key this package ships with is <strong>not a secret</strong> — Application Insights instrumentation keys are write-only and are commonly embedded in open-source clients. The shipped key, plainly: <code>InstrumentationKey=394da360-a50c-4700-bcf9-87b8d9d6e0ee</code> (ingestion endpoint <code>eastus-8.in.applicationinsights.azure.com</code>).</li>
+  <li><strong>Current status</strong>: a real Azure Application Insights resource is wired up as of 2026-07-02, so the diagnostics events documented above are sent by default (subject to the kill switches and the 300 ms bounded flush). Run <code>aireceipts --telemetry-show</code> to see exactly what a run would send before it sends anything.</li>
+  <li><code>AIRECEIPTS_TELEMETRY_CONNECTION</code> overrides the shipped default. Set it to point at your own Application Insights resource (e.g. for local development or a private fork), or set it to an empty string to force-disable telemetry independent of the kill switches.</li>
+  <li>A malformed connection string (missing either <code>InstrumentationKey</code> or <code>IngestionEndpoint</code>) also degrades to <code>enabled: false</code> rather than sending to an incomplete endpoint.</li>
+</ul>
+
+<h2 id="first-run-notice">First-run notice</h2>
+
+<p>The first time <code>aireceipts</code> runs for a given user, it prints a one-line disclosure (pointing here) before doing anything else, then persists that fact to <code>~/.aireceipts/telemetry.json</code> so it never prints again. If that file can't be read or written (no home directory, read-only filesystem), the notice is simply shown again on the next run rather than the CLI failing.</p>
+
+<h2 id="source-of-truth">Source of truth</h2>
+
+<p>The schemas in <code>src/telemetry/schemas.ts</code> are the actual source of truth; this document is kept in sync with them by hand and reviewed alongside any change to that file. If you find a discrepancy, please open an issue.</p>
+    </article>
+  </main>
+  <footer>
+    <div class="close">
+      <div class="close-copy">
+        <p class="issued"><span>No account</span><span>No upload</span><span>Docs</span></p>
+        <p class="thanks">Thank you for your tokens.</p>
+        <p class="serial">AIRECEIPTS · NO. 0001</p>
+      </div>
+      <svg class="seal" viewBox="0 0 200 200" role="img" aria-label="A round vermillion seal reading RECEIPTED, SETTLED, and NO FABRICATED DOLLARS.">
+  <defs>
+    <path id="ring-top" d="M 30 100 A 70 70 0 0 1 170 100"/>
+    <path id="ring-bot" d="M 34 100 A 66 66 0 0 0 166 100"/>
+  </defs>
+  <circle cx="100" cy="100" r="95" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <circle cx="100" cy="100" r="83" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700">
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-top" startOffset="50%">RECEIPTED</textPath></text>
+    <text font-size="14.5" letter-spacing="3.5" text-anchor="middle"><textPath href="#ring-bot" startOffset="50%">SETTLED</textPath></text>
+  </g>
+  <line x1="66" y1="70" x2="134" y2="70" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="66" y1="130" x2="134" y2="130" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor" font-family="system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700" text-anchor="middle" letter-spacing="1.5">
+    <text x="100" y="91" font-size="15">NO</text>
+    <text x="100" y="106" font-size="13">FABRICATED</text>
+    <text x="100" y="121" font-size="15">DOLLARS</text>
+  </g>
+</svg>
+    </div>
+    <svg class="barcode" viewBox="0 0 90 34" width="180" height="30" fill="currentColor" role="img" aria-label="Barcode encoding the word aireceipts.">
+  <rect x="0" y="0" width="3" height="34"/><rect x="4" y="0" width="2" height="34"/><rect x="8" y="0" width="3" height="34"/><rect x="12" y="0" width="2" height="34"/><rect x="16" y="0" width="4" height="34"/><rect x="21" y="0" width="3" height="34"/><rect x="26" y="0" width="3" height="34"/><rect x="31" y="0" width="2" height="34"/><rect x="35" y="0" width="3" height="34"/><rect x="39" y="0" width="4" height="34"/><rect x="45" y="0" width="3" height="34"/><rect x="50" y="0" width="2" height="34"/><rect x="54" y="0" width="3" height="34"/><rect x="58" y="0" width="2" height="34"/><rect x="62" y="0" width="4" height="34"/><rect x="67" y="0" width="1" height="34"/><rect x="70" y="0" width="4" height="34"/><rect x="76" y="0" width="1" height="34"/><rect x="79" y="0" width="4" height="34"/><rect x="84" y="0" width="4" height="34"/>
+</svg>
+    <p class="flinks">
+      <a href="../index.html">Home</a><span class="sep" aria-hidden="true">·</span><a href="index.html">Docs</a><span class="sep" aria-hidden="true">·</span><span>Apache-2.0</span>
+    </p>
+    <p class="samosa">buy me a samosa</p>
+  </footer>
+</div>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -379,7 +379,7 @@ vs. prior 7 days (Jun 06 2026 → Jun 13 2026)
       <rect x="0" y="0" width="3" height="34"/><rect x="4" y="0" width="2" height="34"/><rect x="8" y="0" width="3" height="34"/><rect x="12" y="0" width="2" height="34"/><rect x="16" y="0" width="4" height="34"/><rect x="21" y="0" width="3" height="34"/><rect x="26" y="0" width="3" height="34"/><rect x="31" y="0" width="2" height="34"/><rect x="35" y="0" width="3" height="34"/><rect x="39" y="0" width="4" height="34"/><rect x="45" y="0" width="3" height="34"/><rect x="50" y="0" width="2" height="34"/><rect x="54" y="0" width="3" height="34"/><rect x="58" y="0" width="2" height="34"/><rect x="62" y="0" width="4" height="34"/><rect x="67" y="0" width="1" height="34"/><rect x="70" y="0" width="4" height="34"/><rect x="76" y="0" width="1" height="34"/><rect x="79" y="0" width="4" height="34"/><rect x="84" y="0" width="4" height="34"/>
     </svg>
     <p class="flinks">
-      <a href="https://github.com/aireceipts/aireceipts">GitHub</a><span class="sep" aria-hidden="true">·</span><a href="https://github.com/aireceipts/aireceipts#readme">docs</a><span class="sep" aria-hidden="true">·</span><a href="https://github.com/aireceipts/aireceipts/blob/main/LICENSE">Apache-2.0</a>
+      <a href="https://github.com/aireceipts/aireceipts">GitHub</a><span class="sep" aria-hidden="true">·</span><a href="docs/index.html">docs</a><span class="sep" aria-hidden="true">·</span><a href="https://github.com/aireceipts/aireceipts/blob/main/LICENSE">Apache-2.0</a>
     </p>
     <p class="samosa">buy me a samosa 🥟</p>
   </footer>

--- a/specs/SPEC-0022-docs-site.md
+++ b/specs/SPEC-0022-docs-site.md
@@ -1,0 +1,85 @@
+---
+id: SPEC-0022
+title: "Docs site from repo markdown"
+status: approved
+milestone: M4
+depends: [SPEC-0021]
+---
+
+# SPEC-0022: Docs site from repo markdown
+
+Invariants: I1 (deterministic; zero model calls; zero product-path network), I3
+(claims traceable to repo docs), I5 (generated output is byte-stable), I6 (facts,
+never rankings). Approval basis: maintainer requested this build directly on
+2026-07-02.
+
+## Purpose
+
+Publish the root `docs/*.md` files as static GitHub Pages HTML under `site/docs/`
+without adding a docs framework, runtime dependency, workflow, or external asset
+request. The docs pages inherit the SPEC-0021 landing site's receipt-certificate visual
+system so the documentation feels like the same product surface while preserving I1's
+local, deterministic build path.
+
+## Requirements
+
+- **R1** — `scripts/build-docs-site.mjs` reads only root-level `docs/*.md`, sorts them
+  deterministically, and writes one matching `site/docs/<name>.html` page plus
+  `site/docs/index.html`.
+- **R2** — The markdown renderer is dependency-free and supports the subset the repo
+  docs use: headings, paragraphs, fenced code blocks, tables, links, inline code,
+  bold text, ordered lists, and unordered lists.
+- **R3** — Every generated page uses the LANDING V3 token set, masthead, sheet layout,
+  and footer language from SPEC-0021's `site/index.html`, with docs-local navigation.
+- **R4** — Generated output is idempotent and deterministic: running the script twice
+  with unchanged docs produces no diff.
+- **R5** — Generated HTML makes no external load requests: no remote scripts, styles,
+  fonts, images, iframes, CSS imports, or CSS `url(http...)` references.
+- **R6** — The landing page's docs link is relative (`docs/index.html`) so GitHub Pages
+  can serve docs with no workflow change once the landing PR is live.
+
+## Scenarios
+
+- **Given** the six root markdown docs **When** `node scripts/build-docs-site.mjs` runs
+  **Then** `site/docs/index.html` links to every source file and each doc has a
+  same-named HTML page.
+- **Given** markdown tables with escaped pipe characters **When** docs are rendered
+  **Then** cells stay in the intended columns and inline code is HTML-escaped.
+- **Given** a committed `site/docs/` tree **When** the build script runs twice **Then**
+  `git diff -- site/docs` stays empty after the second run.
+- **Given** the generated docs HTML **When** it is scanned for remote resource loads
+  **Then** none are present.
+
+## Non-goals
+
+- No docs framework, bundler, client-side router, search index, syntax highlighter, or
+  new npm dependency; the site stays static and dependency-free.
+- No recursive publishing of `docs/spikes/**`; this spec intentionally publishes only
+  root `docs/*.md` as the public docs set.
+- No rewriting the docs' factual content or adding marketing copy; the generator wraps
+  existing repo docs and converts their markdown structure.
+- No Pages workflow change; generated files are committed under `site/docs/` for the
+  existing Pages artifact.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 root docs | `find docs -maxdepth 1 -name '*.md'` | each file appears in `site/docs/index.html` and has a matching `.html` |
+| R2 markdown subset | docs headings, code fences, tables, links, lists | rendered HTML has semantic headings, `pre/code`, `table`, `a`, `ol`, `ul` |
+| R2 escaped cells | `docs/json-schema.md` table rows with `\|` | escaped pipes remain inside cells, not split columns |
+| R3 visual system | generated page source | V3 tokens (`--field`, `--sheet`, `--ink`, `--ledger`) and masthead/footer classes present |
+| R4 idempotence | run script twice | second run leaves no `git diff -- site/docs scripts/build-docs-site.mjs` output |
+| R5 no external requests | generated HTML grep | no remote `script/link/img/iframe/srcset`, CSS `@import`, or CSS `url(http...)` loads |
+| R6 relative landing link | `site/index.html` | footer docs link is `href="docs/index.html"` |
+| gates | repo root | full verification block passes unmasked with `echo $?` after each command |
+
+## Success criteria
+
+- [ ] `node scripts/build-docs-site.mjs`; `echo $?` passes and writes `site/docs/`.
+- [ ] `site/docs/index.html` contains every root `docs/*.md` source path and link.
+- [ ] Generated docs HTML has no external resource loads.
+- [ ] Re-running `node scripts/build-docs-site.mjs` leaves generated output unchanged.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, determinism, spec-lint, and hygiene all pass
+      unmasked with `echo $?`.


### PR DESCRIPTION
## What this adds
Every docs/*.md rendered to site/docs/ by a dependency-free generator wearing the landing v3 visual system — one Pages deploy serves landing + docs (anandgupta42.github.io/aireceipts/docs/ once #35 merges first).

## What to review, in order
1. site/docs/index.html contents page in a browser
2. scripts/build-docs-site.mjs (the md subset renderer — no marked/remark)
3. Determinism: rerun the script, git diff must be empty

## Evidence
spec-lint 23 OK · vitest green · hygiene OK. Spec: SPEC-0022 (approval basis: direct maintainer request). Built by Codex; committed+published by lead (connector offline). MERGE ORDER: after #35.