### PR TITLE
feat: SPEC-0026 PR comment polish — role, cache, label, details

### DIFF
--- a/goldens/cli/help.txt
+++ b/goldens/cli/help.txt
@@ -15,7 +15,7 @@ Usage:
   aireceipts compare <a> <b> --svg      write a side-by-side SVG (default compare.svg)
   aireceipts week [--by-project] [--since <date>] [--json]
                                         trailing-7-day digest across sessions
-  aireceipts pr [--post] [--session <id>] [--artifact]
+  aireceipts pr [--post] [--session <id>] [--artifact] [--no-details]
                                         attach the building session's receipt to
                                          the current PR (dry-run prints the body;
                                          --post upserts it via gh; --artifact also

--- a/goldens/html/pr-artifact.html
+++ b/goldens/html/pr-artifact.html
@@ -32,9 +32,11 @@ builder · claude-opus-4-8 100%...............$0.09
 --------------------------------------------------
 TOTAL priced.................................$0.27
   counted: 2 sessions
+  cache served 86% of input tokens
 
 1 candidate session not attributed
 (in repo + branch window, no branch commit)
+  details: npx aireceipts --session &lt;id&gt;
 - - - - - - - - - - - - - - - - - - - - - - - - -
       aireceipts · local · buy me a samosa 🥟      
 - - - - - - - - - - - - - - - - - - - - - - - - -</pre></div></section>

--- a/specs/SPEC-0026-pr-comment-polish.md
+++ b/specs/SPEC-0026-pr-comment-polish.md
@@ -194,7 +194,7 @@ informative.
 
 ## Success criteria
 
-- [ ] This spec's own implementation PR carries the new comment shape: solo
+- [x] This spec's own implementation PR carries the new comment shape: solo
       or multi rows per R1, cache line if applicable, hint line, and a
       working collapsed details section.
 - [x] Goldens untouched — the terminal receipt surface did not move (only `goldens/cli/help.txt` and the SPEC-0027 artifact-page golden regenerated, both deliberate).

--- a/specs/SPEC-0026-pr-comment-polish.md
+++ b/specs/SPEC-0026-pr-comment-polish.md
@@ -128,6 +128,44 @@ that made a git write, that is an honesty bug — R3 reverts to
 - **Comment pagination / multiple comments.** One marked comment remains the
   contract (SPEC-0019 R2); size pressure is handled by omission, not spam.
 
+## Design (lead-authored — implementers execute, never invent)
+
+Rendered mockups: https://claude.ai/code/artifact/6067cce8-25fa-467e-a36d-42190f15e003
+(before/after pairs built from PR #58's real numbers). The normative line
+design, in render order inside the fenced block:
+
+```
+            3 sessions behind this PR          ← unchanged (R1: N=1 drops role on the row only)
+<role> · <mix>........................$X       ← N≥2 rows unchanged
+<mix>.................................$X       ← N=1 row, no role prefix (R1)
+  session: <id>                                ← unchanged muted provenance
+  entire session (no git writes)               ← R3, helper-credited only
+  entire session (slice unavailable)           ← unchanged for anchored fallbacks
+--------------------------------------------------
+TOTAL priced..........................$X       ← unchanged
+  counted: N sessions [+ M subagents]          ← unchanged
+  cache served N% of input tokens              ← R2, muted, only when cacheRead > 0
+  <existing excluded-candidates note>          ← unchanged, stays above the hint
+  details: npx aireceipts --session <id>       ← R4, muted, always last note
+```
+
+After the fenced block (R5):
+
+```
+<details><summary>full receipts (N sessions)</summary>
+
+<one fenced full receipt per contributor, row order — the renderer's exact
+bytes for the sliced model (color off, RECEIPT_WIDTH); an omitted receipt
+renders as one line: full receipt omitted (comment size limit)>
+
+</details>
+```
+
+Copy rules: `no git writes` (not "helper" — name the observable fact, not our
+jargon); the hint says `npx aireceipts` (the README's canonical invocation);
+the summary line always carries the count so the collapsed state is
+informative.
+
 ## Test matrix
 
 | Case | Input | Expected |

--- a/specs/SPEC-0026-pr-comment-polish.md
+++ b/specs/SPEC-0026-pr-comment-polish.md
@@ -1,0 +1,213 @@
+---
+id: SPEC-0026
+title: "PR comment polish — leaner N=1, cache line, honest helper label, details on demand"
+status: draft
+milestone: M3
+depends: [SPEC-0023, SPEC-0024]
+---
+
+# SPEC-0026 · PR comment polish
+
+Invariants: I1 (deterministic body), I2/I3 (no new money semantics; every added
+line is computed from already-counted tokens or restates existing honesty
+labels more precisely), I6 (role display changes only; the taxonomy and its
+structural derivation are untouched).
+
+## Purpose
+
+Maintainer review of PR #58's live receipt (2026-07-03) named four paper cuts
+and one missing capability in the PR comment — all display-layer, all in
+`src/pr/body.ts` + `src/pr/comment.ts`:
+
+1. Single-session PRs render a role prefix (`builder ·` / `orchestrator ·`)
+   that differentiates nothing — the maintainer flagged it as setup-specific
+   noise for the N=1 case.
+2. The full receipt's `cache served N% of input tokens` masthead line
+   (`src/receipt/present.ts:71`) never made it into SPEC-0023's comment
+   layout — the maintainer asked where it went.
+3. `entire session (slice unavailable)` (`FULL_FALLBACK_LABEL`,
+   `src/pr/slice.ts:11`) reads as a failure. For a Codex helper credited on
+   cwd+time with **zero git writes**, the whole session *is* the correct
+   scope — the label should state the fact, not apologize.
+4. Nothing in the comment tells a reader how to get the full per-tool story
+   (maintainer: "run <cmd> to get more details").
+5. The full story itself should be one click away without hosting anything:
+   a collapsed `<details>` section in the same comment (the maintainer's
+   alternative — rendered HTML on an artifact branch — is deliberately
+   deferred, see Non-goals).
+
+**Kill criterion:** (a) if in dogfood the expanded comment ever exceeds
+GitHub's 65,536-char comment limit despite R5's cap, or anything other than
+the marker line renders before the concise fenced receipt, the `<details>`
+section is cut back to the R4 hint line alone; (b) if the R3 helper label ever renders on a session
+that made a git write, that is an honesty bug — R3 reverts to
+`FULL_FALLBACK_LABEL` everywhere until fixed.
+
+## Requirements
+
+- **R1 — Role suppressed at N=1.** When exactly one contributor renders (auto
+  or `--session`), its row label is the model mix alone (`claude-opus-4-8
+  100%`), no role prefix. With two or more contributors, rows keep
+  `<role> · <mix>` unchanged. `deriveRole` and the Role type
+  (`src/pr/contributors.ts`) are untouched (I6) — this is display-only in
+  `src/pr/body.ts`'s `contributorBlocks`.
+- **R2 — Aggregate cache line.** A muted note under the `counted:` line:
+  the cache-served formatter of `src/receipt/present.ts:56-72` applied to
+  the summed `TokenUsage` of every counted atom — the same atom set
+  `collectAtoms` walks (`src/pr/body.ts:133`), including readable subagent
+  rows; the `TokenUsage` summation itself is new code (today `totalsFor`
+  folds only subtotals/counts). Same display-honesty rules: absent when
+  `cacheRead <= 0`; a partial ratio never rounds up to `100` (`>99`
+  boundary preserved). The formatter is extracted to take a `TokenUsage`
+  and reused by both surfaces — reviewers reject a duplicated
+  implementation (structural, enforced at review; the parity row is the
+  behavioral check).
+- **R3 — Honest helper label.** A contributor credited by the SHA-less Codex
+  helper rule (own anchor absent, `writeCount === 0` — computed and currently discarded
+  by `selectContributors`, `src/pr/contributors.ts:95`, so retaining it is
+  part of this change) renders
+  its provenance line as `entire session (no git writes)` instead of
+  `entire session (slice unavailable)`. The attribution basis travels on
+  `RawContributor` → `ContributorView`; every other full-session fallback
+  (anchored session whose slice can't be cut) keeps `FULL_FALLBACK_LABEL`
+  byte-for-byte.
+- **R4 — Footer hint.** One muted line at the bottom of the fenced receipt,
+  after the counted/excluded notes: `details: npx aireceipts --session <id>`
+  (literal `<id>`; the per-session ids are already on the provenance lines).
+  Always present in the PR body; never in the terminal receipt surface.
+- **R5 — Collapsed full receipts, size-capped.** After the fenced concise
+  receipt, the comment gains a `<details><summary>full receipts (N
+  sessions)</summary>` section containing, per contributor in render order,
+  one fenced full receipt — the same bytes `renderReceipt` produces for that
+  contributor's sliced model (color off, `RECEIPT_WIDTH`), i.e. what
+  `aireceipts --session <id>` shows for the slice. The `DOGFOOD_MARKER`
+  stays the first line and the upsert (`src/pr/comment.ts`) is unchanged.
+  `aireceipts pr --no-details` omits the section (flag on `PrOptions`,
+  `src/pr/index.ts:23`, parsed through `src/cli/options.ts:10` and wired in
+  `src/cli/commands/pr.ts:7` — a new CLI flag, so it gets the SPEC-0018
+  registry help text and an e2e dispatch test). If the assembled comment would exceed 65,000
+  chars, per-session receipts are dropped from the END until it fits, each
+  replaced by one muted line `full receipt omitted (comment size limit)`;
+  if it still does not fit with every receipt omitted, the whole `<details>`
+  section is dropped. Deterministic, never mid-receipt truncation. The cap
+  governs the details section only — a concise body that alone exceeded the
+  limit would be a pre-existing SPEC-0023 condition, out of scope here.
+
+## Scenarios
+
+- **Given** a PR built by one session, **when** the comment renders, **then**
+  the row reads `claude-opus-4-8 100% … $X` with no role, the body still says
+  `1 session behind this PR`, and the details section holds one full receipt.
+- **Given** three contributors, **when** the comment renders, **then** roles
+  render exactly as today and the details section holds three fenced receipts
+  in row order.
+- **Given** counted atoms whose summed `cacheRead` is positive, **when** the
+  totals render, **then** one muted `cache served N% of input tokens` line
+  appears under `counted:`; **given** zero `cacheRead`, no line.
+- **Given** a Codex helper with no git writes, **then** its provenance reads
+  `entire session (no git writes)`; **given** an anchored session whose slice
+  falls back, **then** it still reads `entire session (slice unavailable)`.
+- **Given** `--no-details`, **then** the comment is the fenced receipt only
+  (plus marker), byte-identical to today's body apart from R1–R4.
+- **Given** contributors whose combined details would exceed the size cap,
+  **then** trailing receipts are replaced by the omission note and the
+  comment stays under 65,000 chars.
+
+## Non-goals
+
+- **Hosted/rendered HTML artifacts on a shared branch.** Deferred until the
+  `<details>` section proves insufficient: it adds per-PR commits to a shared
+  branch from contributors' machines and a wider privacy surface (full
+  render exposes more than the curated comment). Revisit on demand.
+- **Role taxonomy or derivation changes** (I6). Display-only.
+- **Time-window slicing for anchorless sessions.** SPEC-0019's "time is a
+  filter, never the slicer" stands; R3 relabels honestly, it does not guess
+  a slice.
+- **Terminal receipt changes.** `aireceipts` / `--session` output is
+  untouched; goldens must not change.
+- **Comment pagination / multiple comments.** One marked comment remains the
+  contract (SPEC-0019 R2); size pressure is handled by omission, not spam.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 solo row | one contributor | row label has no role prefix; `1 session behind this PR` kept |
+| R1 multi rows | three contributors | `<role> · <mix>` unchanged |
+| R2 cache line | atoms with cacheRead > 0 | one muted `cache served N% …` line under `counted:` |
+| R2 no cache | all cacheRead = 0 | no cache line |
+| R2 parity | same TokenUsage sum | PR-body percentage equals the receipt masthead's for identical usage |
+| R2 subagents counted | cacheRead only on a subagent atom | cache line present, reflects the subagent's tokens |
+| R2 >99 boundary | summed ratio 0.995..0.999 | renders `>99`, never `100` |
+| R3 helper label | helper-credited codex (writeCount 0) | `entire session (no git writes)` |
+| R3 anchored fallback | anchored session, slice falls back | `entire session (slice unavailable)` unchanged |
+| R4 hint | any body | muted `details: npx aireceipts --session <id>` line present |
+| R4 terminal untouched | terminal receipt render | no hint line; goldens byte-identical |
+| R5 details | N contributors | `<details>` after the fence with N fenced full receipts, in order |
+| R5 marker | rendered comment | first line is still `DOGFOOD_MARKER`; upsert finds exactly one comment |
+| R5 opt-out | `--no-details` | no `<details>` section |
+| R5 size cap | oversized combined receipts | trailing receipts → omission notes; total < 65,000 chars |
+| R5 slice parity | contributor with a real slice | details receipt renders the SLICED model, not the whole session |
+| R5 byte parity | any contributor | details receipt bytes equal `renderReceipt` (color off, `RECEIPT_WIDTH`) of that model |
+| R5 flag parsing | `aireceipts pr --no-details` through real CLI dispatch | flag accepted; help text lists it |
+| R5 cap floor | omission notes alone still too big | whole `<details>` section dropped |
+| determinism | same fixtures, 10 runs | byte-identical comment (I1) |
+
+## Success criteria
+
+- [ ] This spec's own implementation PR carries the new comment shape: solo
+      or multi rows per R1, cache line if applicable, hint line, and a
+      working collapsed details section.
+- [ ] Goldens untouched — the terminal receipt surface did not move.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass
+      unmasked (`echo $?`).
+
+## Validation
+
+**2026-07-03 · S1 (self):** every line is computed from tokens the body
+already counts (cache aggregate) or relabels an existing honesty state (R3);
+no predictions, no new dollars, role taxonomy untouched (I6). The one privacy
+delta — R5 embeds per-tool receipts in the comment — is bounded by the
+existing render-first spine: the author sees the full body on stdout before
+any `--post`.
+
+**2026-07-03 · S2 (Codex, read-only): REWORK → draft reworked.** Findings and
+disposition:
+1. Unmeasurable rhetoric in Purpose/kill criterion — **accepted**; paper cuts
+   now attributed to the maintainer's review verbatim, kill criterion (a)
+   restated as an observable ordering check.
+2. R2 rows missing (subagent inclusion, `>99` boundary); reuse claim
+   untestable — **accepted**; rows added, reuse restated as review-enforced
+   with the parity row as the behavioral check.
+3. R4 terminal-surface row missing — **accepted**; row added (goldens
+   byte-identical).
+4. R5 rows missing (byte parity with `renderReceipt`, flag parsing/help) —
+   **accepted**; rows added.
+5. `PrOptions` seam miscited; CLI flag seams uncited — **accepted**; now
+   `src/pr/index.ts:23`, `src/cli/options.ts:10`, `src/cli/commands/pr.ts:7`.
+6. `totalsFor` "already folds" overstated — **accepted**; reworded (atom set
+   from `collectAtoms`; `TokenUsage` summation is new code).
+7. R3 needs plumbing, not just display — **accepted**; spec now names the
+   discard point (`contributors.ts:95`) and the basis field as in-scope.
+8. Size cap could not guarantee fit — **accepted**; cap floor added (whole
+   section dropped) and the cap's scope bounded to the details section.
+9. R5 called scope creep / 10. weakest, cut it — **rejected**: the collapsed
+   details section is the maintainer's explicit ask from the PR #58 review
+   ("more interesting insight … someone can go and visit later"); the R4
+   command hint serves only the author's machine, not PR readers. R5 stays,
+   carrying the extra rows from finding 4 and its own kill-criterion
+   fallback to R4.
+
+**2026-07-03 · S3 (value gate):** kill-criterion dry run — (a) size: the
+live PR #57/#58 receipts are ~1–2 KB per session; five sessions with full
+per-tool blocks stay two orders of magnitude under the 65k cap, and the cap
+logic covers the pathological tail; (b) honesty: the R3 label keys on the
+same `writeCount === 0` classification that has survived SPEC-0023's
+dogfood since PR #49. Cheapest further evidence is built into the success
+criteria: this spec's own PR must post the new comment shape.
+
+**2026-07-03 · S4 (lint):** `node scripts/spec-lint.mjs` → 26 spec(s) OK,
+exit 0.
+
+Status remains draft pending maintainer approval (button 1).

--- a/specs/SPEC-0026-pr-comment-polish.md
+++ b/specs/SPEC-0026-pr-comment-polish.md
@@ -66,7 +66,7 @@ that made a git write, that is an honesty bug — R3 reverts to
   helper rule (own anchor absent, `writeCount === 0` — computed and currently discarded
   by `selectContributors`, `src/pr/contributors.ts:95`, so retaining it is
   part of this change) renders
-  its provenance line as `entire session (no git writes)` instead of
+  its provenance line as `entire session (no commits to slice by)` instead of
   `entire session (slice unavailable)`. The attribution basis travels on
   `RawContributor` → `ContributorView`; every other full-session fallback
   (anchored session whose slice can't be cut) keeps `FULL_FALLBACK_LABEL`
@@ -105,7 +105,7 @@ that made a git write, that is an honesty bug — R3 reverts to
   totals render, **then** one muted `cache served N% of input tokens` line
   appears under `counted:`; **given** zero `cacheRead`, no line.
 - **Given** a Codex helper with no git writes, **then** its provenance reads
-  `entire session (no git writes)`; **given** an anchored session whose slice
+  `entire session (no commits to slice by)`; **given** an anchored session whose slice
   falls back, **then** it still reads `entire session (slice unavailable)`.
 - **Given** `--no-details`, **then** the comment is the fenced receipt only
   (plus marker), byte-identical to today's body apart from R1–R4.
@@ -139,7 +139,7 @@ design, in render order inside the fenced block:
 <role> · <mix>........................$X       ← N≥2 rows unchanged
 <mix>.................................$X       ← N=1 row, no role prefix (R1)
   session: <id>                                ← unchanged muted provenance
-  entire session (no git writes)               ← R3, helper-credited only
+  entire session (no commits to slice by)      ← R3, helper-credited only
   entire session (slice unavailable)           ← unchanged for anchored fallbacks
 --------------------------------------------------
 TOTAL priced..........................$X       ← unchanged
@@ -161,8 +161,9 @@ renders as one line: full receipt omitted (comment size limit)>
 </details>
 ```
 
-Copy rules: `no git writes` (not "helper" — name the observable fact, not our
-jargon); the hint says `npx aireceipts` (the README's canonical invocation);
+Copy rules: `no commits to slice by` (maintainer pushed back on "(no git
+writes)" as attribution-internal jargon, 2026-07-03 — the label must name the
+user-visible fact and the reason there is no turn range); the hint says `npx aireceipts` (the README's canonical invocation);
 the summary line always carries the count so the collapsed state is
 informative.
 
@@ -177,7 +178,7 @@ informative.
 | R2 parity | same TokenUsage sum | PR-body percentage equals the receipt masthead's for identical usage |
 | R2 subagents counted | cacheRead only on a subagent atom | cache line present, reflects the subagent's tokens |
 | R2 >99 boundary | summed ratio 0.995..0.999 | renders `>99`, never `100` |
-| R3 helper label | helper-credited codex (writeCount 0) | `entire session (no git writes)` |
+| R3 helper label | helper-credited codex (writeCount 0) | `entire session (no commits to slice by)` |
 | R3 anchored fallback | anchored session, slice falls back | `entire session (slice unavailable)` unchanged |
 | R4 hint | any body | muted `details: npx aireceipts --session <id>` line present |
 | R4 terminal untouched | terminal receipt render | no hint line; goldens byte-identical |

--- a/specs/SPEC-0026-pr-comment-polish.md
+++ b/specs/SPEC-0026-pr-comment-polish.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0026
 title: "PR comment polish — leaner N=1, cache line, honest helper label, details on demand"
-status: draft
+status: building
 milestone: M3
 depends: [SPEC-0023, SPEC-0024]
 ---
@@ -197,8 +197,8 @@ informative.
 - [ ] This spec's own implementation PR carries the new comment shape: solo
       or multi rows per R1, cache line if applicable, hint line, and a
       working collapsed details section.
-- [ ] Goldens untouched — the terminal receipt surface did not move.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] Goldens untouched — the terminal receipt surface did not move (only `goldens/cli/help.txt` and the SPEC-0027 artifact-page golden regenerated, both deliberate).
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass
       unmasked (`echo $?`).
 
@@ -249,4 +249,15 @@ criteria: this spec's own PR must post the new comment shape.
 **2026-07-03 · S4 (lint):** `node scripts/spec-lint.mjs` → 26 spec(s) OK,
 exit 0.
 
-Status remains draft pending maintainer approval (button 1).
+**2026-07-03 · S5 (implementation review, Codex): REWORK → fixed.** (1) MEDIUM:
+the size-cap budget reserved a hardcoded 200 chars for the artifact link —
+accepted; the budget now counts the exact link line + join newlines. (2) LOW:
+no dispatch-level test for `--no-details` — accepted; registry
+`resolveCommand` assertions added (an empty-HOME `main()` probe was tried and
+dropped: adapter roots snapshot at import, so it cannot isolate). The critic
+confirmed: R1 test rewrites are the specced flip, R3 basis honesty and the
+cache-formatter extraction behaviorally identical, R5 assembly order correct.
+
+**2026-07-03 · approved (button 1):** maintainer, in-session — *"SPEC-0026 -
+approved."* Status → building. Build base: PR #63's branch (SPEC-0027 impl),
+so R5's details section can also give 0027's link line its final home.

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -5,7 +5,12 @@ import { runPr } from "../../pr/index.js";
 import type { CommandContext, CommandDef } from "../types.js";
 
 function run(ctx: CommandContext): Promise<number> {
-  return runPr({ post: ctx.options.post, session: ctx.options.prSession, artifact: ctx.options.artifact });
+  return runPr({
+    post: ctx.options.post,
+    session: ctx.options.prSession,
+    artifact: ctx.options.artifact,
+    details: !ctx.options.noDetails,
+  });
 }
 
 export const command: CommandDef = {
@@ -16,7 +21,7 @@ export const command: CommandDef = {
   help: {
     order: 100,
     lines: [
-      "  aireceipts pr [--post] [--session <id>] [--artifact]",
+      "  aireceipts pr [--post] [--session <id>] [--artifact] [--no-details]",
       "                                        attach the building session's receipt to",
       "                                         the current PR (dry-run prints the body;",
       "                                         --post upserts it via gh; --artifact also",

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -37,6 +37,8 @@ export interface CliOptions {
   readonly prSession?: string;
   /** SPEC-0027: `aireceipts pr --post --artifact` publishes the HTML receipt artifact. */
   readonly artifact: boolean;
+  /** SPEC-0026 R5: `aireceipts pr --no-details` omits the collapsed full-receipts section. */
+  readonly noDetails: boolean;
   // Command-selecting boolean flags (consumed by the registry, not the commands):
   readonly help: boolean;
   readonly methodology: boolean;
@@ -72,6 +74,7 @@ export function parseOptions(argv: string[]): CliOptions {
   let post = false;
   let prSession: string | undefined;
   let artifact = false;
+  let noDetails = false;
   const positional: string[] = [];
 
   for (let i = 0; i < argv.length; i++) {
@@ -116,6 +119,8 @@ export function parseOptions(argv: string[]): CliOptions {
       post = true;
     } else if (arg === "--artifact") {
       artifact = true;
+    } else if (arg === "--no-details") {
+      noDetails = true;
     } else if (arg === "--session") {
       prSession = argv[++i];
     } else if (arg.startsWith("--session=")) {
@@ -151,6 +156,7 @@ export function parseOptions(argv: string[]): CliOptions {
     post,
     prSession,
     artifact,
+    noDetails,
     help,
     methodology,
     telemetryShow,

--- a/src/pr/body.ts
+++ b/src/pr/body.ts
@@ -8,6 +8,8 @@ import type { TokenUsage } from "../parse/types.js";
 import type { Block } from "../receipt/blocks.js";
 import type { ModelMixEntry } from "../receipt/model.js";
 import { formatInt, formatUsd } from "../receipt/format.js";
+import { cacheServedText } from "../receipt/present.js";
+import { addUsage, emptyUsage } from "../parse/util.js";
 import { RECEIPT_WIDTH, renderBlockLines } from "../receipt/render.js";
 import type { Role } from "./contributors.js";
 import type { SliceResult } from "./slice.js";
@@ -28,6 +30,8 @@ export interface ContributorView {
   usd: number | null;
   tokens: TokenUsage;
   subagents: SubagentRow[];
+  /** SPEC-0026 R3 — how selection credited this session; `helper` relabels the full-session line honestly. */
+  basis?: "anchor" | "helper";
 }
 
 export interface PrBodyInput {
@@ -35,6 +39,12 @@ export interface PrBodyInput {
   /** Candidates that were in repo + window but not credited (R1) — reported honestly (R4). */
   excludedCount: number;
 }
+
+/** SPEC-0026 R3 — a helper session made no commits, so the whole session IS the correct scope (maintainer wording, 2026-07-03). */
+export const HELPER_FULL_LABEL = "entire session (no commits to slice by)";
+/** SPEC-0026 R5 — GitHub caps issue comments at 65,536 chars; we cap under it. */
+const COMMENT_SIZE_CAP = 65_000;
+const OMITTED_NOTE = "full receipt omitted (comment size limit)";
 
 const WORDMARK = "AIRECEIPTS";
 const FOOTER_TEXT = "aireceipts · local · buy me a samosa";
@@ -83,7 +93,8 @@ function mutedNote(text: string, indent = NOTE_INDENT): Block {
 }
 
 function provenanceBlocks(view: ContributorView): Block[] {
-  const slice = sliceHeaderLine(view.slice);
+  const slice =
+    view.basis === "helper" && view.slice.kind === "full" ? HELPER_FULL_LABEL : sliceHeaderLine(view.slice);
   const joined = `${view.sessionId} · ${slice}`;
   const capacity = RECEIPT_WIDTH - NOTE_INDENT;
   if (codepointLength(joined) <= capacity) {
@@ -104,12 +115,12 @@ function subagentValue(row: SubagentRow): string {
   return row.unreadable ? "(unreadable)" : costText(row.usd, row.tokens);
 }
 
-/** One contributor: role/model dotted row, muted provenance line, then any SUBAGENTS sub-rows. */
-function contributorBlocks(view: ContributorView, spaceBefore: boolean): Block[] {
+/** One contributor: role/model dotted row (role only when rows need telling apart — SPEC-0026 R1), muted provenance line, then any SUBAGENTS sub-rows. */
+function contributorBlocks(view: ContributorView, spaceBefore: boolean, showRole: boolean): Block[] {
   const blocks: Block[] = [
     {
       kind: "row",
-      label: `${view.role} · ${formatModelMix(view.modelMix)}`,
+      label: showRole ? `${view.role} · ${formatModelMix(view.modelMix)}` : formatModelMix(view.modelMix),
       value: costText(view.usd, view.tokens),
       spaceBefore,
     },
@@ -188,6 +199,13 @@ function totalBlocks(input: PrBodyInput): Block[] {
     blocks.push({ kind: "total", label: "TOTAL unpriced", value: "0 tokens" });
   }
   blocks.push(mutedNote(countLine(input.contributors.length, totals)));
+  // SPEC-0026 R2 — one aggregate cache line over exactly the atoms the totals
+  // count, through the receipt masthead's own formatter (one implementation).
+  const summed = collectAtoms(input.contributors).atoms.reduce((acc, a) => addUsage(acc, a.tokens), emptyUsage());
+  const cache = cacheServedText(summed);
+  if (cache !== undefined) {
+    blocks.push(mutedNote(cache));
+  }
   if (totals.unreadableCount > 0) {
     blocks.push(mutedNote(`${plural(totals.unreadableCount, "unreadable subagent")} not priced`));
   }
@@ -200,6 +218,8 @@ function totalBlocks(input: PrBodyInput): Block[] {
     });
     blocks.push({ kind: "note", text: "(in repo + branch window, no branch commit)", muted: true });
   }
+  // SPEC-0026 R4 — the route to the full per-tool story, always the last note.
+  blocks.push(mutedNote("details: npx aireceipts --session <id>"));
   return blocks;
 }
 
@@ -209,8 +229,9 @@ function prBlocks(input: PrBodyInput): Block[] {
     { kind: "masthead", text: WORDMARK },
     { kind: "meta", lines: [`${plural(n, "session")} behind this PR`] },
   ];
+  const showRole = n > 1;
   input.contributors.forEach((view, i) => {
-    blocks.push(...contributorBlocks(view, i === 0));
+    blocks.push(...contributorBlocks(view, i === 0, showRole));
   });
   blocks.push(...totalBlocks(input));
   blocks.push({ kind: "footer", text: FOOTER_TEXT, emoji: FOOTER_EMOJI });
@@ -222,16 +243,73 @@ export function renderPrReceiptText(input: PrBodyInput): string {
   return renderBlockLines(prBlocks(input), { color: false, width: RECEIPT_WIDTH }).join("\n");
 }
 
+/** One pre-rendered per-session full receipt for the R5 details section. */
+export interface DetailReceipt {
+  /** `<role> · <sessionId>` — the same strings the rows already show. */
+  label: string;
+  /** `renderReceipt(model, { color: false })` output for the contributor's sliced model. */
+  text: string;
+}
+
+export interface PrBodyExtras {
+  /** SPEC-0027 R3 — present only after a confirmed artifact push. */
+  artifactLink?: { fileName: string; url: string };
+  /** SPEC-0026 R5 — per-session full receipts, row order; omitted under `--no-details`. */
+  details?: DetailReceipt[];
+}
+
+const FENCE = "```";
+
 /**
- * The complete comment body (R4): marker line plus fenced receipt blocks.
- * SPEC-0027 R3: `artifactLink` (a blob URL, present only after a confirmed
- * push) appends one markdown line after the fence — printed and posted bodies
- * are always identical.
+ * The `<details>` section, size-capped: the largest prefix of receipts that
+ * fits is kept, trailing ones degrade to one-line omission notes; `null` when
+ * even all-omitted cannot fit (the caller drops the section). Computed with
+ * prefix sums — one pass, no quadratic reassembly.
  */
-export function renderPrBody(input: PrBodyInput, artifactLink?: { fileName: string; url: string }): string {
+function detailsSection(details: DetailReceipt[], budget: number): string | null {
+  const kept = details.map((d) => `${d.label}\n\n${FENCE}\n${d.text}\n${FENCE}`);
+  const omitted = details.map((d) => `${d.label} — ${OMITTED_NOTE}`);
+  const header = `<details><summary>full receipts (${plural(details.length, "session")})</summary>`;
+  const frame = [...header].length + [...`\n\n${"\n"}\n</details>`].length + details.length; // header + blank lines + joins
+  const size = (s: string): number => [...s].length + 1; // +1 for its join newline
+
+  const allOmitted = frame + omitted.reduce((sum, s) => sum + size(s), 0);
+  if (allOmitted > budget) {
+    return null;
+  }
+  // Largest keep-prefix that fits: swap omitted→kept from the front while the total holds.
+  let total = allOmitted;
+  let keep = 0;
+  while (keep < details.length && total - size(omitted[keep]) + size(kept[keep]) <= budget) {
+    total = total - size(omitted[keep]) + size(kept[keep]);
+    keep++;
+  }
+  const parts = details.map((_, i) => (i < keep ? kept[i] : omitted[i]));
+  return [header, "", ...parts, "", "</details>"].join("\n");
+}
+
+/**
+ * The complete comment body: marker line, fenced receipt blocks, the R5
+ * details section, then the SPEC-0027 artifact link (present only after a
+ * confirmed push) — printed and posted bodies are always identical.
+ */
+export function renderPrBody(input: PrBodyInput, extras: PrBodyExtras = {}): string {
   const lines = [DOGFOOD_MARKER, "```", renderPrReceiptText(input), "```"];
-  if (artifactLink) {
-    lines.push(`full receipt: [${artifactLink.fileName}](${artifactLink.url})`);
+  const linkLine = extras.artifactLink
+    ? `full receipt: [${extras.artifactLink.fileName}](${extras.artifactLink.url})`
+    : undefined;
+  if (extras.details !== undefined && extras.details.length > 0) {
+    // Budget with the EXACT bytes that surround the section: everything
+    // rendered so far, the real link line (never a guess), and the join
+    // newlines each appended line costs.
+    const used = [...lines.join("\n")].length + (linkLine === undefined ? 0 : [...linkLine].length + 1) + 2;
+    const section = detailsSection(extras.details, COMMENT_SIZE_CAP - used);
+    if (section !== null) {
+      lines.push(section);
+    }
+  }
+  if (linkLine !== undefined) {
+    lines.push(linkLine);
   }
   lines.push("");
   return lines.join("\n");

--- a/src/pr/contributors.ts
+++ b/src/pr/contributors.ts
@@ -30,11 +30,13 @@ export interface PoolCandidate {
   pool: CandidatePool;
 }
 
-/** One session credited to the PR: the loaded session and its own PR-scoped slice. */
+/** One session credited to the PR: the loaded session, its own PR-scoped slice, and how it was credited (SPEC-0026 R3). */
 export interface RawContributor {
   summary: SessionSummary;
   session: Session;
   slice: SliceResult;
+  /** `anchor` = own branch-SHA proof; `helper` = the SHA-less current-worktree Codex rule. */
+  basis: "anchor" | "helper";
 }
 
 export interface ContributorSelection {
@@ -92,7 +94,12 @@ export async function selectContributors(
     // the anchor pool, is not proven ours (R1).
     const include = anchors.hasOwn || (isCodex && anchors.writeCount === 0 && here);
     if (include) {
-      contributors.push({ summary, session, slice: computeSlice(session.turns, branchShas) });
+      contributors.push({
+        summary,
+        session,
+        slice: computeSlice(session.turns, branchShas),
+        basis: anchors.hasOwn ? "anchor" : "helper",
+      });
     } else if (here) {
       // Plausibly ours (this worktree) but unproven — surface it in the honest note.
       excludedCount++;

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -11,6 +11,7 @@
 import * as path from "node:path";
 import type { Session, SessionSummary } from "../parse/types.js";
 import { buildReceiptModel, sliceSessionForReceipt } from "../receipt/model.js";
+import { renderReceipt } from "../receipt/render.js";
 import { branchCommits, currentWorktreeRoot, defaultRunner, worktreeRoots, type CommandRunner } from "./git.js";
 import { isBranchCandidate, overlapsBranchWindow, selectExplicitSession } from "./select.js";
 import { computeSlice } from "./slice.js";
@@ -28,6 +29,8 @@ export interface PrOptions {
   session?: string;
   /** SPEC-0027: publish the HTML receipt artifact and link it (requires --post). */
   artifact?: boolean;
+  /** SPEC-0026 R5: include the collapsed full-receipts section (default true; `--no-details` clears it). */
+  details?: boolean;
 }
 
 export interface PrDeps {
@@ -93,7 +96,8 @@ async function resolveContributors(
       return { error: `failed to load session "${summary.id}"` };
     }
     return {
-      contributors: [{ summary, session, slice: computeSlice(session.turns, shas) }],
+      // Explicitly-selected sessions are the user's own attribution claim — anchor-grade.
+      contributors: [{ summary, session, slice: computeSlice(session.turns, shas), basis: "anchor" }],
       excludedCount: 0,
       sidechains: [],
     };
@@ -150,6 +154,7 @@ async function buildContributorView(raw: RawContributor, deps: PrDeps): Promise<
     usd: model.totalUsd,
     tokens: model.totalTokens,
     subagents,
+    basis: raw.basis,
   };
   return { view, model };
 }
@@ -236,7 +241,15 @@ export async function runPr(opts: PrOptions, deps: PrDeps = defaultPrDeps()): Pr
     link = publishAndLink(bodyInput, sessions, deps);
     artifactFailed = link === null;
   }
-  const body = renderPrBody(bodyInput, link ?? undefined);
+  // SPEC-0026 R5 — per-session full receipts, collapsed, unless --no-details.
+  const details =
+    opts.details === false
+      ? undefined
+      : entries.map((e) => ({
+          label: `${e.view.role} · ${e.view.sessionId}`,
+          text: renderReceipt(e.model, { color: false }),
+        }));
+  const body = renderPrBody(bodyInput, { artifactLink: link ?? undefined, details });
 
   // R3 (SPEC-0019): render before the comment upsert, unconditionally.
   deps.out(body);

--- a/src/pr/promote.ts
+++ b/src/pr/promote.ts
@@ -37,7 +37,7 @@ export async function promoteOrphanSidechains(
     if (!classifyBranchAnchors(session.turns, branchShas).hasOwn) {
       continue;
     }
-    promoted.push({ summary, session, slice: computeSlice(session.turns, branchShas) });
+    promoted.push({ summary, session, slice: computeSlice(session.turns, branchShas), basis: "anchor" });
   }
   return promoted;
 }

--- a/src/receipt/present.ts
+++ b/src/receipt/present.ts
@@ -21,6 +21,7 @@ import {
 import type { Block, ReceiptView, TemplateName } from "./blocks.js";
 import { formatAbsoluteUtc, formatDuration, formatInt, formatUsd } from "./format.js";
 import type { ReceiptModel, ToolRow, WasteLine } from "./model.js";
+import type { TokenUsage } from "../parse/types.js";
 
 export type { ReceiptView } from "./blocks.js";
 export { PRICE_DELTA_NOTE, TRIVIAL_SPANS_LABEL } from "./blocks.js";
@@ -53,12 +54,13 @@ function titleLine(model: ReceiptModel): string | undefined {
   return `“${cut}”`;
 }
 
-/** Share of prompt-side tokens served from cache — the single most explanatory cost fact a session has. `undefined` when there is no per-turn usage (Cursor) or no prompt tokens at all. */
-function cacheLine(model: ReceiptModel): string | undefined {
-  if (model.unpriceable) {
-    return undefined;
-  }
-  const t = model.totalTokens;
+/**
+ * Share of prompt-side tokens served from cache, over any `TokenUsage` — one
+ * formatter for the receipt masthead AND the PR comment's aggregate line
+ * (SPEC-0026 R2; a duplicated implementation is a review-rejected defect).
+ * `undefined` when there are no prompt tokens or no cache reads.
+ */
+export function cacheServedText(t: TokenUsage): string | undefined {
   const promptSide = t.input + t.cacheRead + t.cacheCreation;
   if (promptSide <= 0 || t.cacheRead <= 0) {
     return undefined;
@@ -69,6 +71,14 @@ function cacheLine(model: ReceiptModel): string | undefined {
   // fixtures) may say it; 99.5%+ says ">99%".
   const pct = ratio >= 1 ? "100" : Math.round(ratio * 100) >= 100 ? ">99" : String(Math.round(ratio * 100));
   return `cache served ${pct}% of input tokens`;
+}
+
+/** Share of prompt-side tokens served from cache — the single most explanatory cost fact a session has. `undefined` when there is no per-turn usage (Cursor) or no prompt tokens at all. */
+function cacheLine(model: ReceiptModel): string | undefined {
+  if (model.unpriceable) {
+    return undefined;
+  }
+  return cacheServedText(model.totalTokens);
 }
 
 function charCount(s: string): number {

--- a/test/cli/artifact-flag.test.ts
+++ b/test/cli/artifact-flag.test.ts
@@ -1,5 +1,6 @@
-// SPEC-0027 R4 — the `--artifact` flag through the real option parser and the
-// registered `pr` command's help text (SPEC-0018 registry surface).
+// SPEC-0027 R4 + SPEC-0026 R5 — the `--artifact`/`--no-details` flags through
+// the real option parser, registered help text, and main() dispatch
+// (SPEC-0018 registry surface).
 import { describe, expect, it } from "vitest";
 import { parseOptions } from "../../src/cli/options.js";
 import { command as prCommand } from "../../src/cli/commands/pr.js";
@@ -19,6 +20,18 @@ describe("SPEC-0027 R4 --artifact CLI surface", () => {
 
   it("lists --artifact in the pr command's help text", () => {
     expect(prCommand.help.lines.join("\n")).toContain("--artifact");
+  });
+
+  it("parses and lists --no-details (SPEC-0026 R5)", () => {
+    expect(parseOptions(["pr", "--no-details"]).noDetails).toBe(true);
+    expect(parseOptions(["pr"]).noDetails).toBe(false);
+    expect(prCommand.help.lines.join("\n")).toContain("--no-details");
+  });
+
+  it("dispatch: --no-details never changes command selection (a pr flag, not a positional)", async () => {
+    const { resolveCommand } = await import("../../src/cli/args.js");
+    expect(await resolveCommand(["pr", "--no-details"])).toBe("pr");
+    expect(await resolveCommand(["pr", "--post", "--artifact", "--no-details"])).toBe("pr");
   });
 
   it("dispatches through main(): pr --artifact without --post exits 1 before rendering", async () => {

--- a/test/pr/body.test.ts
+++ b/test/pr/body.test.ts
@@ -5,7 +5,8 @@
 import { describe, expect, it } from "vitest";
 import { emptyUsage, withTotal } from "../../src/parse/util.js";
 import type { ModelMixEntry } from "../../src/receipt/model.js";
-import { DOGFOOD_MARKER, renderPrBody, sliceHeaderLine, type ContributorView } from "../../src/pr/body.js";
+import { DOGFOOD_MARKER, HELPER_FULL_LABEL, renderPrBody, renderPrReceiptText, sliceHeaderLine, type ContributorView } from "../../src/pr/body.js";
+import { cacheServedText } from "../../src/receipt/present.js";
 import type { SubagentRow } from "../../src/pr/rollup.js";
 import { FULL_FALLBACK_LABEL } from "../../src/pr/slice.js";
 
@@ -52,19 +53,25 @@ describe("renderPrBody header + rows (#39 fixes)", () => {
     expect(body.match(/```/g)).toHaveLength(2);
   });
 
-  it("renders a role · model-mix dotted row with the slice as a muted provenance line under it", () => {
+  it("suppresses the role at N=1 (SPEC-0026 R1) — the row is the model mix alone", () => {
     const body = renderPrBody({ contributors: [builder()], excludedCount: 0 });
-    expect(body).toContain("builder · claude-opus-4-8 100%...............$1.50");
+    expect(body).not.toContain("builder ·");
+    expect(body).toMatch(/^claude-opus-4-8 100%\.+\$1\.50$/m);
     // provenance line: session id + slice header, demoted below the row.
     expect(body).toContain("abc123 · session slice: turns 2–4 of 6");
     // the slice line is NOT a markdown headline.
     expect(body).not.toContain("🧾 **aireceipts**");
   });
 
-  it("shows each model with its rounded share for a multi-model session", () => {
+  it("keeps the role prefix whenever rows need telling apart (N≥2)", () => {
+    const body = renderPrBody({ contributors: [builder(), builder({ sessionId: "def456" })], excludedCount: 0 });
+    expect(body).toContain("builder · claude-opus-4-8 100%");
+  });
+
+  it("shows each model with its rounded share for a multi-model session (no role at N=1)", () => {
     const view = builder({ modelMix: [mix("claude-opus-4-8", 0.8), mix("claude-haiku-4-5", 0.2)] });
     const body = renderPrBody({ contributors: [view], excludedCount: 0 });
-    expect(body).toContain("builder · claude-opus-4-8 80% · claude-ha…...$1.50");
+    expect(body).toMatch(/^claude-opus-4-8 80% · claude-haiku-4-5 20%\.*\$1\.50$/m);
   });
 
   it("keeps long provenance inside the 50-column receipt", () => {
@@ -140,5 +147,121 @@ describe("renderPrBody combined total (SPEC-0008 honesty)", () => {
     const body = renderPrBody({ contributors: [builder()], excludedCount: 2 });
     expect(body).toContain("2 candidate sessions not attributed");
     expect(body).toContain("(in repo + branch window, no branch commit)");
+  });
+});
+
+
+describe("SPEC-0026 R2 · aggregate cache line", () => {
+  const cached = (cacheRead: number, input = 1000) =>
+    withTotal({ ...emptyUsage(), input, cacheRead });
+
+  it("renders one muted cache line over the counted atoms, under counted:", () => {
+    const view = builder({ tokens: cached(600, 400) });
+    const lines = fencedLines(renderPrBody({ contributors: [view], excludedCount: 0 }));
+    const counted = lines.findIndex((l) => l.includes("counted: 1 session"));
+    expect(lines[counted + 1]).toContain("cache served 60% of input tokens");
+  });
+
+  it("stays absent when no counted atom read cache", () => {
+    const body = renderPrBody({ contributors: [builder()], excludedCount: 0 });
+    expect(body).not.toContain("cache served");
+  });
+
+  it("counts subagent tokens in the aggregate (a child's cache reads are real spend)", () => {
+    const sub: SubagentRow = { name: "kid", usd: null, tokens: cached(500, 500), unreadable: false, filePath: "kid.jsonl" };
+    const body = renderPrBody({ contributors: [builder({ subagents: [sub] })], excludedCount: 0 });
+    expect(body).toContain("cache served");
+  });
+
+  it("matches the receipt masthead formatter exactly (one implementation, I3)", () => {
+    const usage = cached(600, 400);
+    const view = builder({ tokens: usage });
+    const body = renderPrBody({ contributors: [view], excludedCount: 0 });
+    expect(body).toContain(cacheServedText(usage)!);
+  });
+
+  it("never rounds a partial ratio up to 100 (>99 boundary preserved)", () => {
+    const usage = cached(9990, 10);
+    expect(cacheServedText(usage)).toBe("cache served >99% of input tokens");
+    const body = renderPrBody({ contributors: [builder({ tokens: usage })], excludedCount: 0 });
+    expect(body).toContain(">99% of input tokens");
+    expect(body).not.toContain("cache served 100%");
+  });
+});
+
+describe("SPEC-0026 R3 · honest helper label", () => {
+  const fullSlice = { kind: "full" as const, startTurn: 0, endTurn: 5, turnCount: 6, label: FULL_FALLBACK_LABEL };
+
+  it("relabels a helper-credited full session: no commits to slice by", () => {
+    const body = renderPrBody({ contributors: [builder({ slice: fullSlice, basis: "helper" })], excludedCount: 0 });
+    expect(body).toContain(HELPER_FULL_LABEL);
+    expect(body).not.toContain(FULL_FALLBACK_LABEL);
+  });
+
+  it("keeps the anchored fallback label byte-for-byte", () => {
+    const body = renderPrBody({ contributors: [builder({ slice: fullSlice, basis: "anchor" })], excludedCount: 0 });
+    expect(body).toContain(FULL_FALLBACK_LABEL);
+    expect(body).not.toContain(HELPER_FULL_LABEL);
+  });
+});
+
+describe("SPEC-0026 R4 · footer hint", () => {
+  it("is the last muted note of the fenced receipt", () => {
+    const body = renderPrBody({ contributors: [builder()], excludedCount: 1 });
+    const lines = fencedLines(body);
+    const hint = lines.findIndex((l) => l.includes("details: npx aireceipts --session <id>"));
+    expect(hint).toBeGreaterThan(-1);
+    // After the hint: only the rule/footer decoration, never another note.
+    expect(lines.slice(hint + 1).every((l) => !l.trim().startsWith("(") && !l.includes("not attributed"))).toBe(true);
+  });
+});
+
+describe("SPEC-0026 R5 · collapsed full receipts", () => {
+  const detail = (label: string, text = "RECEIPT-TEXT") => ({ label, text });
+
+  it("appends the details section after the fence, receipts in row order, marker still first", () => {
+    const body = renderPrBody(
+      { contributors: [builder(), builder({ sessionId: "def456" })], excludedCount: 0 },
+      { details: [detail("builder · abc123", "AAA"), detail("builder · def456", "BBB")] },
+    );
+    expect(body.startsWith(DOGFOOD_MARKER)).toBe(true);
+    expect(body).toContain("<details><summary>full receipts (2 sessions)</summary>");
+    expect(body.indexOf("</details>")).toBeGreaterThan(body.indexOf("AAA"));
+    expect(body.indexOf("AAA")).toBeLessThan(body.indexOf("BBB"));
+    expect(body.indexOf("<details>")).toBeGreaterThan(body.indexOf("```"));
+  });
+
+  it("places the SPEC-0027 artifact link under the details section", () => {
+    const body = renderPrBody(
+      { contributors: [builder()], excludedCount: 0 },
+      { details: [detail("builder · abc123")], artifactLink: { fileName: "pr-9.html", url: "https://x/pr-9.html" } },
+    );
+    expect(body.indexOf("full receipt: [pr-9.html]")).toBeGreaterThan(body.indexOf("</details>"));
+  });
+
+  it("omits the section entirely without details (--no-details path)", () => {
+    const body = renderPrBody({ contributors: [builder()], excludedCount: 0 });
+    expect(body).not.toContain("<details>");
+  });
+
+  it("drops trailing receipts to omission notes under the size cap — never mid-receipt truncation", () => {
+    const big = "X".repeat(40_000);
+    const body = renderPrBody(
+      { contributors: [builder(), builder({ sessionId: "def456" })], excludedCount: 0 },
+      { details: [detail("builder · abc123", big), detail("builder · def456", big)] },
+    );
+    expect([...body].length).toBeLessThanOrEqual(65_000);
+    expect(body).toContain("builder · def456 — full receipt omitted (comment size limit)");
+    // The kept receipt is intact, not truncated.
+    expect(body).toContain(big);
+  });
+
+  it("drops the whole section when even omission notes cannot fit", () => {
+    const rollup = renderPrReceiptText({ contributors: [builder()], excludedCount: 0 });
+    // 800 sessions × ~100-char labels → omission notes alone exceed the cap.
+    const many = Array.from({ length: 800 }, (_, i) => detail(`session-${i}-${"L".repeat(90)}`, "small"));
+    const body = renderPrBody({ contributors: [builder()], excludedCount: 0 }, { details: many });
+    expect(body).not.toContain("<details>");
+    expect(body).toContain(rollup);
   });
 });


### PR DESCRIPTION
## What this adds

The five comment fixes from your PR #58 receipt review (SPEC-0026, approved): role suppressed at N=1, aggregate cache line, `entire session (no commits to slice by)` for helpers, the `details:` command hint, and a collapsed `<details>` section carrying every session's full per-tool receipt — size-capped, with `--no-details` to opt out. SPEC-0027's artifact link moves to its final home under the details section, closing that PR's flagged deviation.

## See it

Dogfooded on this PR — the receipt comment below shows the full new shape live (matches the [design mockups](https://claude.ai/code/artifact/6067cce8-25fa-467e-a36d-42190f15e003) you reviewed).

## What changed

- `src/pr/body.ts` — R1 role-at-N≥2 only; R2 cache line over exactly the counted atoms; R3 `HELPER_FULL_LABEL`; R4 hint as last note; R5 `detailsSection` with prefix-sum size cap (largest keep-prefix, omission notes, floor drop) and exact-link-length budgeting.
- `src/receipt/present.ts` — `cacheServedText` extracted (one formatter, both surfaces; masthead behavior identical).
- `src/pr/contributors.ts` / `promote.ts` / `index.ts` — attribution `basis` (`anchor`/`helper`) plumbed through; details assembly with `renderReceipt` per retained model.
- `--no-details` flag + help; `goldens/cli/help.txt` + `goldens/html/pr-artifact.html` regenerated deliberately; terminal receipt goldens untouched.

## What to review, in order

1. **Size-cap math** — `src/pr/body.ts` `detailsSection` + the exact-budget block in `renderPrBody` (Codex S5 MEDIUM finding, fixed: no hardcoded reserve).
2. **R3 honesty** — the basis plumbing: `HELPER_FULL_LABEL` can only render on `basis === "helper"` + full slice; anchored fallbacks byte-identical.
3. **Deliberate test flips** — two R1 rewrites in `test/pr/body.test.ts` (critic-confirmed as the specced flip, not weakenings).

## Evidence

- Gates unmasked exit 0: tsc · eslint · vitest **909/909** (26-test body battery) · goldens 90 byte-identical · determinism ×10 · spec-lint 27 OK · hygiene OK.
- Spec: `specs/SPEC-0026-pr-comment-polish.md` — S1–S5 recorded (draft REWORK 10 findings → 8 accepted; impl REWORK 2 findings → both fixed).

## Notes

- **Base is PR #63's branch** (its `body.ts` seams are prerequisites) — merge #63 first and this retargets to `main` clean.
- The in-flight SPEC-0028 build touches `totalBlocks`; whichever lands second rebases trivially (disjoint functions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)