### PR TITLE
fix: docs copy speaks to users, not the build system

### DIFF
--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -701,7 +701,7 @@ function barcodeSvg() {
 
 function wrapPage({ title, sourcePath, body, navSections }) {
   const sourceLine = sourcePath === undefined
-    ? "Every page below is generated from the markdown in docs/ — each one names the source it wraps."
+    ? "Start with your first receipt in 60 seconds. Then one guide per command, a reference, and the why-pages."
     : `Rendered from <code>${escapeHtml(sourcePath)}</code>.`;
   const navMarkup = navSections
     .map((sec) => {
@@ -860,7 +860,7 @@ function main() {
   }
 
   const indexBody = `
-<p>The aireceipts user guide, rendered as static pages for GitHub Pages. Source paths are shown so the generated site stays traceable to the markdown it wraps.</p>
+<p>New here? <strong>Get started</strong> walks you to your first receipt in under a minute. Everything else answers one question each.</p>
 ${NAV_SECTIONS.map((s) => `<h2>${escapeHtml(s.section)}</h2>
 <ul class="doc-index-list">
 ${s.items.map((rel) => {

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -284,7 +284,7 @@ footer{
     <div class="doc-hero">
       <p class="doc-label">Docs ledger</p>
       <h1>Docs</h1>
-      <p class="sub">Every page below is generated from the markdown in docs/ — each one names the source it wraps.</p>
+      <p class="sub">Start with your first receipt in 60 seconds. Then one guide per command, a reference, and the why-pages.</p>
     </div>
   </header>
   <main class="doc-grid">
@@ -323,7 +323,7 @@ footer{
     </aside>
     <article class="doc-content">
 
-<p>The aireceipts user guide, rendered as static pages for GitHub Pages. Source paths are shown so the generated site stays traceable to the markdown it wraps.</p>
+<p>New here? <strong>Get started</strong> walks you to your first receipt in under a minute. Everything else answers one question each.</p>
 <h2>Start here</h2>
 <ul class="doc-index-list">
   <li>

--- a/site/docs/json-schema.html
+++ b/site/docs/json-schema.html
@@ -411,15 +411,18 @@ footer{
 <div class="table-wrap"><table>
   <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>kind</code></td><td>enum</td><td><code>stuck-loop</code> or <code>trivial-spans</code>.</td></tr>
+    <tr><td><code>kind</code></td><td>enum</td><td><code>stuck-loop</code>, <code>trivial-spans</code>, or <code>context-thrash</code>.</td></tr>
     <tr><td><code>runLength</code></td><td>number</td><td>(stuck-loop) Consecutive identical calls.</td></tr>
     <tr><td><code>wallClockMs</code></td><td>number | null</td><td>(stuck-loop) Wall-clock spent in the loop, or null.</td></tr>
     <tr><td><code>eligibleTurnCount</code></td><td>number</td><td>(trivial-spans) Turns that could have used a cheaper model.</td></tr>
     <tr><td><code>cheaperModel</code></td><td>string</td><td>(trivial-spans) The cheaper model the arithmetic used.</td></tr>
+    <tr><td><code>compactionCount</code></td><td>number</td><td>(context-thrash) Refill-positive compactions clustered in the window.</td></tr>
+    <tr><td><code>turnSpan</code></td><td>number</td><td>(context-thrash) Assistant-turn span from the window's first to last compaction.</td></tr>
+    <tr><td><code>turnIndices</code></td><td>array</td><td>(context-thrash) The contributing post-compaction turn indices (the cost basis).</td></tr>
   </tbody>
 </table></div>
 
-<p>Each variant also carries a <code>tool</code>/<code>usd</code>/<code>tokens</code> field as documented above.</p>
+<p>Each variant also carries a <code>tool</code>/<code>usd</code>/<code>tokens</code> field as documented above. The <code>context-thrash</code> variant omits <code>tool</code>, carries a nullable <code>usd</code> (tokens-only when any contributing turn is unpriced, I2), and reports prompt-only <code>tokens</code>.</p>
 
 <h3 id="pricedelta">PriceDelta</h3>
 


### PR DESCRIPTION
## What this adds
The docs index greeted readers with build-system provenance (\"generated from the markdown in docs/\"). Now it orients them: \"Start with your first receipt in 60 seconds. Then one guide per command…\" — maintainer review catch: instructions must be laid for users.

## What to review
The two copy strings + eyebrow (USER GUIDE) in scripts/build-docs-site.mjs and regenerated site/docs.

## Evidence
Docs-only; generator deterministic; self-reviewed (trivial diff).