### PR TITLE
feat: SPEC-0024 SHA-anchor attribution — sidechains + cross-repo (#51)

### DIFF
--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -46,17 +46,32 @@ blocked.
 
 - A marker line (`<!-- aireceipts-dogfood -->`) so the upsert and the CI check can find
   exactly one comment to keep current.
-- A `🧾 aireceipts — session <id>` header and a fenced receipt.
-- A slice header: `session slice: turns A–B of N` when the PR's work is isolated to a
-  commit window, or `entire session (slice unavailable)` when it can't be cut cleanly
-  (ambiguity is labeled, never presented as PR cost).
-- A `SUBAGENTS` section rolling up any subagent sessions the PR's work launched, with a
-  combined total.
+- A fenced receipt headed `N sessions behind this PR`: one row per contributing
+  session (`<role> · <model mix> · <cost>`), a muted provenance line under each
+  (session id + `session slice: turns A–B of N`, or `entire session (slice
+  unavailable)` when the work can't be cut cleanly — ambiguity is labeled, never
+  presented as PR cost), and indented `SUBAGENTS` sub-rows for any subagent
+  sessions a contributor launched.
+- One combined total. Priced and unpriced sessions are never blended: dollars and
+  tokens total separately.
+- An honest note counting any plausible-but-unproven sessions that were **not**
+  attributed.
 
-## How a session is matched to a PR
+## How sessions are matched to a PR
 
-Auto-selection (no `--session`) picks the session whose working directory is inside one
-of this repo's worktrees **and** whose time window overlaps the branch's commit window.
-Zero matches or more than one → `aireceipts pr` refuses to guess and asks for
-`--session <id>`. The `cwd`/branch used for matching are attribution-only: they never
-enter the rendered receipt, `--json`/`--csv`, or telemetry.
+Auto-selection (no `--session`) credits every session that can be tied to the branch,
+conservatively:
+
+- A session whose recorded git output contains one of the **branch's commit SHAs** is
+  credited wherever it ran — another checkout, another repo's working directory, or an
+  agent-team sidechain. The commit SHA is the primary attribution key; a sidechain is
+  promoted to its own row only when no other credited session already counts it.
+- A session inside one of this repo's worktrees that time-overlaps the branch's commit
+  window gets the softer rules: a Codex session there with **no** git writes at all is
+  credited as a helper on cwd+time.
+- Everything else is excluded. Sessions without SHA proof outside the repo are never
+  credited — and never guessed in.
+
+Zero credited sessions → `aireceipts pr` refuses to guess and asks for `--session <id>`.
+The `cwd`/branch/SHA signals used for matching are attribution-only: they never enter
+the rendered receipt, `--json`/`--csv`, or telemetry.

--- a/specs/SPEC-0024-sha-anchor-attribution.md
+++ b/specs/SPEC-0024-sha-anchor-attribution.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0024
 title: "SHA-anchored attribution — orphan sidechains and cross-repo leads count"
-status: draft
+status: building
 milestone: M3
 depends: [SPEC-0023]
 ---
@@ -168,16 +168,16 @@ a hard load cap with an honest "K overlapping sessions not scanned" note.
 
 ## Success criteria
 
-- [ ] This spec's own implementation PR carries a receipt that includes the
+- [x] This spec's own implementation PR carries a receipt that includes the
       lead/orchestrator session (the exact gap of issue #51's second comment)
       or documents why none existed for that PR.
-- [ ] No false-positive row in dogfood (kill criterion (a) not fired) — every
+- [x] No false-positive row in dogfood (kill criterion (a) not fired) — every
       row on the posted receipt is checkable against a branch anchor or the
       repo-pool helper rule.
-- [ ] The PR body states, from the maintainer's machine, how many sessions the
+- [x] The PR body states, from the maintainer's machine, how many sessions the
       anchor pool loaded for this repo's own PR and the added wall time —
       kill criterion (b) evaluated against those numbers.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass
       unmasked (`echo $?`); goldens untouched (the PR comment body is not
       golden-gated).
@@ -237,4 +237,5 @@ maintainer's machine before merge.
 **2026-07-02 · S4 (lint):** `node scripts/spec-lint.mjs` → 25 spec(s) OK,
 exit 0.
 
-Status remains draft pending maintainer approval (button 1).
+**2026-07-02 · approved:** maintainer approval given directly in session
+("approve SPEC-0024") after reviewing the validated draft — button 1.

--- a/specs/SPEC-0024-sha-anchor-attribution.md
+++ b/specs/SPEC-0024-sha-anchor-attribution.md
@@ -1,0 +1,240 @@
+---
+id: SPEC-0024
+title: "SHA-anchored attribution — orphan sidechains and cross-repo leads count"
+status: draft
+milestone: M3
+depends: [SPEC-0023]
+---
+
+# SPEC-0024 · SHA-anchored attribution widening
+
+Invariants: I1 (deterministic selection — same disk state, same receipt), I2/I3
+(no money semantics change; every row this spec makes newly reachable is
+SHA-provable — SPEC-0023's existing rules, including the current-worktree
+SHA-less Codex helper rule, are unchanged), I6 (roles describe structure,
+never rank).
+
+## Purpose
+
+SPEC-0023 sums every session behind a PR — but only among candidates whose `cwd`
+is inside this repo's worktrees and which are not sidechains
+(`isBranchCandidate`, `src/pr/select.ts:59`). Issue #51 documents the two
+sessions that rule makes invisible, from this repo's own dogfood:
+
+1. **Agent-team teammate builders** are sidechains recorded under the LEAD's
+   project dir: standalone transcripts in the top-level list whose first record
+   carries `isSidechain: true` (`src/parse/discovery.ts:118`). `!s.isSidechain`
+   excludes them from candidacy, and `rollupChildren` (`src/pr/rollup.ts:53`)
+   never sees them either — it only discovers path-based
+   `<parent>/subagents/agent-*.jsonl` children (`src/parse/children.ts`). A
+   flagged sidechain's cost is counted **nowhere** — even when its slice is
+   SHA-provably the branch author (PR #49's builders).
+2. **The lead itself** (PR #54's receipt, maintainer catch: *"we used fable to
+   design — it should call out fable"*): a lead orchestrating from a different
+   working repo is recorded under THAT repo's project dir with THAT repo's
+   `cwd`, while committing here via absolute paths. Discovery already lists its
+   transcript (adapters scan their whole root — `src/parse/claudeCode.ts:362`,
+   path-children filtered at `:365`), but the cwd filter drops it before its
+   branch-SHA anchors are ever checked.
+
+The fix direction (maintainer, issue #51): the commit-SHA anchor becomes the
+primary attribution key; `cwd` remains only a *pool-bounding* heuristic, never
+a veto over SHA proof. No new proof rule is invented — `classifyBranchAnchors`
+(`src/pr/slice.ts:70`) is reused unchanged.
+
+**Kill criterion:** (a) any dogfood receipt credits a session that did not
+author a branch commit (a false-positive row) → the widening narrows: first to
+full-40-hex anchor matches for anchor-pool sessions (a named contingency that
+overrides the anchor-classification non-goal), and if that is not enough the
+widening ships behind `--wide` while default behavior reverts to SPEC-0023;
+(b) the widened scan makes `aireceipts pr` noticeably slower in dogfood
+(> ~2× SPEC-0023 wall time on the maintainer's machine) → the anchor pool gets
+a hard load cap with an honest "K overlapping sessions not scanned" note.
+
+## Requirements
+
+- **R1 — Anchor pool: time-overlap is the bound, SHA anchor is the only key.**
+  The candidate set becomes the union of two pools, and each candidate carries
+  which pool admitted it (the credit rules differ):
+  - the **repo pool** — SPEC-0023's `isBranchCandidate`, unchanged
+    (non-sidechain, cwd in repo roots, window overlaps a branch commit
+    ±15 min), with its existing credit rules: own anchor for any source, plus
+    the SHA-less cwd+time helper rule for Codex in the **current** worktree;
+  - the **anchor pool** — every other listed session (any source, any `cwd`
+    including none, flagged sidechains included) whose time window overlaps a
+    branch commit (±15 min, `OVERLAP_SLACK_MS`). The overlap test is the
+    issue's "mtime bound": `endedAt` derives from the transcript (or file
+    mtime in lazy mode, `src/parse/discovery.ts:113`); `aireceipts pr` itself
+    lists via `listFullSessions` (`src/pr/index.ts:37`), so no new config knob
+    and no discovery change — only the filter in front of `selectContributors`
+    widens.
+  An anchor-pool session is loaded and credited **iff** `classifyBranchAnchors`
+  finds an own branch-SHA anchor. The Codex helper rule never applies to the
+  anchor pool (a SHA-less Codex sidechain or cross-repo session is not
+  credited), and anchor-pool misses are silently ignored — another repo's (or
+  another parent's) work is not "plausibly ours" noise, so `excludedCount`
+  semantics stay exactly SPEC-0023's (repo-pool, this-worktree only).
+  `selectContributors` (`src/pr/contributors.ts:53`) therefore takes the pool
+  tag as input; crediting logic branches on it, nothing else changes.
+- **R2 — Orphan sidechain promotion, dedup-safe.** A SHA-anchored **listed**
+  sidechain (a flagged, top-level-list transcript — case 1 above) becomes a
+  top-level contributor **iff** its `filePath` is not already one of another
+  contributor's rolled-up subagent rows (`SubagentRow.filePath`). Today no
+  flagged sidechain can appear in a rollup (rollups are path-based), so the
+  guard is a cheap safety invariant, not dead logic: it keys on *observed
+  rollup membership*, not parent linkage, so no token is ever counted twice
+  (I3) even if a future adapter links flagged sidechains to parents. This is
+  deliberately stronger than issue #51's "parent not itself a contributor".
+- **R3 — Orchestration order changes in `src/pr/index.ts`; the machinery is
+  reused.** `runPr` currently resolves contributors, then builds each view
+  (slice → price → rollup) — `src/pr/index.ts:95`. R2's guard needs rollups
+  before promotion, so the order becomes: resolve non-sidechain contributors →
+  build their views (computing rollups) → promote anchored listed sidechains
+  whose `filePath` no rollup covers → build promoted views → merge and sort
+  the final set chronologically (startedAt, then id — SPEC-0023's order).
+  `computeSlice`, `rollupChildren`, `deriveRole` (a promoted teammate
+  typically renders `builder`; a cross-repo lead that spawned agents renders
+  `orchestrator`), pricing, and the comment body are reused as-is; the body
+  shape is untouched.
+- **R4 — Explicit selection and empty-set behavior unchanged.**
+  `--session <id>` still resolves exactly one session (`selectExplicitSession`,
+  which can already name a child by stem). Zero contributors after widening →
+  the same NO_MATCH message + exit 1.
+
+## Scenarios
+
+- **Given** a lead session under `~/.claude/projects/<other-repo>/` whose
+  transcript contains `git commit` output with this branch's SHA, **when**
+  `aireceipts pr` runs, **then** it renders as a contributor row (role
+  `orchestrator` when it launched agents) and its path-based subagent children
+  roll up under it.
+- **Given** an agent-team teammate sidechain with an own branch-SHA anchor that
+  no contributor's rollup covers, **when** `aireceipts pr` runs, **then** it is
+  promoted to a top-level row and the combined total includes it exactly once.
+- **Given** a cross-repo session that time-overlaps but has no branch-SHA
+  anchor, **when** `aireceipts pr` runs, **then** it is neither credited nor
+  counted in the "not attributed" note.
+- **Given** a SHA-less Codex helper in the **current** worktree, **when**
+  `aireceipts pr` runs, **then** it is still credited (repo-pool rule
+  unchanged); **given** the same helper in another repo or as a sidechain,
+  **then** it is not.
+- **Given** the same fixture set, **when** `aireceipts pr` runs repeatedly,
+  **then** the body is byte-identical and promoted rows interleave with
+  repo-pool rows in chronological order.
+
+## Non-goals
+
+- **Any non-SHA credit outside the repo's worktrees.** cwd+time never proves
+  cross-repo authorship; if it can't be anchored, it isn't credited. (Honesty
+  over completeness — SPEC-0023's kill criterion already fired once.)
+- **Changing anchor classification** (the 7–40-hex prefix rule,
+  `src/pr/gitWrite.ts:222`) — reused as-is, *except* as the kill criterion's
+  named full-40-hex contingency, which fires only on an observed false
+  positive.
+- **Promoting orphan path-based children** (`<parent>/subagents/agent-*.jsonl`
+  whose parent is not a contributor). They are excluded from the top-level
+  list (`src/parse/claudeCode.ts:365`), so promotion cannot see them without a
+  new discovery pass; the issue's observed cases are flagged sidechains and
+  cross-repo leads, both covered. Revisit on a real dogfood case.
+- **Recursive promotion** (a promoted sidechain's own sidechains). One level,
+  same reason.
+- **A "scanned N repos" line in the comment body.** The body shape is
+  SPEC-0023's; methodology stays in `--methodology`.
+- **Discovery/perf work.** SPEC-0022 owns discovery perf; this spec only widens
+  a filter over the already-listed sessions and records the measured impact in
+  its PR (success criteria).
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 cross-repo lead | summary cwd outside roots, own anchor in output | contributor; sliced; role per structure |
+| R1 cross-repo no-anchor | cwd outside roots, overlap, no branch SHA | ignored; excludedCount unchanged |
+| R1 no-cwd anchored | summary without `cwd`, own anchor | contributor (anchor beats missing cwd) |
+| R1 overlap bound | cross-repo anchored session outside ±15 min of every commit | not loaded, not credited |
+| R1 helper rule preserved | SHA-less Codex, no writes, current worktree | still credited (repo pool) |
+| R1 codex cross-repo SHA-less | Codex helper, other repo, no writes | not credited (helper rule never widens) |
+| R1 codex sidechain SHA-less | flagged Codex-style sidechain, no anchor | not credited |
+| R1 any-source anchor | non-Claude, non-Codex source with own anchor | contributor (anchor is source-agnostic) |
+| R2 orphan flagged sidechain | listed `isSidechain` summary, own anchor, no rollup covers it | promoted top-level row |
+| R2 flagged sidechain, lead contributes | sidechain w/ anchor; lead's rollup does NOT list it | promoted (counted nowhere else) |
+| R2 dedup guard | promoted-candidate `filePath` equals a contributor's `SubagentRow.filePath` | not promoted; total counts it once |
+| R2 anchorless sidechain | sidechain, overlap, no anchor | not promoted, not counted |
+| R3 rollup for promoted/cross-repo | promoted or cross-repo contributor with path-based children | children roll up under it |
+| R3 sort after promotion | promoted row starting before a repo-pool row | final order chronological across pools |
+| R3 determinism | same fixture set, 10 runs | byte-identical body (I1) |
+| R4 explicit child | `--session <child-stem>` | single-contributor body (unchanged) |
+| R4 empty | widened pool has no anchored session | NO_MATCH + exit 1 |
+
+## Success criteria
+
+- [ ] This spec's own implementation PR carries a receipt that includes the
+      lead/orchestrator session (the exact gap of issue #51's second comment)
+      or documents why none existed for that PR.
+- [ ] No false-positive row in dogfood (kill criterion (a) not fired) — every
+      row on the posted receipt is checkable against a branch anchor or the
+      repo-pool helper rule.
+- [ ] The PR body states, from the maintainer's machine, how many sessions the
+      anchor pool loaded for this repo's own PR and the added wall time —
+      kill criterion (b) evaluated against those numbers.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass
+      unmasked (`echo $?`); goldens untouched (the PR comment body is not
+      golden-gated).
+
+## Validation
+
+**2026-07-02 · S1 (self):** all requirements compute deterministically from
+local transcripts + git; no predictions, no new money semantics. Collision
+exposure of machine-wide anchor scanning checked against the real matcher:
+anchors require a ≥7-hex run inside a git-write span's OUTPUT prefix-matching
+a branch SHA (`src/pr/slice.ts:33`, `src/pr/gitWrite.ts:222`) — negligible
+odds, with kill criterion (a) as the named escalation. Invariant header
+corrected in rework (see S2 finding 1).
+
+**2026-07-02 · S2 (Codex, read-only): REWORK → draft reworked.** Findings and
+disposition:
+1. "Every credited row is SHA-provable" false while the Codex helper rule
+   remains — **accepted**; invariants line now scopes the claim to newly
+   reachable rows.
+2. `selectContributors` can't distinguish pools; naive union would misapply
+   the helper rule and excludedCount — **accepted**; R1 now requires a pool
+   tag with branching credit rules.
+3. Orphan path-based children aren't in the top-level list, so their
+   promotion was unimplementable as written — **accepted**; promotion scoped
+   to listed flagged sidechains (the issue's observed case); orphan path-based
+   children moved to Non-goals pending a dogfood case.
+4. `pr` lists via `listFullSessions`, so the lazy-mtime bound wasn't the real
+   path — **accepted**; R1 now names the actual seam and clarifies only the
+   filter widens.
+5. "Reuse unchanged" hid a required orchestration reorder in `runPr` —
+   **accepted**; now explicit as R3.
+6. Full-40-hex contingency contradicted the anchor-classification non-goal —
+   **accepted**; non-goal now carves out the named contingency.
+7. Missing matrix rows (helper preserved, sidechain Codex, sort-after-
+   promotion, dedup guard, promoted-contributor rollup, any-source anchor) —
+   **accepted**; rows added.
+8. Dogfood/perf claims not fixture-testable — **partially rejected**: dogfood
+   success criteria are house style (SPEC-0023 precedent); PR-referenced
+   motivation stays in Purpose. Perf moved out of Requirements (see 10).
+9. Kill-criterion contingencies (`--wide`, caps) called scope creep —
+   **rejected**: naming the narrowing path inside the kill criterion is house
+   style (SPEC-0023's fired kill criterion did exactly this).
+10. R5 (perf statement) was process, not product behavior — **accepted**; cut
+    as a requirement, kept as a success-criteria checkbox.
+Wrong citation (`claudeCode.ts:339` for the scan) — **accepted**; now `:362`
+and `:365`.
+
+**2026-07-02 · S3 (value gate):** kill-criterion dry run. Evidence this
+survives (a): the anchor key is the same one SPEC-0023 dogfooded — its only
+false-positive incident came from the *SHA-less* rule, which this spec
+explicitly refuses to widen; anchor-pool credit is anchor-only. Evidence for
+(b): the pool is bounded by ±15 min overlap with branch commits, and the
+cheapest experiment is built into the success criteria — the implementation
+PR must publish the measured load count + wall-time delta from the
+maintainer's machine before merge.
+
+**2026-07-02 · S4 (lint):** `node scripts/spec-lint.mjs` → 25 spec(s) OK,
+exit 0.
+
+Status remains draft pending maintainer approval (button 1).

--- a/src/pr/contributors.ts
+++ b/src/pr/contributors.ts
@@ -15,6 +15,21 @@ import { isCodexExec, toolCallInvocations } from "./gitWrite.js";
 
 export type Role = "orchestrator" | "builder" | "codex";
 
+/**
+ * SPEC-0024 R1 — which pool admitted a candidate decides its credit rules:
+ * `repo` (cwd in a repo worktree, non-sidechain — SPEC-0023's set) keeps the
+ * SHA-less Codex helper rule and the honest excluded count; `anchor` (any
+ * other time-overlapping session, any cwd) is credited on an own branch-SHA
+ * anchor ONLY, and its misses are silently ignored — another repo's work is
+ * not "plausibly ours" noise.
+ */
+export type CandidatePool = "repo" | "anchor";
+
+export interface PoolCandidate {
+  summary: SessionSummary;
+  pool: CandidatePool;
+}
+
 /** One session credited to the PR: the loaded session and its own PR-scoped slice. */
 export interface RawContributor {
   summary: SessionSummary;
@@ -40,26 +55,26 @@ function inCurrentWorktree(summary: SessionSummary, currentRoot: string | null):
 }
 
 /**
- * Select the contributing sessions from pre-filtered candidates (R1). Loads each
- * candidate to inspect its git-write anchors — the summary-level filter has
- * already bounded this to cwd-in-repo, time-overlapping, non-sidechain sessions.
- * A branch-SHA anchor credits any session regardless of worktree (SHA proof);
- * the SHA-less Codex helper rule is scoped to THIS worktree so unrelated
- * concurrent Codex work in sibling worktrees is not credited. Only plausible
- * (this-worktree) exclusions are counted — a sibling-worktree candidate that
- * only passed the repo-wide filter is silently ignored, not reported as noise.
- * Deterministic order: chronological by start, then session id.
+ * Select the contributing sessions from pre-filtered, pool-tagged candidates
+ * (R1; SPEC-0024 widens). Loads each candidate to inspect its git-write
+ * anchors. A branch-SHA anchor credits any session regardless of pool or
+ * worktree (SHA proof); the SHA-less Codex helper rule and the honest excluded
+ * count apply to the repo pool only — an anchor-pool candidate (cross-repo cwd
+ * or none) is credited on its own anchor or silently ignored. Deterministic
+ * order: chronological by start, then session id.
  */
 export async function selectContributors(
-  candidates: SessionSummary[],
+  candidates: PoolCandidate[],
   branchShas: readonly string[],
   deps: ContributorDeps,
 ): Promise<ContributorSelection> {
   const contributors: RawContributor[] = [];
   let excludedCount = 0;
 
-  for (const summary of candidates) {
-    const here = inCurrentWorktree(summary, deps.currentWorktreeRoot);
+  for (const { summary, pool } of candidates) {
+    // `here` gates both softeners (helper rule, excluded count) — always false
+    // for the anchor pool, where the SHA anchor is the only key (SPEC-0024 R1).
+    const here = pool === "repo" && inCurrentWorktree(summary, deps.currentWorktreeRoot);
     const session = await deps.loadSession(summary);
     if (!session) {
       // A candidate we can't load can't be proven — count it only if it's plausibly ours.
@@ -70,10 +85,11 @@ export async function selectContributors(
     }
     const anchors = classifyBranchAnchors(session.turns, branchShas);
     const isCodex = summary.source === "codex";
-    // Own branch SHA → contributes (any source, SHA-proven). Codex that made NO
-    // git writes at all AND ran in this worktree → a pure helper (cwd+time). A
-    // session that committed/pushed but produced no branch SHA, or a SHA-less
-    // Codex session from a sibling worktree, is not proven ours (R1).
+    // Own branch SHA → contributes (any source, any pool, SHA-proven). Codex
+    // that made NO git writes at all AND ran in this worktree → a pure helper
+    // (cwd+time, repo pool only). A session that committed/pushed but produced
+    // no branch SHA, or a SHA-less Codex session from a sibling worktree or
+    // the anchor pool, is not proven ours (R1).
     const include = anchors.hasOwn || (isCodex && anchors.writeCount === 0 && here);
     if (include) {
       contributors.push({ summary, session, slice: computeSlice(session.turns, branchShas) });
@@ -81,7 +97,7 @@ export async function selectContributors(
       // Plausibly ours (this worktree) but unproven — surface it in the honest note.
       excludedCount++;
     }
-    // else: a sibling-worktree candidate with no branch-SHA proof — another branch's work, ignored.
+    // else: a sibling-worktree or anchor-pool candidate with no branch-SHA proof — not ours, ignored.
   }
 
   contributors.sort(

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -1,17 +1,21 @@
-// SPEC-0023 (widens SPEC-0019) — `aireceipts pr` orchestration. Selects EVERY
-// session that built the current branch (R1: Claude by branch-SHA anchor, Codex
-// by cwd+time), slices each to its own PR turn range (R1e), rolls up each one's
-// subagents (R1c), labels a descriptive role (R3), and renders one body with
-// per-session rows + a single combined total (R4). R3 of SPEC-0019 is still the
-// spine: the full pasteable body is ALWAYS written to stdout BEFORE any `gh`
-// call. `--session <id>` still resolves exactly one session (R5).
+// SPEC-0023 (widens SPEC-0019) + SPEC-0024 — `aireceipts pr` orchestration.
+// Selects EVERY session that built the current branch: the repo pool (cwd in a
+// worktree; Claude by branch-SHA anchor, Codex by cwd+time) plus SPEC-0024's
+// anchor pool (any time-overlapping session — cross-repo leads — credited on
+// an own branch-SHA anchor ONLY). Each contributor is sliced to its PR turn
+// range (R1e), its subagents rolled up (R1c), then orphan SHA-anchored listed
+// sidechains no rollup covers are promoted (SPEC-0024 R2/R3) and the merged
+// set sorts chronologically. R3 of SPEC-0019 is still the spine: the full
+// pasteable body is ALWAYS written to stdout BEFORE any `gh` call.
+// `--session <id>` still resolves exactly one session (R5).
 import * as path from "node:path";
 import type { Session, SessionSummary } from "../parse/types.js";
 import { buildReceiptModel, sliceSessionForReceipt } from "../receipt/model.js";
 import { branchCommits, currentWorktreeRoot, defaultRunner, worktreeRoots, type CommandRunner } from "./git.js";
-import { isBranchCandidate, selectExplicitSession } from "./select.js";
+import { isBranchCandidate, overlapsBranchWindow, selectExplicitSession } from "./select.js";
 import { computeSlice } from "./slice.js";
-import { deriveRole, selectContributors, type RawContributor } from "./contributors.js";
+import { deriveRole, selectContributors, type PoolCandidate, type RawContributor } from "./contributors.js";
+import { promoteOrphanSidechains } from "./promote.js";
 import { rollupChildren, type RollupWindow, type SubagentRow } from "./rollup.js";
 import { renderPrBody, type ContributorView } from "./body.js";
 import { upsertPrComment } from "./comment.js";
@@ -52,13 +56,26 @@ function stemOf(filePath: string): string {
   return path.basename(filePath).replace(/\.jsonl$/, "");
 }
 
-/** Resolve the contributor set: explicit --session → exactly one (R5); else the conservative auto-selected set (R1). */
+interface Resolved {
+  contributors: RawContributor[];
+  excludedCount: number;
+  /** Time-overlapping listed sidechains — SPEC-0024 R2 promotion candidates, judged after rollups. */
+  sidechains: SessionSummary[];
+}
+
+/**
+ * Resolve the contributor set: explicit --session → exactly one (R5); else the
+ * conservative auto-selected union of the repo pool and SPEC-0024's anchor
+ * pool (R1). Sidechain candidates are returned for the post-rollup promotion
+ * pass, so an empty contributor list here is not yet a NO_MATCH — `runPr`
+ * decides after promotion (SPEC-0024 R4).
+ */
 async function resolveContributors(
   opts: PrOptions,
   deps: PrDeps,
   shas: readonly string[],
   commitMs: readonly number[],
-): Promise<{ contributors: RawContributor[]; excludedCount: number } | { error: string }> {
+): Promise<Resolved | { error: string }> {
   const sessions = await deps.listSessions();
 
   if (opts.session) {
@@ -70,25 +87,41 @@ async function resolveContributors(
     if (!session) {
       return { error: `failed to load session "${summary.id}"` };
     }
-    return { contributors: [{ summary, session, slice: computeSlice(session.turns, shas) }], excludedCount: 0 };
+    return {
+      contributors: [{ summary, session, slice: computeSlice(session.turns, shas) }],
+      excludedCount: 0,
+      sidechains: [],
+    };
   }
 
   if (sessions.length === 0) {
     return { error: "no agent sessions found on disk" };
   }
   const roots = worktreeRoots(deps.runGit, deps.cwd);
-  const candidates = sessions.filter((s) => isBranchCandidate(s, roots, commitMs));
-  if (candidates.length === 0) {
+  const candidates: PoolCandidate[] = [];
+  const sidechains: SessionSummary[] = [];
+  for (const s of sessions) {
+    if (isBranchCandidate(s, roots, commitMs)) {
+      candidates.push({ summary: s, pool: "repo" });
+    } else if (overlapsBranchWindow(s, commitMs)) {
+      // SPEC-0024 R1/R2 — time-overlapping but outside the repo pool: flagged
+      // sidechains queue for promotion; everything else (cross-repo leads,
+      // no-cwd sessions) joins the anchor pool, credited on SHA proof only.
+      if (s.isSidechain === true) {
+        sidechains.push(s);
+      } else {
+        candidates.push({ summary: s, pool: "anchor" });
+      }
+    }
+  }
+  if (candidates.length === 0 && sidechains.length === 0) {
     return { error: NO_MATCH };
   }
   const selection = await selectContributors(candidates, shas, {
     loadSession: deps.loadSession,
     currentWorktreeRoot: currentWorktreeRoot(deps.runGit, deps.cwd) ?? deps.cwd,
   });
-  if (selection.contributors.length === 0) {
-    return { error: NO_MATCH };
-  }
-  return selection;
+  return { ...selection, sidechains };
 }
 
 /** Slice → price → roll up → role each contributor into what the comment renders (R2/R3). */
@@ -122,10 +155,29 @@ export async function runPr(opts: PrOptions, deps: PrDeps = defaultPrDeps()): Pr
     return 1;
   }
 
-  const views: ContributorView[] = [];
+  // SPEC-0024 R3 ordering: base views first (their rollups define what is
+  // already counted), then promotion of uncovered anchored sidechains, then
+  // one chronological sort across both (startedAt, then id — SPEC-0023 order).
+  const entries: { view: ContributorView; startedAt: number; id: string }[] = [];
+  const covered = new Set<string>();
   for (const raw of resolved.contributors) {
-    views.push(await buildContributorView(raw, deps));
+    const view = await buildContributorView(raw, deps);
+    covered.add(raw.summary.filePath);
+    for (const row of view.subagents) {
+      covered.add(row.filePath);
+    }
+    entries.push({ view, startedAt: raw.session.startedAt ?? 0, id: raw.summary.id });
   }
+  const promoted = await promoteOrphanSidechains(resolved.sidechains, shas, covered, deps.loadSession);
+  for (const raw of promoted) {
+    entries.push({ view: await buildContributorView(raw, deps), startedAt: raw.session.startedAt ?? 0, id: raw.summary.id });
+  }
+  if (entries.length === 0) {
+    deps.err(NO_MATCH);
+    return 1;
+  }
+  entries.sort((a, b) => a.startedAt - b.startedAt || a.id.localeCompare(b.id));
+  const views = entries.map((e) => e.view);
   const body = renderPrBody({ contributors: views, excludedCount: resolved.excludedCount });
 
   // R3 (SPEC-0019): render first, unconditionally — before any gh call.

--- a/src/pr/promote.ts
+++ b/src/pr/promote.ts
@@ -1,0 +1,43 @@
+// SPEC-0024 R2 — promote orphan SHA-anchored listed sidechains to top-level
+// contributors. An agent-team teammate is a flagged sidechain (`isSidechain`
+// in the top-level list) that neither `isBranchCandidate` nor `rollupChildren`
+// ever sees — its cost is counted nowhere even when its slice SHA-provably
+// authored the branch (issue #51). Promotion is dedup-safe: a candidate whose
+// `filePath` is already covered (a contributor itself, or any contributor's
+// rolled-up `SubagentRow`) is skipped, so no token is ever counted twice (I3).
+import type { Session, SessionSummary } from "../parse/types.js";
+import type { RawContributor } from "./contributors.js";
+import { classifyBranchAnchors, computeSlice } from "./slice.js";
+
+/**
+ * Load each time-overlapping listed sidechain and promote it iff it carries an
+ * own branch-SHA anchor and is not already counted elsewhere. Anchor-only:
+ * there is no cwd+time credit for sidechains, and misses are silently ignored
+ * (another parent's work is not "plausibly ours" noise). Deterministic order:
+ * chronological by start, then session id.
+ */
+export async function promoteOrphanSidechains(
+  sidechains: SessionSummary[],
+  branchShas: readonly string[],
+  coveredFilePaths: ReadonlySet<string>,
+  loadSession: (summary: SessionSummary) => Promise<Session | null>,
+): Promise<RawContributor[]> {
+  const promoted: RawContributor[] = [];
+  const ordered = [...sidechains].sort(
+    (a, b) => (a.startedAt ?? 0) - (b.startedAt ?? 0) || a.id.localeCompare(b.id),
+  );
+  for (const summary of ordered) {
+    if (coveredFilePaths.has(summary.filePath)) {
+      continue;
+    }
+    const session = await loadSession(summary);
+    if (!session) {
+      continue;
+    }
+    if (!classifyBranchAnchors(session.turns, branchShas).hasOwn) {
+      continue;
+    }
+    promoted.push({ summary, session, slice: computeSlice(session.turns, branchShas) });
+  }
+  return promoted;
+}

--- a/src/pr/select.ts
+++ b/src/pr/select.ts
@@ -48,6 +48,16 @@ function overlaps(startedAt: number, endedAt: number, commitMs: readonly number[
 }
 
 /**
+ * SPEC-0024 R1 — the anchor pool's summary-level bound: a timestamped session
+ * whose window overlaps a branch commit (±15 min). `cwd` and sidechain status
+ * are deliberately not consulted — an anchor-pool session is only ever credited
+ * on an own branch-SHA anchor, so the time bound is all the pre-filter needs.
+ */
+export function overlapsBranchWindow(s: SessionSummary, commitMs: readonly number[]): boolean {
+  return s.startedAt !== undefined && s.endedAt !== undefined && overlaps(s.startedAt, s.endedAt, commitMs);
+}
+
+/**
  * The cheap, summary-level candidate predicate shared by SPEC-0019's
  * `selectCandidates` and SPEC-0023's contributor set: a non-sidechain session
  * whose `cwd` is inside a repo worktree root (R1b) and whose time window
@@ -58,12 +68,7 @@ function overlaps(startedAt: number, endedAt: number, commitMs: readonly number[
  */
 export function isBranchCandidate(s: SessionSummary, roots: string[], commitMs: readonly number[]): boolean {
   return (
-    !s.isSidechain &&
-    typeof s.cwd === "string" &&
-    cwdInsideRoots(s.cwd, roots) &&
-    s.startedAt !== undefined &&
-    s.endedAt !== undefined &&
-    overlaps(s.startedAt, s.endedAt, commitMs)
+    !s.isSidechain && typeof s.cwd === "string" && cwdInsideRoots(s.cwd, roots) && overlapsBranchWindow(s, commitMs)
   );
 }
 

--- a/test/pr/contributors.test.ts
+++ b/test/pr/contributors.test.ts
@@ -10,7 +10,7 @@ import type { AgentSource, Session, SessionSummary, Turn } from "../../src/parse
 import { emptyUsage, withTotal } from "../../src/parse/util.js";
 import { loadById } from "../../src/parse/load.js";
 import { classifyBranchAnchors } from "../../src/pr/slice.js";
-import { deriveRole, selectContributors } from "../../src/pr/contributors.js";
+import { deriveRole, selectContributors, type PoolCandidate } from "../../src/pr/contributors.js";
 
 const BRANCH_SHA = "b1c2d3e4f5061728394a5b6c7d8e9f0011223344";
 const FIX = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "pr");
@@ -56,6 +56,14 @@ function summaryOf(s: Session): SessionSummary {
   return s;
 }
 
+/** Pool-tagged candidates (SPEC-0024 R1): repo pool keeps SPEC-0023 rules; anchor pool is SHA-anchor-only. */
+function repo(s: Session): PoolCandidate {
+  return { summary: s, pool: "repo" };
+}
+function anchor(s: Session): PoolCandidate {
+  return { summary: s, pool: "anchor" };
+}
+
 /** A loader that resolves candidates from a fixed map; unknown ids resolve to null (unreadable). Scoped to CURRENT_ROOT. */
 function loaderFor(sessions: Session[]) {
   const byId = new Map(sessions.map((s) => [s.id, s]));
@@ -72,7 +80,7 @@ describe("R1 contributor selection", () => {
   it("credits two own-anchored Claude sessions (the union — no 'pick one' error)", async () => {
     const a = ownCommit("a", 1000);
     const b = ownCommit("b", 3000);
-    const sel = await selectContributors([summaryOf(a), summaryOf(b)], [BRANCH_SHA], loaderFor([a, b]));
+    const sel = await selectContributors([repo(a), repo(b)], [BRANCH_SHA], loaderFor([a, b]));
     expect(sel.contributors.map((c) => c.summary.id)).toEqual(["a", "b"]);
     expect(sel.excludedCount).toBe(0);
   });
@@ -80,14 +88,14 @@ describe("R1 contributor selection", () => {
   it("excludes a Claude session with no branch-SHA anchor and counts it (not attributed)", async () => {
     const owned = ownCommit("owned");
     const noAnchor = makeSession("edits", [namedToolTurn(0, "Edit", { file_path: "x.ts" })]);
-    const sel = await selectContributors([summaryOf(owned), summaryOf(noAnchor)], [BRANCH_SHA], loaderFor([owned, noAnchor]));
+    const sel = await selectContributors([repo(owned), repo(noAnchor)], [BRANCH_SHA], loaderFor([owned, noAnchor]));
     expect(sel.contributors.map((c) => c.summary.id)).toEqual(["owned"]);
     expect(sel.excludedCount).toBe(1);
   });
 
   it("credits a Codex helper that made no git writes in THIS worktree (cwd+time rule)", async () => {
     const helper = makeSession("cx-help", [bashTurn(0, "ls -la", "src\ntest")], "codex");
-    const sel = await selectContributors([summaryOf(helper)], [BRANCH_SHA], loaderFor([helper]));
+    const sel = await selectContributors([repo(helper)], [BRANCH_SHA], loaderFor([helper]));
     expect(sel.contributors.map((c) => c.summary.id)).toEqual(["cx-help"]);
     expect(sel.excludedCount).toBe(0);
   });
@@ -96,7 +104,7 @@ describe("R1 contributor selection", () => {
     // A codex session doing unrelated work in another worktree of the same repo,
     // overlapping this branch's window. cwd is a sibling → silently ignored.
     const sibling = makeSession("cx-sibling", [bashTurn(0, "ls -la", "src")], "codex", 1000, "/home/dev/repo-spec9999");
-    const sel = await selectContributors([summaryOf(sibling)], [BRANCH_SHA], loaderFor([sibling]));
+    const sel = await selectContributors([repo(sibling)], [BRANCH_SHA], loaderFor([sibling]));
     expect(sel.contributors).toHaveLength(0);
     expect(sel.excludedCount).toBe(0); // not plausible for this branch → not even noted
   });
@@ -104,19 +112,19 @@ describe("R1 contributor selection", () => {
   it("still credits a sibling-worktree session that carries a branch-SHA anchor (SHA proof beats worktree scope)", async () => {
     const sibling = ownCommit("builder-sibling", 1000, "claude-code");
     sibling.cwd = "/home/dev/repo-spec9999";
-    const sel = await selectContributors([summaryOf(sibling)], [BRANCH_SHA], loaderFor([sibling]));
+    const sel = await selectContributors([repo(sibling)], [BRANCH_SHA], loaderFor([sibling]));
     expect(sel.contributors.map((c) => c.summary.id)).toEqual(["builder-sibling"]);
   });
 
   it("credits an own-anchored Codex session", async () => {
     const cx = ownCommit("cx-own", 1000, "codex");
-    const sel = await selectContributors([summaryOf(cx)], [BRANCH_SHA], loaderFor([cx]));
+    const sel = await selectContributors([repo(cx)], [BRANCH_SHA], loaderFor([cx]));
     expect(sel.contributors.map((c) => c.summary.id)).toEqual(["cx-own"]);
   });
 
   it("excludes a foreign-only session (committed to another branch) and counts it", async () => {
     const foreign = makeSession("cx-foreign", [bashTurn(0, "git commit -m y", "[other deadbee1] y\n 1 file changed")], "codex");
-    const sel = await selectContributors([summaryOf(foreign)], [BRANCH_SHA], loaderFor([foreign]));
+    const sel = await selectContributors([repo(foreign)], [BRANCH_SHA], loaderFor([foreign]));
     expect(sel.contributors).toHaveLength(0);
     expect(sel.excludedCount).toBe(1);
   });
@@ -125,15 +133,15 @@ describe("R1 contributor selection", () => {
     // Regression (codex review): `writeCount` must count git writes independent of
     // SHA output, so this is NOT mistaken for a no-git-writes helper.
     const noop = makeSession("cx-noop", [bashTurn(0, "git commit -m x", "nothing to commit, working tree clean")], "codex");
-    const sel = await selectContributors([summaryOf(noop)], [BRANCH_SHA], loaderFor([noop]));
+    const sel = await selectContributors([repo(noop)], [BRANCH_SHA], loaderFor([noop]));
     expect(sel.contributors).toHaveLength(0);
     expect(sel.excludedCount).toBe(1);
   });
 
   it("counts a candidate it can't load as excluded, never guessed in", async () => {
     const owned = ownCommit("owned");
-    const ghost = summaryOf(makeSession("ghost", []));
-    const sel = await selectContributors([summaryOf(owned), ghost], [BRANCH_SHA], loaderFor([owned]));
+    const ghost = repo(makeSession("ghost", []));
+    const sel = await selectContributors([repo(owned), ghost], [BRANCH_SHA], loaderFor([owned]));
     expect(sel.contributors.map((c) => c.summary.id)).toEqual(["owned"]);
     expect(sel.excludedCount).toBe(1);
   });
@@ -141,8 +149,56 @@ describe("R1 contributor selection", () => {
   it("orders contributors chronologically by session start", async () => {
     const late = ownCommit("late", 5000);
     const early = ownCommit("early", 1000);
-    const sel = await selectContributors([summaryOf(late), summaryOf(early)], [BRANCH_SHA], loaderFor([late, early]));
+    const sel = await selectContributors([repo(late), repo(early)], [BRANCH_SHA], loaderFor([late, early]));
     expect(sel.contributors.map((c) => c.summary.id)).toEqual(["early", "late"]);
+  });
+});
+
+
+describe("SPEC-0024 R1 anchor pool (SHA anchor is the only key)", () => {
+  it("credits a cross-repo lead on its own branch-SHA anchor (cwd outside every repo root)", async () => {
+    const lead = ownCommit("lead-other-repo", 1000);
+    lead.cwd = "/home/dev/OTHER-repo";
+    const sel = await selectContributors([anchor(lead)], [BRANCH_SHA], loaderFor([lead]));
+    expect(sel.contributors.map((c) => c.summary.id)).toEqual(["lead-other-repo"]);
+    expect(sel.excludedCount).toBe(0);
+  });
+
+  it("silently ignores a cross-repo session with no anchor — not credited, not counted as excluded", async () => {
+    const bystander = makeSession("bystander", [namedToolTurn(0, "Edit", { file_path: "x.ts" })], "claude-code", 1000, "/home/dev/OTHER-repo");
+    const sel = await selectContributors([anchor(bystander)], [BRANCH_SHA], loaderFor([bystander]));
+    expect(sel.contributors).toHaveLength(0);
+    expect(sel.excludedCount).toBe(0);
+  });
+
+  it("credits an anchored session with no cwd at all (anchor beats missing cwd)", async () => {
+    const noCwd = ownCommit("no-cwd", 1000);
+    noCwd.cwd = undefined;
+    const sel = await selectContributors([anchor(noCwd)], [BRANCH_SHA], loaderFor([noCwd]));
+    expect(sel.contributors.map((c) => c.summary.id)).toEqual(["no-cwd"]);
+  });
+
+  it("never applies the SHA-less Codex helper rule to the anchor pool — even for a current-worktree cwd", async () => {
+    // Same session shape the repo pool WOULD credit as a helper; in the anchor
+    // pool the SHA anchor is the only key (SPEC-0024 R1).
+    const helper = makeSession("cx-anchor-pool", [bashTurn(0, "ls -la", "src")], "codex");
+    const sel = await selectContributors([anchor(helper)], [BRANCH_SHA], loaderFor([helper]));
+    expect(sel.contributors).toHaveLength(0);
+    expect(sel.excludedCount).toBe(0);
+  });
+
+  it("anchor credit is source-agnostic (a non-Claude, non-Codex session with an own anchor contributes)", async () => {
+    const gem = ownCommit("gem", 1000, "gemini");
+    gem.cwd = "/home/dev/OTHER-repo";
+    const sel = await selectContributors([anchor(gem)], [BRANCH_SHA], loaderFor([gem]));
+    expect(sel.contributors.map((c) => c.summary.id)).toEqual(["gem"]);
+  });
+
+  it("an unloadable anchor-pool candidate is ignored, never counted in the excluded note", async () => {
+    const ghost = anchor(makeSession("anchor-ghost", []));
+    const sel = await selectContributors([ghost], [BRANCH_SHA], loaderFor([]));
+    expect(sel.contributors).toHaveLength(0);
+    expect(sel.excludedCount).toBe(0);
   });
 });
 

--- a/test/pr/promote.test.ts
+++ b/test/pr/promote.test.ts
@@ -1,0 +1,88 @@
+// SPEC-0024 R2 — orphan SHA-anchored listed sidechains promote to top-level
+// contributors, dedup-safe: a candidate already covered (a contributor's file
+// or any rolled-up SubagentRow.filePath) is skipped so no token counts twice
+// (I3); anchorless or unloadable sidechains are silently ignored (no cwd+time
+// credit for sidechains, ever).
+import { describe, expect, it } from "vitest";
+import type { Session, SessionSummary, Turn } from "../../src/parse/types.js";
+import { emptyUsage, withTotal } from "../../src/parse/util.js";
+import { promoteOrphanSidechains } from "../../src/pr/promote.js";
+
+const BRANCH_SHA = "b1c2d3e4f5061728394a5b6c7d8e9f0011223344";
+const usage = withTotal({ ...emptyUsage(), input: 1000, output: 100 });
+
+function commitTurn(index: number, output: string): Turn {
+  return {
+    index,
+    timestamp: 1000 + index,
+    model: "claude-opus-4-8",
+    usage,
+    toolCalls: [{ name: "Bash", input: { command: "git commit -m x" }, output, status: "ok" }],
+  };
+}
+
+function sidechain(id: string, turns: Turn[], startedAt = 1000): Session {
+  return {
+    id,
+    source: "claude-code",
+    filePath: `${id}.jsonl`,
+    cwd: "/home/dev/lead-repo",
+    isSidechain: true,
+    startedAt,
+    endedAt: startedAt + 1000,
+    totals: { tokens: usage, turnCount: turns.length, toolCallCount: turns.length },
+    turns,
+  };
+}
+
+const anchored = (id: string, startedAt = 1000) =>
+  sidechain(id, [commitTurn(0, "[featB b1c2d3e] x\n 1 file changed")], startedAt);
+
+function loader(sessions: Session[]) {
+  const byId = new Map(sessions.map((s) => [s.id, s]));
+  return async (summary: SessionSummary) => byId.get(summary.id) ?? null;
+}
+
+describe("SPEC-0024 R2 orphan sidechain promotion", () => {
+  it("promotes an anchored sidechain no rollup covers, with its own PR slice", async () => {
+    const teammate = anchored("teammate");
+    const promoted = await promoteOrphanSidechains([teammate], [BRANCH_SHA], new Set(), loader([teammate]));
+    expect(promoted.map((c) => c.summary.id)).toEqual(["teammate"]);
+    expect(promoted[0].slice.kind).toBe("slice");
+  });
+
+  it("skips a candidate whose filePath is already covered — the dedup guard (counted once)", async () => {
+    const teammate = anchored("teammate");
+    const covered = new Set([teammate.filePath]);
+    const promoted = await promoteOrphanSidechains([teammate], [BRANCH_SHA], covered, loader([teammate]));
+    expect(promoted).toHaveLength(0);
+  });
+
+  it("never promotes an anchorless sidechain (no cwd+time credit for sidechains)", async () => {
+    const idle = sidechain("idle", [commitTurn(0, "nothing to commit, working tree clean")]);
+    const promoted = await promoteOrphanSidechains([idle], [BRANCH_SHA], new Set(), loader([idle]));
+    expect(promoted).toHaveLength(0);
+  });
+
+  it("never promotes a sidechain whose only SHA is foreign (another branch's commit)", async () => {
+    const foreign = sidechain("foreign", [commitTurn(0, "[other deadbee1] y\n 1 file changed")]);
+    const promoted = await promoteOrphanSidechains([foreign], [BRANCH_SHA], new Set(), loader([foreign]));
+    expect(promoted).toHaveLength(0);
+  });
+
+  it("silently skips an unloadable sidechain", async () => {
+    const ghost = anchored("ghost");
+    const promoted = await promoteOrphanSidechains([ghost], [BRANCH_SHA], new Set(), loader([]));
+    expect(promoted).toHaveLength(0);
+  });
+
+  it("orders promotions chronologically by start, then id (deterministic)", async () => {
+    const late = anchored("late", 5000);
+    const early = anchored("early", 1000);
+    const tieB = anchored("tie-b", 3000);
+    const tieA = anchored("tie-a", 3000);
+    const all = [late, tieB, early, tieA];
+    const promoted = await promoteOrphanSidechains(all, [BRANCH_SHA], new Set(), loader(all));
+    expect(promoted.map((c) => c.summary.id)).toEqual(["early", "tie-a", "tie-b", "late"]);
+  });
+});

--- a/test/pr/run.test.ts
+++ b/test/pr/run.test.ts
@@ -138,10 +138,17 @@ describe("R3 render-first ordering", () => {
 
 describe("R1d selection outcomes", () => {
   it("zero matches → stderr message, exit 1, nothing rendered", async () => {
-    // Worktree root does not contain the fixture session's cwd (/home/dev/repo).
+    // Worktree root does not contain the fixture session's cwd, AND the session
+    // carries no branch-SHA anchor — since SPEC-0024, cwd alone no longer
+    // excludes an anchored session, so a true zero-match needs both.
     const gitElsewhere: CommandRunner = (_cmd, args) =>
       args[0] === "worktree" ? ok("worktree /other/root\n") : gitOk(_cmd, args);
-    const { deps, out, err } = await makeDeps({ runGit: gitElsewhere });
+    const anchorless = { ...(await loadById("claude-code", ANCHORS))!, turns: [] };
+    const { deps, out, err } = await makeDeps({
+      runGit: gitElsewhere,
+      listSessions: async () => [anchorless],
+      loadSession: async () => anchorless,
+    });
     const code = await runPr({ post: false }, deps);
     expect(code).toBe(1);
     expect(out).toHaveLength(0);
@@ -197,5 +204,105 @@ describe("R1d selection outcomes", () => {
     expect(code).toBe(1);
     expect(out).toHaveLength(0);
     expect(err.join("\n")).toContain('no session matched "missing-child"');
+  });
+});
+
+describe("SPEC-0024 attribution widening (e2e)", () => {
+  const otherRepo = "/home/dev/OTHER-repo";
+
+  async function crossRepoLead() {
+    const session = (await loadById("claude-code", ANCHORS))!;
+    // Recorded under another repo's project dir: cwd outside every worktree root.
+    return { ...session, id: "lead", filePath: "lead.jsonl", cwd: otherRepo };
+  }
+
+  it("credits a cross-repo lead on its branch-SHA anchor and rolls up its children", async () => {
+    const lead = await crossRepoLead();
+    const { deps, out } = await makeDeps({
+      listSessions: async () => [lead],
+      loadSession: async (summary) => (summary.id === "lead" ? lead : null),
+      rollup: async (parentFilePath) =>
+        parentFilePath === "lead.jsonl"
+          ? [{ name: "designer", model: "claude-opus-4-8", usd: null, tokens: lead.totals.tokens, unreadable: false, filePath: "lead/subagents/agent-designer.jsonl" }]
+          : [],
+    });
+    const code = await runPr({ post: false }, deps);
+    expect(code).toBe(0);
+    expect(out[0]).toContain("1 session behind this PR");
+    expect(out[0]).toContain("orchestrator · ");
+    expect(out[0]).toContain("lead · session slice");
+    expect(out[0]).toContain("SUBAGENTS (1)");
+    expect(out[0]).toContain("counted: 1 session + 1 subagent");
+  });
+
+  it("does NOT credit a cross-repo session whose window misses every branch commit (overlap bound)", async () => {
+    const lead = await crossRepoLead();
+    // Shift the window a day before the only branch commit (2026-06-28T10:02Z ± 15 min).
+    const stale = { ...lead, startedAt: Date.parse("2026-06-27T00:00:00.000Z"), endedAt: Date.parse("2026-06-27T01:00:00.000Z") };
+    let loads = 0;
+    const { deps, out, err } = await makeDeps({
+      listSessions: async () => [stale],
+      loadSession: async () => {
+        loads++;
+        return stale;
+      },
+    });
+    const code = await runPr({ post: false }, deps);
+    expect(code).toBe(1);
+    expect(out).toHaveLength(0);
+    expect(loads).toBe(0); // outside the bound → never even loaded
+    expect(err.join("\n")).toContain("no session matches");
+  });
+
+  it("promotes an anchored teammate sidechain to a top-level row, sorted chronologically with the builder", async () => {
+    const builder = (await loadById("claude-code", ANCHORS))!;
+    // The teammate started BEFORE the builder and is a flagged sidechain under the lead's (other) repo.
+    const teammate = { ...builder, id: "team-1", filePath: "team-1.jsonl", cwd: otherRepo, isSidechain: true, startedAt: (builder.startedAt ?? 0) - 60_000 };
+    const byId = new Map([[builder.id, builder], ["team-1", teammate]]);
+    const { deps, out } = await makeDeps({
+      listSessions: async () => [builder, teammate],
+      loadSession: async (summary) => byId.get(summary.id) ?? null,
+    });
+    const code = await runPr({ post: false }, deps);
+    expect(code).toBe(0);
+    expect(out[0]).toContain("2 sessions behind this PR");
+    // Chronological across pools: the promoted teammate row renders before the builder row.
+    expect(out[0].indexOf("team-1 · ")).toBeLessThan(out[0].indexOf("claude-anchors · "));
+    expect(out[0].indexOf("team-1 · ")).toBeGreaterThan(-1);
+    expect(out[0]).toContain("counted: 2 sessions");
+  });
+
+  it("does NOT promote a sidechain already covered by a contributor's rollup (dedup guard, counted once)", async () => {
+    const builder = (await loadById("claude-code", ANCHORS))!;
+    const teammate = { ...builder, id: "team-1", filePath: "team-1.jsonl", cwd: otherRepo, isSidechain: true };
+    const byId = new Map([[builder.id, builder], ["team-1", teammate]]);
+    const { deps, out } = await makeDeps({
+      listSessions: async () => [builder, teammate],
+      loadSession: async (summary) => byId.get(summary.id) ?? null,
+      // The builder's rollup already lists the teammate transcript by filePath.
+      rollup: async (parentFilePath) =>
+        parentFilePath === builder.filePath
+          ? [{ name: "team-1", model: "claude-opus-4-8", usd: null, tokens: teammate.totals.tokens, unreadable: false, filePath: "team-1.jsonl" }]
+          : [],
+    });
+    const code = await runPr({ post: false }, deps);
+    expect(code).toBe(0);
+    expect(out[0]).toContain("1 session behind this PR");
+    expect(out[0]).toContain("counted: 1 session + 1 subagent");
+  });
+
+  it("renders byte-identically across repeated runs with promotion in play (I1)", async () => {
+    const builder = (await loadById("claude-code", ANCHORS))!;
+    const teammate = { ...builder, id: "team-1", filePath: "team-1.jsonl", cwd: otherRepo, isSidechain: true, startedAt: (builder.startedAt ?? 0) - 60_000 };
+    const byId = new Map([[builder.id, builder], ["team-1", teammate]]);
+    const render = async () => {
+      const { deps, out } = await makeDeps({
+        listSessions: async () => [builder, teammate],
+        loadSession: async (summary) => byId.get(summary.id) ?? null,
+      });
+      expect(await runPr({ post: false }, deps)).toBe(0);
+      return out[0];
+    };
+    expect(await render()).toBe(await render());
   });
 });


### PR DESCRIPTION
## What this adds

`aireceipts pr` now credits **every session that SHA-provably authored the branch**, wherever it ran. Issue #51's two dogfooded gaps close: a lead orchestrating from another repo's working directory (recorded under that repo's project dir) now appears as a contributor row, and an agent-team teammate sidechain — previously counted **nowhere** — is promoted to its own row when its slice carries a branch-commit anchor. The commit SHA is the attribution key; `cwd` only bounds the pool and never vetoes SHA proof. Implements SPEC-0024 (approved).

## Why it matters to users

- A PR designed by a cross-repo orchestrator and built by agent-team teammates now shows all of them — the exact multi-agent story the receipt exists to tell.
- No token is ever counted twice: promotion is dedup-safe against rollup rows.
- Nothing got looser where it matters: outside the repo there is **no** cwd+time credit — SHA anchor or nothing.

## See it

Live dry run on this PR's own worktree (verbatim, post-widening — same rows as pre-widening, no false positives):

```
- - - - - - - - - - - - - - - - - - - - - - - - -
                    AIRECEIPTS                    
            3 sessions behind this PR             

orchestrator · claude-fable-5 100%..........$92.38
  session: df374859-7920-40f3-88e0-a613ae74b101
  entire session (slice unavailable)
codex · gpt-5.5 100%.........................$1.33
  session: rollout-2026-07-02T21-05-43-019f2627-6…
  entire session (slice unavailable)
codex · gpt-5.5 100%.........................$0.64
  session: rollout-2026-07-02T21-18-07-019f2632-b…
  entire session (slice unavailable)
--------------------------------------------------
TOTAL priced................................$94.36
  counted: 3 sessions
- - - - - - - - - - - - - - - - - - - - - - - - -
      aireceipts · local · buy me a samosa 🥟      
- - - - - - - - - - - - - - - - - - - - - - - - -
```

## What changed

- `src/pr/contributors.ts` — `PoolCandidate` tag (`repo` | `anchor`): anchor-pool sessions are credited on an own branch-SHA anchor ONLY; the SHA-less Codex helper rule and the honest excluded count stay repo-pool-scoped.
- `src/pr/promote.ts` (new) — orphan sidechain promotion: anchored, listed sidechains not covered by any contributor or rolled-up `SubagentRow.filePath` become top-level contributors.
- `src/pr/select.ts` — `overlapsBranchWindow` exported as the anchor pool's summary-level bound (±15 min around branch commits).
- `src/pr/index.ts` — orchestration reorder: resolve → build views (rollups define coverage) → promote → merge + chronological sort; NO_MATCH decided after promotion; `--session` unchanged.
- `docs/pr-receipts.md` — attribution section rewritten (was still describing SPEC-0019's single-session pick-one behavior).
- `specs/SPEC-0024-sha-anchor-attribution.md` — approved by maintainer in-session; status `building`; success boxes checked from the live walk.
- Tests: `test/pr/promote.test.ts` (new, 6 cases), anchor-pool battery in `contributors.test.ts` (6 cases), 5 e2e cases in `run.test.ts` incl. determinism and the dedup guard.

## What to review, in order

1. **The riskiest decision — anchor-only credit for the widened pool**: `src/pr/contributors.ts:66-110` (`here` is hard-false for the anchor pool, so neither the Codex helper rule nor the excluded count can leak across repos).
2. **Dedup guard** so a promoted sidechain can't double-count: `src/pr/index.ts` runPr's `covered` set (contributor filePaths + every `SubagentRow.filePath`) feeding `src/pr/promote.ts`.
3. **Deliberate test change**: the "zero matches" case in `test/pr/run.test.ts:140` — under SPEC-0024, cwd alone no longer excludes an anchored session, so the zero-match setup now also strips anchors. This is the specced behavior change, not a weakened test.
4. **NO_MATCH moved after promotion**: `src/pr/index.ts` (a promotion-only receipt is valid; empty stays exit 1).
5. `docs/pr-receipts.md` copy — matches actual behavior.

## Evidence

- Gates, all unmasked exit 0: `tsc` · `eslint --max-warnings 0` · `vitest run` **887/887** · `verify-goldens` 89 byte-identical · `determinism-check --runs=10` · `spec-lint` 25 OK · `hygiene` OK.
- Spec: `specs/SPEC-0024-sha-anchor-attribution.md` — Validation record: S1 self-audit, S2 Codex REWORK (10 findings, dispositions recorded), S3 kill-criterion dry run, S4 lint; maintainer approval logged.
- **R5 perf evidence (kill criterion b)**: 2,612 sessions listed machine-wide → the ±15 min bound admits 4 → anchor pool loaded **1** extra session (no anchor → correctly ignored). Wall: 4.60 s before, 4.51 s after (noise). Not fired.
- **Kill criterion (a)**: live receipt identical rows pre/post widening — no false positive. Not fired.
- Independent Codex review of the final diff: PASS on all five audit dimensions (test-diff legitimacy, attribution honesty, excludedCount semantics, sort determinism, R1–R4 conformance).
- Build receipt: attached via `aireceipts pr --post` (comment below).

## Notes

- The cross-repo-lead case can't demo on THIS PR (its lead runs in-repo); it is locked by the e2e battery (`run.test.ts` "credits a cross-repo lead…"). First real-world confirmation will be the next PR orchestrated from the other repo — the exact scenario of #51's second comment.
- `/review-docs` deferred to the release gate (where it is blocking); the docs diff was covered by the Codex pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
