### PR TITLE
chore: spec-ledger cleanup — dedupe SPEC-0022, record shipped

### DIFF
--- a/specs/SPEC-0021-landing-site.md
+++ b/specs/SPEC-0021-landing-site.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0021
 title: "Launch site — the landing page IS a receipt (GitHub Pages)"
-status: draft
+status: shipped
 milestone: M4
 depends: [SPEC-0003, SPEC-0012]
 ---
@@ -117,4 +117,11 @@ PNG is dark; the paper page is the light); pricing/SaaS pages.
 
 ## Validation
 
-*(pending /validate-spec)*
+**2026-07-03 · spec-ledger cleanup (maintainer-directed, 2026-07-03):** status set to `shipped`, recording decisions the
+maintainer already made by merging: the landing site shipped and iterated to
+v4 across merged PRs (latest #54, `feat: landing v4 — word economy, receipt
+as object`; the v4 polish commit is explicitly "maintainer-approved
+direction"). The button-1 approval was exercised through those merges; this
+entry records it rather than granting it. Historical note: the draft never
+went through /validate-spec before building — recorded here honestly, not
+backfilled.

--- a/specs/SPEC-0022-discovery-perf.md
+++ b/specs/SPEC-0022-discovery-perf.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0022
 title: "Make transcript discovery lazy and cache full summaries"
-status: building
+status: shipped
 milestone: M1
 depends: [SPEC-0001, SPEC-0008, SPEC-0009, SPEC-0019]
 ---
@@ -69,3 +69,9 @@ cache for Cursor's SQLite rows because multiple sessions share one database path
       `node scripts/verify-goldens.mjs`; determinism, spec-lint, and hygiene all pass
       unmasked with `echo $?`.
 - [ ] Commit message: `perf: lazy session discovery + incremental summary cache (fixes #13)`.
+
+## Validation
+
+**2026-07-03 · spec-ledger cleanup (maintainer-directed, 2026-07-03):** status set to `shipped` — implementation merged in
+PR #29 (`perf: lazy session discovery + incremental summary cache (fixes
+#13)`); the status had been left at `building` after the merge.

--- a/specs/SPEC-0024-sha-anchor-attribution.md
+++ b/specs/SPEC-0024-sha-anchor-attribution.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0024
 title: "SHA-anchored attribution — orphan sidechains and cross-repo leads count"
-status: building
+status: shipped
 milestone: M3
 depends: [SPEC-0023]
 ---
@@ -239,3 +239,6 @@ exit 0.
 
 **2026-07-02 · approved:** maintainer approval given directly in session
 ("approve SPEC-0024") after reviewing the validated draft — button 1.
+
+**2026-07-03 · spec-ledger cleanup (maintainer-directed, 2026-07-03):** status set to `shipped` — implementation merged in
+PR #57 with the build receipt attached; issue #51 closed.

--- a/specs/SPEC-0025-docs-site.md
+++ b/specs/SPEC-0025-docs-site.md
@@ -1,12 +1,12 @@
 ---
-id: SPEC-0022
+id: SPEC-0025
 title: "Docs site from repo markdown"
-status: approved
+status: shipped
 milestone: M4
 depends: [SPEC-0021]
 ---
 
-# SPEC-0022: Docs site from repo markdown
+# SPEC-0025: Docs site from repo markdown
 
 Invariants: I1 (deterministic; zero model calls; zero product-path network), I3
 (claims traceable to repo docs), I5 (generated output is byte-stable), I6 (facts,
@@ -83,3 +83,11 @@ local, deterministic build path.
 - [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, determinism, spec-lint, and hygiene all pass
       unmasked with `echo $?`.
+
+## Validation
+
+**2026-07-03 · spec-ledger cleanup (maintainer-directed, 2026-07-03):** renumbered from SPEC-0022 — that id was already
+taken by the discovery-perf spec (one numbering scheme, AGENTS.md); no code or
+doc outside `specs/` referenced the docs-site spec by number. Status set to
+`shipped`: implementation merged in PR #42 (`feat: [SPEC-0022] docs site on
+the same Pages deploy`) and extended by PR #43's user guide wiring.


### PR DESCRIPTION
## What this adds

A ledger-truth pass over `specs/` before external eyes land on it: the duplicate spec id is resolved and every spec's `status` now matches what actually merged. No product code, no requirement text touched — statuses, one renumber, and dated Validation-log entries naming the merge evidence.

## What changed

- `SPEC-0022-docs-site.md` → **`SPEC-0025-docs-site.md`** — the id was already taken by discovery-perf ("one numbering scheme", AGENTS.md). Nothing outside `specs/` referenced the docs-site spec by number (verified by repo-wide grep).
- `SPEC-0022` discovery-perf: `building` → `shipped` (merged in PR #29).
- `SPEC-0025` docs-site: `approved` → `shipped` (merged in PR #42, extended by #43).
- `SPEC-0024` SHA-anchor attribution: `building` → `shipped` (merged in PR #57, issue #51 closed).
- `SPEC-0021` landing site: `draft` → `shipped` — records the button-1 approval the maintainer already exercised by merging landing v1–v4 (latest PR #54; the v4 polish commit is explicitly "maintainer-approved direction"). Its Validation section honestly records that `/validate-spec` was skipped before building; nothing is backfilled.

## What to review, in order

1. **The SPEC-0021 entry** (`specs/SPEC-0021-landing-site.md`, Validation) — the one judgment call: it *records* approval-by-merge rather than granting it. If you'd rather park or tombstone instead, say so and I'll flip it.
2. The renumber completeness in `specs/SPEC-0025-docs-site.md` (id, heading, validation note).
3. The two mechanical flips' evidence lines (`SPEC-0022`, `SPEC-0024`).

## Evidence

- Gates, all unmasked exit 0: `tsc` · `eslint --max-warnings 0` · `vitest run` 887/887 · `verify-goldens` 89 byte-identical · `spec-lint` 25 OK · `hygiene` OK.
- Independent Codex review of the diff: PASS (renumber complete, evidence plausible, SPEC-0021 records-not-grants, no requirement content altered).

## Notes

- `AGENTS.md`'s "Current-state inventory" is also stale (still says Tier 0), but that section is release-skill-owned by its own rule — left for `/release`.
- After this merges, the spec ledger reads: 0021/0022/0024/0025 `shipped`, everything else `approved`, zero drafts dangling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
