### PR TITLE
feat: labeled clean-corpus calibration gate for context-thrash (#46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage/
 reports/
 .review-ok
 .github/meta/
+# maintainer-labeled thrash calibration corpus — local transcript paths, never committed (SPEC-0017, issue #46)
+eval/clean-corpus.local.json

--- a/scripts/thrash-calibration.mjs
+++ b/scripts/thrash-calibration.mjs
@@ -1,0 +1,73 @@
+// Maintainer gate: labeled clean-corpus precision check for context-thrash
+// (SPEC-0017 kill criterion, issue #46). Compile-to-temp like verify-goldens
+// so this never depends on `npx` fetching tsx or on a stale dist/.
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+
+function tsFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsFiles(path);
+    return entry.isFile() && path.endsWith(".ts") ? [path] : [];
+  });
+}
+
+const root = process.cwd();
+const tmp = mkdtempSync(join(tmpdir(), "aireceipts-thrash-cal-"));
+const outDir = join(tmp, "out");
+const configPath = join(tmp, "tsconfig.thrash-cal.json");
+const tscPath = join(root, "node_modules", "typescript", "bin", "tsc");
+const files = [join(root, "scripts", "thrash-calibration.mts"), ...tsFiles(join(root, "src"))];
+
+writeFileSync(
+  configPath,
+  JSON.stringify(
+    {
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        lib: ["ES2022"],
+        strict: true,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        resolveJsonModule: true,
+        rootDir: root,
+        outDir,
+      },
+      files,
+    },
+    null,
+    2,
+  ),
+);
+
+let status = 1;
+try {
+  const compile = spawnSync(process.execPath, [tscPath, "--project", configPath], {
+    stdio: "inherit",
+    env: { ...process.env, NO_COLOR: "1", TZ: "UTC", LANG: "C" },
+  });
+  // A compile failure is a tooling error (exit 1) — tsc's own status 2 must not
+  // masquerade as the gate's "evidence insufficient" exit code.
+  status = compile.status === 0 ? 0 : 1;
+
+  if (status === 0) {
+    cpSync(join(root, "data"), join(outDir, "data"), { recursive: true });
+    const script = join(outDir, relative(root, join(root, "scripts", "thrash-calibration.mts"))).replace(
+      /\.mts$/u,
+      ".mjs",
+    );
+    const run = spawnSync(process.execPath, [script, ...process.argv.slice(2)], {
+      stdio: "inherit",
+      env: { ...process.env, NO_COLOR: "1", TZ: "UTC", LANG: "C" },
+    });
+    status = run.status ?? 1;
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+process.exit(status);

--- a/scripts/thrash-calibration.mts
+++ b/scripts/thrash-calibration.mts
@@ -1,0 +1,174 @@
+// SPEC-0017 kill criterion + issue #46 — the labeled clean-corpus precision
+// gate for the context-thrash detector. Maintainer-run, local-only: the corpus
+// manifest points at real transcripts on this machine and is never committed
+// (eval/clean-corpus.local.json is gitignored — file paths are private, I4).
+//
+//   node scripts/thrash-calibration.mjs --init [--limit N]   write a template
+//     manifest of the newest local sessions, every entry UNLABELED — the
+//     maintainer flips `labeledClean` to true and signs `labeledBy` per entry;
+//     the tool never pre-labels a session clean.
+//   node scripts/thrash-calibration.mjs [--corpus <path>]    run the gate.
+//
+// Exit codes (gate mode; --init exits 0 on a written template): 0 = N>=20
+// labeled-clean sessions, 0 thrash firings (gate PASSES); 1 = a labeled-clean
+// session fired (tune T/K/REFILL_RATIO before the waste line ships — issue
+// #46) or usage error; 2 = evidence insufficient (fewer than 20 distinct
+// labeled-clean loadable sessions — per SPEC-0017 the detector cannot ship on
+// this evidence).
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { listSessions, loadById } from "../src/index.js";
+import type { AgentSource, SessionSummary } from "../src/parse/types.js";
+import {
+  CONTEXT_THRASH_K,
+  CONTEXT_THRASH_MAX_GAP,
+  CONTEXT_THRASH_REFILL_RATIO,
+  detectContextThrash,
+} from "../src/pricing/waste.js";
+
+const DEFAULT_CORPUS = "eval/clean-corpus.local.json";
+const MIN_CLEAN = 20;
+const DEFAULT_INIT_LIMIT = 40;
+
+interface CorpusEntry {
+  source: AgentSource;
+  path: string;
+  title?: string;
+  startedAt?: string;
+  labeledClean: boolean;
+  labeledBy: string;
+}
+
+function argValue(flag: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  if (i < 0) {
+    return undefined;
+  }
+  const value = process.argv[i + 1];
+  if (value === undefined || value.startsWith("--")) {
+    console.error(`${flag} requires a value`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function thresholds(): string {
+  return `T(max gap)=${CONTEXT_THRASH_MAX_GAP} turns · K(refill window)=${CONTEXT_THRASH_K} turns · refill ratio=${CONTEXT_THRASH_REFILL_RATIO}`;
+}
+
+async function init(corpusPath: string, limit: number): Promise<number> {
+  if (existsSync(corpusPath)) {
+    console.error(`refusing to overwrite ${corpusPath} — delete it first if you mean to relabel from scratch`);
+    return 1;
+  }
+  const sessions = await listSessions();
+  const newest = sessions
+    .filter((s: SessionSummary) => s.startedAt !== undefined)
+    .sort((a, b) => (b.startedAt ?? 0) - (a.startedAt ?? 0) || a.filePath.localeCompare(b.filePath))
+    .slice(0, limit);
+  const entries: CorpusEntry[] = newest.map((s) => ({
+    source: s.source,
+    path: s.filePath,
+    title: s.title,
+    startedAt: s.startedAt !== undefined ? new Date(s.startedAt).toISOString() : undefined,
+    labeledClean: false,
+    labeledBy: "",
+  }));
+  const manifest = {
+    $schema:
+      "maintainer-labeled clean corpus for the context-thrash precision gate (SPEC-0017 kill criterion, issue #46). " +
+      "For every session you have REVIEWED and judged free of context thrash, set labeledClean: true and put your " +
+      "name in labeledBy. Unreviewed entries stay false and are ignored. Local-only file — never commit it.",
+    entries,
+  };
+  writeFileSync(corpusPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  console.log(`wrote ${corpusPath} with ${entries.length} UNLABELED sessions.`);
+  console.log(`label >= ${MIN_CLEAN} clean sessions (labeledClean: true + labeledBy), then rerun without --init.`);
+  return 0;
+}
+
+async function check(corpusPath: string): Promise<number> {
+  if (!existsSync(corpusPath)) {
+    console.error(`no corpus at ${corpusPath} — run with --init to scaffold one, then label it`);
+    return 2;
+  }
+  const parsed = JSON.parse(readFileSync(corpusPath, "utf8")) as { entries?: CorpusEntry[] };
+  const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
+  const seen = new Set<string>();
+  const labeled: CorpusEntry[] = [];
+  for (const e of entries
+    .filter((e) => e.labeledClean === true && typeof e.labeledBy === "string" && e.labeledBy.trim() !== "")
+    .sort((a, b) => a.path.localeCompare(b.path))) {
+    // A duplicate (source, path) row is one session, not two pieces of evidence.
+    const key = `${e.source} ${e.path}`;
+    if (seen.has(key)) {
+      console.error(`duplicate labeled entry (counted once): ${e.path}`);
+      continue;
+    }
+    seen.add(key);
+    labeled.push(e);
+  }
+
+  const unloadable: string[] = [];
+  const firings: { path: string; compactionCount: number; turnSpan: number }[] = [];
+  let checked = 0;
+  for (const entry of labeled) {
+    const session = await loadById(entry.source, entry.path);
+    if (!session) {
+      unloadable.push(entry.path);
+      continue;
+    }
+    checked++;
+    for (const finding of await detectContextThrash(session)) {
+      firings.push({ path: entry.path, compactionCount: finding.compactionCount, turnSpan: finding.turnSpan });
+    }
+  }
+
+  for (const path of unloadable) {
+    console.error(`unloadable labeled session (excluded from evidence): ${path}`);
+  }
+  if (checked < MIN_CLEAN) {
+    console.error(
+      `evidence insufficient: ${checked} loadable labeled-clean session(s) < ${MIN_CLEAN} ` +
+        `(SPEC-0017 kill criterion) — the context-thrash line cannot ship on this corpus.`,
+    );
+    return 2;
+  }
+  if (firings.length > 0) {
+    for (const f of firings) {
+      console.error(
+        `FALSE POSITIVE: ${f.path} fired context-thrash (${f.compactionCount} compactions over ${f.turnSpan} turns)`,
+      );
+    }
+    console.error(`${firings.length} firing(s) on labeled-clean sessions at ${thresholds()}.`);
+    console.error("tune the thresholds (issue #46) before the v0.1.0 release-manager verdict.");
+    return 1;
+  }
+  console.log(`PASS: 0 false positives on ${checked} maintainer-labeled clean sessions at ${thresholds()}.`);
+  return 0;
+}
+
+// Strict argv: an unrecognized flag must never silently fall through to the
+// default corpus and print a PASS the maintainer didn't ask for.
+{
+  const valueFlags = new Set(["--corpus", "--limit"]);
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--init") {
+      continue;
+    }
+    if (valueFlags.has(args[i])) {
+      i++;
+      continue;
+    }
+    console.error(`unknown argument "${args[i]}" — usage: [--init] [--limit N] [--corpus <path>]`);
+    process.exit(1);
+  }
+}
+const corpusPath = argValue("--corpus") ?? DEFAULT_CORPUS;
+const limitRaw = argValue("--limit");
+if (limitRaw !== undefined && !/^[1-9]\d*$/.test(limitRaw)) {
+  console.error(`--limit must be a positive integer, got "${limitRaw}"`);
+  process.exit(1);
+}
+const limit = limitRaw !== undefined ? Number.parseInt(limitRaw, 10) : DEFAULT_INIT_LIMIT;
+process.exit(process.argv.includes("--init") ? await init(corpusPath, limit) : await check(corpusPath));

--- a/test/eval.test.ts
+++ b/test/eval.test.ts
@@ -30,8 +30,7 @@ if (!hasDetectors) {
 }
 
 interface CorpusEntry {
-  source: "claude-code" | "codex" | "cursor" | "gemini";
-  source: "claude-code" | "codex" | "cursor" | "opencode";
+  source: "claude-code" | "codex" | "cursor" | "gemini" | "opencode";
   path: string;
   expected: string[];
 }


### PR DESCRIPTION
## What this adds

The maintainer-run precision gate SPEC-0017's kill criterion requires and issue #46 names as blocking for the `context-thrash` waste line: `node scripts/thrash-calibration.mjs` verifies **0 false positives on ≥ 20 maintainer-labeled clean sessions**, or refuses to pass.

## See it

```
$ node scripts/thrash-calibration.mjs
no corpus at eval/clean-corpus.local.json — run with --init to scaffold one, then label it
$ echo $?
2
```

Gate run over 25 real local sessions (smoke-labeled to exercise the mechanics — not the maintainer corpus):

```
PASS: 0 false positives on 25 maintainer-labeled clean sessions at T(max gap)=25 turns · K(refill window)=5 turns · refill ratio=0.8.
```

Seeded red path (committed true-positive fixture injected among 24 real sessions):

```
FALSE POSITIVE: .../test/fixtures/claude-code/context-thrash-3x.jsonl fired context-thrash (3 compactions over 4 turns)
1 firing(s) on labeled-clean sessions at T(max gap)=25 turns · K(refill window)=5 turns · refill ratio=0.8.
tune the thresholds (issue #46) before the v0.1.0 release-manager verdict.
```

## What changed

- `scripts/thrash-calibration.mts` — gate logic: `--init` scaffolds `eval/clean-corpus.local.json` from the newest local sessions with every entry UNLABELED (the tool never pre-labels a session clean); gate mode dedupes `(source, path)` rows, requires ≥ 20 distinct loadable labeled-clean sessions (exit 2 otherwise), exits 1 listing any firing with the `T`/`K`/refill thresholds; strict argv (unknown flags exit 1).
- `scripts/thrash-calibration.mjs` — compile-to-temp wrapper mirroring `scripts/verify-goldens.mjs` (no `tsx`, no stale-`dist/` dependence); compile failure exits 1 so `tsc`'s status 2 can't masquerade as "evidence insufficient".
- `.gitignore` — `eval/clean-corpus.local.json` (local transcript paths are private, I4).
- `test/eval.test.ts` — fixed a silent duplicate `source` key in `CorpusEntry` (invisible because `tsconfig` excludes `test/`): one union carrying both `gemini` and `opencode`.

## What to review, in order

1. **Evidence-counting honesty** — `scripts/thrash-calibration.mts:96-135`: dedupe of duplicate labeled rows, unloadable sessions excluded from evidence, the `< 20 → exit 2` refusal. This is the gate's trust core.
2. **Init never pre-labels** — `scripts/thrash-calibration.mts:58-87`: every scaffolded entry is `labeledClean: false`, `labeledBy: ""`.
3. **Exit-code contract** — header comment vs `check()`/`init()` returns and the wrapper's compile-failure mapping (`scripts/thrash-calibration.mjs:53-56`).
4. **Wrapper parity** with `scripts/verify-goldens.mjs` — same frozen env, same temp-compile shape.
5. `test/eval.test.ts:33` one-line union fix.

## Evidence

- Gates, all unmasked exit 0: `tsc --noEmit` · `eslint --max-warnings 0` · `vitest run` 870/870 · `verify-goldens` 89 byte-identical · `determinism-check --runs=10` · `spec-lint` 25 OK · `hygiene` OK.
- Spec: `specs/SPEC-0017-context-thrash-waste.md` (approved) — this implements its kill-criterion / R8 labeled-corpus half; the committed-fixture half already lives in `test/eval.test.ts`.
- Two Codex review rounds applied: (1) duplicate-evidence inflation, argv validation, exit-code wording; (2) unknown-flag fall-through, wrapper exit-code collision.
- Build receipt: this session runs `aireceipts pr --post` after the PR opens (SPEC-0019).

## Notes

- The gate cannot pass in CI by design — the corpus is local and maintainer-labeled. The remaining work on #46 is labeling: `node scripts/thrash-calibration.mjs --init`, flip `labeledClean`/sign `labeledBy` on ≥ 20 reviewed sessions, rerun.
- Encouraging non-gate signal: 0 firings across 25 recent real sessions at current thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
