### PR TITLE
feat: receipt round 2 — grouped helpers, story over list

### DIFF
--- a/goldens/html/pr-artifact.html
+++ b/goldens/html/pr-artifact.html
@@ -25,10 +25,7 @@ footer{font-size:11px;color:var(--muted);text-align:center;margin-top:36px}</sty
             2 sessions behind this PR             
 
 builder · claude-opus-4-8 87% · claude-so…...$0.18
-  session: golden-builder
-  entire session (slice unavailable)
-builder · claude-opus-4-8 100%...............$0.09
-  golden-loop · entire session (slice unavailable)
+builder · claude-opus-4-8....................$0.09
 --------------------------------------------------
 TOTAL priced.................................$0.27
   counted: 2 sessions

--- a/specs/SPEC-0026-pr-comment-polish.md
+++ b/specs/SPEC-0026-pr-comment-polish.md
@@ -161,11 +161,45 @@ renders as one line: full receipt omitted (comment size limit)>
 </details>
 ```
 
-Copy rules: `no commits to slice by` (maintainer pushed back on "(no git
-writes)" as attribution-internal jargon, 2026-07-03 — the label must name the
-user-visible fact and the reason there is no turn range); the hint says `npx aireceipts` (the README's canonical invocation);
+Copy rules (round 2 supersedes the per-row label): helpers group under one
+header — `CODEX HELPERS (N) — no commits` — because the explainer belongs to
+the GROUP the credit rule proved things about, not to five identical rows; the hint says `npx aireceipts` (the README's canonical invocation);
 the summary line always carries the count so the collapsed state is
 informative.
+
+### Round 2 (maintainer dogfood on PR #63's live receipt, 2026-07-03)
+
+The first shipped shape read as "very busy" on a real 6-session receipt, and
+flat rows hid the story ("someone will be confused what actually happened
+here"). Iterated live over five mockup rounds
+(https://claude.ai/code/artifact/6067cce8-25fa-467e-a36d-42190f15e003);
+final grammar, maintainer-accepted ("this looks good"):
+
+- **Fence = story.** Top-level rows are sessions that COMMITTED (role at
+  N≥2, model mix, cost; their `session slice: turns A–B of N` line stays —
+  a sliced cost means something different). The supporting cast indents:
+  `SUBAGENTS (N)` as before, and helper-credited sessions under
+  `CODEX HELPERS (N) — no commits`, one muted row each with ONE fact:
+  `<model> · <duration>` (a receipt is not a dashboard — time, token
+  triples, and labeled token facts were each tried and rejected as busy
+  or legend-dependent).
+- **No session ids in the fence.** Ids and full-session explainers move to
+  the details section's per-session stat line:
+  `<role> · <id> · <slice|no commits> · <turns> turns · <dur> · in <k> ·
+  out <k> · <cached>% cached` (self-labeling; cache as percent — the
+  masthead's own convention). The `npx aireceipts --session <id>` hint
+  moves inside the details section next to the ids it needs; the fence's
+  last note points at the section (`full receipts + session ids: section
+  below`) and falls back to the command hint whenever no section follows
+  (`--no-details`, or the size floor dropped it — a hint must never point
+  at nothing).
+- **`100%` never renders** — a share earns ink only for a real mix.
+- **Subagent names sanitized** — a markup-shaped child title (fork
+  boilerplate) falls back to `agent-<id>`, the masthead's own rule.
+- **Not configurable, deliberately**: one canonical comment shape is the
+  trust asset; per-fact knobs fragment the contract and multiply the
+  honesty surface. SPEC-0020 templates remain the principled home if
+  customization demand ever materializes.
 
 ## Test matrix
 
@@ -248,6 +282,13 @@ criteria: this spec's own PR must post the new comment shape.
 
 **2026-07-03 · S4 (lint):** `node scripts/spec-lint.mjs` → 26 spec(s) OK,
 exit 0.
+
+**2026-07-03 · round 2 (maintainer dogfood, five design iterations):** fence
+grammar reworked as recorded in the Design section; implemented on PR #63's
+branch with the deliberate test flips documented in the commit. One honesty
+edge found during implementation: the section-pointer hint could dangle when
+the size floor dropped the details section — the final body now decides the
+hint after the section decision.
 
 **2026-07-03 · S5 (implementation review, Codex): REWORK → fixed.** (1) MEDIUM:
 the size-cap budget reserved a hardcoded 200 chars for the artifact link —

--- a/specs/SPEC-0026-pr-comment-polish.md
+++ b/specs/SPEC-0026-pr-comment-polish.md
@@ -179,8 +179,8 @@ final grammar, maintainer-accepted ("this looks good"):
   N≥2, model mix, cost; their `session slice: turns A–B of N` line stays —
   a sliced cost means something different). The supporting cast indents:
   `SUBAGENTS (N)` as before, and helper-credited sessions under
-  `CODEX HELPERS (N) — no commits`, one muted row each with ONE fact:
-  `<model> · <duration>` (a receipt is not a dashboard — time, token
+  `CODEX HELPERS (N) — no commits`, one muted row each carrying its cost
+  plus ONE fact beside it: `<model> · <duration>` (a receipt is not a dashboard — time, token
   triples, and labeled token facts were each tried and rejected as busy
   or legend-dependent).
 - **No session ids in the fence.** Ids and full-session explainers move to
@@ -193,7 +193,11 @@ final grammar, maintainer-accepted ("this looks good"):
   below`) and falls back to the command hint whenever no section follows
   (`--no-details`, or the size floor dropped it — a hint must never point
   at nothing).
-- **`100%` never renders** — a share earns ink only for a real mix.
+- **`100%` never renders** — a share earns ink only for a real mix, and a
+  real mix never rounds a partial share to `100%`/`0%` (`>99%`/`<1%`, the
+  cache line's own honesty rule).
+- **Details/artifact order mirrors the fence** (authors first, helpers
+  after), so the size-cap's drop-from-END sheds helpers before authors.
 - **Subagent names sanitized** — a markup-shaped child title (fork
   boilerplate) falls back to `agent-<id>`, the masthead's own rule.
 - **Not configurable, deliberately**: one canonical comment shape is the

--- a/src/pr/body.ts
+++ b/src/pr/body.ts
@@ -8,7 +8,8 @@ import type { TokenUsage } from "../parse/types.js";
 import type { Block } from "../receipt/blocks.js";
 import type { ModelMixEntry } from "../receipt/model.js";
 import { formatInt, formatUsd } from "../receipt/format.js";
-import { cacheServedText } from "../receipt/present.js";
+import { cacheServedText, compactDuration } from "../receipt/present.js";
+import { formatDuration } from "../receipt/format.js";
 import { addUsage, emptyUsage } from "../parse/util.js";
 import { RECEIPT_WIDTH, renderBlockLines } from "../receipt/render.js";
 import type { Role } from "./contributors.js";
@@ -30,18 +31,22 @@ export interface ContributorView {
   usd: number | null;
   tokens: TokenUsage;
   subagents: SubagentRow[];
-  /** SPEC-0026 R3 — how selection credited this session; `helper` relabels the full-session line honestly. */
+  /** SPEC-0026 R3 — how selection credited this session; `helper` rows render grouped, not top-level (round 2). */
   basis?: "anchor" | "helper";
+  /** Rendered-slice duration — the helper group's one per-row fact (round 2). */
+  durationMs?: number;
 }
 
 export interface PrBodyInput {
   contributors: ContributorView[];
   /** Candidates that were in repo + window but not credited (R1) — reported honestly (R4). */
   excludedCount: number;
+  /** Round 2: true → the hint points at the details section below; false/absent → the command hint (--no-details, unit callers). */
+  detailsBelow?: boolean;
 }
 
-/** SPEC-0026 R3 — a helper session made no commits, so the whole session IS the correct scope (maintainer wording, 2026-07-03). */
-export const HELPER_FULL_LABEL = "entire session (no commits to slice by)";
+/** SPEC-0026 R3 (round 2) — the helper explainer, now the group header's and details stat line's phrasing. */
+export const HELPER_FULL_LABEL = "no commits";
 /** SPEC-0026 R5 — GitHub caps issue comments at 65,536 chars; we cap under it. */
 const COMMENT_SIZE_CAP = 65_000;
 const OMITTED_NOTE = "full receipt omitted (comment size limit)";
@@ -59,10 +64,13 @@ export function sliceHeaderLine(slice: SliceResult): string {
   return `session slice: turns ${slice.startTurn + 1}–${slice.endTurn + 1} of ${slice.turnCount}`;
 }
 
-/** `claude-opus-4-8 100%` / `claude-opus-4-8 80% · claude-haiku-4-5 20%` — each model with its rounded token share (#39). */
+/** `claude-opus-4-8` (a share only earns ink for a real mix) / `claude-opus-4-8 80% · claude-haiku-4-5 20%` (#39, round 2). */
 function formatModelMix(modelMix: ModelMixEntry[]): string {
   if (modelMix.length === 0) {
     return "no model reported";
+  }
+  if (modelMix.length === 1) {
+    return modelMix[0].model;
   }
   return modelMix.map((m) => `${m.model} ${Math.round(m.tokenShare * 100)}%`).join(" · ");
 }
@@ -74,10 +82,6 @@ function costText(usd: number | null, tokens: TokenUsage): string {
 
 function plural(n: number, singular: string, pluralForm = `${singular}s`): string {
   return `${n} ${n === 1 ? singular : pluralForm}`;
-}
-
-function codepointLength(s: string): number {
-  return [...s].length;
 }
 
 function capText(s: string, width: number): string {
@@ -92,19 +96,12 @@ function mutedNote(text: string, indent = NOTE_INDENT): Block {
   return { kind: "note", text, indent, muted: true };
 }
 
+/** Round 2: the fence carries provenance ONLY when it changes a number's meaning — a real slice. Ids and full-session explainers live in the details section. */
 function provenanceBlocks(view: ContributorView): Block[] {
-  const slice =
-    view.basis === "helper" && view.slice.kind === "full" ? HELPER_FULL_LABEL : sliceHeaderLine(view.slice);
-  const joined = `${view.sessionId} · ${slice}`;
-  const capacity = RECEIPT_WIDTH - NOTE_INDENT;
-  if (codepointLength(joined) <= capacity) {
-    return [mutedNote(joined)];
+  if (view.slice.kind !== "slice") {
+    return [];
   }
-  const prefix = "session: ";
-  return [
-    mutedNote(`${prefix}${capText(view.sessionId, capacity - prefix.length)}`),
-    mutedNote(capText(slice, capacity)),
-  ];
+  return [mutedNote(capText(sliceHeaderLine(view.slice), RECEIPT_WIDTH - NOTE_INDENT))];
 }
 
 function subagentLabel(row: SubagentRow): string {
@@ -218,8 +215,27 @@ function totalBlocks(input: PrBodyInput): Block[] {
     });
     blocks.push({ kind: "note", text: "(in repo + branch window, no branch commit)", muted: true });
   }
-  // SPEC-0026 R4 — the route to the full per-tool story, always the last note.
-  blocks.push(mutedNote("details: npx aireceipts --session <id>"));
+  // SPEC-0026 R4 (round 2) — the route to the full per-tool story, always the
+  // last note: point at the details section when one follows, else the command.
+  blocks.push(
+    mutedNote(input.detailsBelow === true ? "full receipts + session ids: section below" : "details: npx aireceipts --session <id>"),
+  );
+  return blocks;
+}
+
+/** Round 2: one muted row per helper — model + duration + cost; the group header explains them once. */
+function helperGroupBlocks(helpers: ContributorView[], spaceBefore: boolean): Block[] {
+  if (helpers.length === 0) {
+    return [];
+  }
+  const blocks: Block[] = [
+    { kind: "note", text: `CODEX HELPERS (${helpers.length}) — ${HELPER_FULL_LABEL}`, indent: NOTE_INDENT, muted: true, spaceBefore },
+  ];
+  for (const h of helpers) {
+    const dur = h.durationMs !== undefined ? compactDuration(formatDuration(h.durationMs)) : undefined;
+    const label = dur !== undefined ? `${formatModelMix(h.modelMix)} · ${dur}` : formatModelMix(h.modelMix);
+    blocks.push({ kind: "row", label: `  ${label}`, value: costText(h.usd, h.tokens), muted: true });
+  }
   return blocks;
 }
 
@@ -229,10 +245,16 @@ function prBlocks(input: PrBodyInput): Block[] {
     { kind: "masthead", text: WORDMARK },
     { kind: "meta", lines: [`${plural(n, "session")} behind this PR`] },
   ];
-  const showRole = n > 1;
-  input.contributors.forEach((view, i) => {
+  // Round 2 grammar: top-level rows are sessions that committed; helpers group
+  // below them under one explanatory header (never nested under a specific
+  // session — grouping states only what the credit rule proved).
+  const authors = input.contributors.filter((v) => v.basis !== "helper");
+  const helpers = input.contributors.filter((v) => v.basis === "helper");
+  const showRole = authors.length > 1;
+  authors.forEach((view, i) => {
     blocks.push(...contributorBlocks(view, i === 0, showRole));
   });
+  blocks.push(...helperGroupBlocks(helpers, authors.length === 0));
   blocks.push(...totalBlocks(input));
   blocks.push({ kind: "footer", text: FOOTER_TEXT, emoji: FOOTER_EMOJI });
   return blocks;
@@ -294,21 +316,28 @@ function detailsSection(details: DetailReceipt[], budget: number): string | null
  * confirmed push) — printed and posted bodies are always identical.
  */
 export function renderPrBody(input: PrBodyInput, extras: PrBodyExtras = {}): string {
-  const lines = [DOGFOOD_MARKER, "```", renderPrReceiptText(input), "```"];
   const linkLine = extras.artifactLink
     ? `full receipt: [${extras.artifactLink.fileName}](${extras.artifactLink.url})`
     : undefined;
+  // Decide the section first against the section-hint fence (the longer of the
+  // two hints, so the budget can only be conservative); the fence's hint then
+  // states what the FINAL body actually contains — a dropped section must
+  // never leave a "section below" pointing at nothing.
+  let section: string | null = null;
   if (extras.details !== undefined && extras.details.length > 0) {
-    // Budget with the EXACT bytes that surround the section: everything
-    // rendered so far, the real link line (never a guess), and the join
-    // newlines each appended line costs (incl. the blank line below).
-    const used = [...lines.join("\n")].length + (linkLine === undefined ? 0 : [...linkLine].length + 1) + 3;
-    const section = detailsSection(extras.details, COMMENT_SIZE_CAP - used);
-    if (section !== null) {
-      // GFM: an HTML block swallows everything until a BLANK line — without
-      // one, the link after </details> renders as raw text, not a link.
-      lines.push(section, "");
-    }
+    const budgetFence = renderPrReceiptText({ ...input, detailsBelow: true });
+    const used =
+      [...[DOGFOOD_MARKER, FENCE, budgetFence, FENCE].join("\n")].length +
+      (linkLine === undefined ? 0 : [...linkLine].length + 1) +
+      3;
+    section = detailsSection(extras.details, COMMENT_SIZE_CAP - used);
+  }
+  const fence = renderPrReceiptText({ ...input, detailsBelow: section !== null });
+  const lines = [DOGFOOD_MARKER, "```", fence, "```"];
+  if (section !== null) {
+    // GFM: an HTML block swallows everything until a BLANK line — without
+    // one, the link after </details> renders as raw text, not a link.
+    lines.push(section, "");
   }
   if (linkLine !== undefined) {
     lines.push(linkLine);

--- a/src/pr/body.ts
+++ b/src/pr/body.ts
@@ -72,7 +72,19 @@ function formatModelMix(modelMix: ModelMixEntry[]): string {
   if (modelMix.length === 1) {
     return modelMix[0].model;
   }
-  return modelMix.map((m) => `${m.model} ${Math.round(m.tokenShare * 100)}%`).join(" · ");
+  // Display honesty (same rule as the cache line): a real mix never rounds a
+  // partial share up to 100% or down to 0%.
+  const sharePct = (share: number): string => {
+    const pct = Math.round(share * 100);
+    if (pct >= 100 && share < 1) {
+      return ">99%";
+    }
+    if (pct <= 0 && share > 0) {
+      return "<1%";
+    }
+    return `${pct}%`;
+  };
+  return modelMix.map((m) => `${m.model} ${sharePct(m.tokenShare)}`).join(" · ");
 }
 
 /** A priced atom renders `$`; an unpriced one falls back to tokens (I2). */

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -12,6 +12,9 @@ import * as path from "node:path";
 import type { Session, SessionSummary } from "../parse/types.js";
 import { buildReceiptModel, sliceSessionForReceipt } from "../receipt/model.js";
 import { renderReceipt } from "../receipt/render.js";
+import { cacheServedPct, compactDuration } from "../receipt/present.js";
+import { formatDuration, formatShortTokens } from "../receipt/format.js";
+import { HELPER_FULL_LABEL, sliceHeaderLine } from "./body.js";
 import { branchCommits, currentWorktreeRoot, defaultRunner, worktreeRoots, type CommandRunner } from "./git.js";
 import { isBranchCandidate, overlapsBranchWindow, selectExplicitSession } from "./select.js";
 import { computeSlice } from "./slice.js";
@@ -155,6 +158,7 @@ async function buildContributorView(raw: RawContributor, deps: PrDeps): Promise<
     tokens: model.totalTokens,
     subagents,
     basis: raw.basis,
+    durationMs: model.durationMs,
   };
   return { view, model };
 }
@@ -186,6 +190,26 @@ function publishAndLink(
     return null;
   }
   return { fileName, url: artifactViewUrl(pr.ownerRepo, fileName) };
+}
+
+/** The details-section stat line: role · id · slice/commits · turns · duration · in/out/cached (round 2). */
+function detailLabel(view: ContributorView, model: ReceiptModel): string {
+  const parts = [view.role, view.sessionId];
+  parts.push(view.basis === "helper" ? HELPER_FULL_LABEL : view.slice.kind === "slice" ? sliceHeaderLine(view.slice) : (view.slice.label ?? "entire session"));
+  const turns = view.slice.kind === "slice" ? view.slice.endTurn - view.slice.startTurn + 1 : view.slice.turnCount;
+  if (turns > 0) {
+    parts.push(`${turns} turns`);
+  }
+  if (model.durationMs !== undefined) {
+    parts.push(compactDuration(formatDuration(model.durationMs)));
+  }
+  const t = model.totalTokens;
+  parts.push(`in ${formatShortTokens(t.input)}`, `out ${formatShortTokens(t.output)}`);
+  const pct = cacheServedPct(t);
+  if (pct !== undefined) {
+    parts.push(`${pct}% cached`);
+  }
+  return parts.join(" · ");
 }
 
 /** `aireceipts pr [--post] [--session <id>] [--artifact]`. Returns the process exit code. */
@@ -241,14 +265,10 @@ export async function runPr(opts: PrOptions, deps: PrDeps = defaultPrDeps()): Pr
     link = publishAndLink(bodyInput, sessions, deps);
     artifactFailed = link === null;
   }
-  // SPEC-0026 R5 — per-session full receipts, collapsed, unless --no-details.
-  const details =
-    opts.details === false
-      ? undefined
-      : entries.map((e) => ({
-          label: `${e.view.role} · ${e.view.sessionId}`,
-          text: renderReceipt(e.model, { color: false }),
-        }));
+  // SPEC-0026 R5 (round 2) — per-session full receipts, collapsed, unless
+  // --no-details. The label is the stat line: everything the fence dropped
+  // (id, slice reason) plus the session's anatomy, in one place.
+  const details = opts.details === false ? undefined : entries.map((e) => ({ label: detailLabel(e.view, e.model), text: renderReceipt(e.model, { color: false }) }));
   const body = renderPrBody(bodyInput, { artifactLink: link ?? undefined, details });
 
   // R3 (SPEC-0019): render before the comment upsert, unconditionally.

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -252,6 +252,10 @@ export async function runPr(opts: PrOptions, deps: PrDeps = defaultPrDeps()): Pr
     return 1;
   }
   entries.sort((a, b) => a.startedAt - b.startedAt || a.id.localeCompare(b.id));
+  // Round 2: the fence renders authors first, helpers grouped after — the
+  // details section and the artifact page must show the SAME order, so the
+  // size-cap's drop-from-END sheds helpers before authors.
+  const fenceOrdered = [...entries.filter((e) => e.view.basis !== "helper"), ...entries.filter((e) => e.view.basis === "helper")];
   const views = entries.map((e) => e.view);
   const bodyInput: PrBodyInput = { contributors: views, excludedCount: resolved.excludedCount };
 
@@ -261,14 +265,14 @@ export async function runPr(opts: PrOptions, deps: PrDeps = defaultPrDeps()): Pr
   let artifactFailed = false;
   let link: { fileName: string; url: string } | null = null;
   if (opts.artifact) {
-    const sessions: ArtifactSession[] = entries.map((e) => ({ label: `${e.view.role} · ${e.view.sessionId}`, model: e.model }));
+    const sessions: ArtifactSession[] = fenceOrdered.map((e) => ({ label: detailLabel(e.view, e.model), model: e.model }));
     link = publishAndLink(bodyInput, sessions, deps);
     artifactFailed = link === null;
   }
   // SPEC-0026 R5 (round 2) — per-session full receipts, collapsed, unless
   // --no-details. The label is the stat line: everything the fence dropped
   // (id, slice reason) plus the session's anatomy, in one place.
-  const details = opts.details === false ? undefined : entries.map((e) => ({ label: detailLabel(e.view, e.model), text: renderReceipt(e.model, { color: false }) }));
+  const details = opts.details === false ? undefined : fenceOrdered.map((e) => ({ label: detailLabel(e.view, e.model), text: renderReceipt(e.model, { color: false }) }));
   const body = renderPrBody(bodyInput, { artifactLink: link ?? undefined, details });
 
   // R3 (SPEC-0019): render before the comment upsert, unconditionally.

--- a/src/pr/rollup.ts
+++ b/src/pr/rollup.ts
@@ -74,8 +74,11 @@ export async function rollupChildren(
       continue;
     }
     const model = await buildReceiptModel(session);
+    // A markup-shaped title (fork boilerplate, injected XML) is machine noise,
+    // not a name — same rule the receipt masthead applies to its title line.
+    const title = session.title?.replace(/\s+/g, " ").trim();
     rows.push({
-      name: session.title ?? agentId,
+      name: title !== undefined && title !== "" && !title.startsWith("<") ? title : `agent-${agentId}`,
       model: session.model,
       usd: model.totalUsd,
       tokens: model.totalTokens,

--- a/src/receipt/format.ts
+++ b/src/receipt/format.ts
@@ -117,3 +117,17 @@ export function formatRatio(ratio: number): string {
 export function formatTokensK(n: number): string {
   return `${formatInt(Math.round(n / 1000))}k tok`;
 }
+
+/**
+ * SPEC-0026 round 2 — abbreviated token counts for stat lines (`371k`, `1.2M`).
+ * One decimal only while it disambiguates (< 10 of the unit), deterministic
+ * rounding; never truncates a digit mid-value.
+ */
+export function formatShortTokens(n: number): string {
+  if (n < 1000) {
+    return String(n);
+  }
+  const unit = (v: number, suffix: string): string =>
+    `${v < 9.95 ? v.toFixed(1).replace(/\.0$/u, "") : String(Math.round(v))}${suffix}`;
+  return n < 999_500 ? unit(n / 1000, "k") : unit(n / 1_000_000, "M");
+}

--- a/src/receipt/present.ts
+++ b/src/receipt/present.ts
@@ -60,7 +60,7 @@ function titleLine(model: ReceiptModel): string | undefined {
  * (SPEC-0026 R2; a duplicated implementation is a review-rejected defect).
  * `undefined` when there are no prompt tokens or no cache reads.
  */
-export function cacheServedText(t: TokenUsage): string | undefined {
+export function cacheServedPct(t: TokenUsage): string | undefined {
   const promptSide = t.input + t.cacheRead + t.cacheCreation;
   if (promptSide <= 0 || t.cacheRead <= 0) {
     return undefined;
@@ -69,8 +69,12 @@ export function cacheServedText(t: TokenUsage): string | undefined {
   // Display honesty: never round a partial ratio up to the impossible-sounding
   // "100%" — a real session always has SOME uncached prompt. True 100% (synthetic
   // fixtures) may say it; 99.5%+ says ">99%".
-  const pct = ratio >= 1 ? "100" : Math.round(ratio * 100) >= 100 ? ">99" : String(Math.round(ratio * 100));
-  return `cache served ${pct}% of input tokens`;
+  return ratio >= 1 ? "100" : Math.round(ratio * 100) >= 100 ? ">99" : String(Math.round(ratio * 100));
+}
+
+export function cacheServedText(t: TokenUsage): string | undefined {
+  const pct = cacheServedPct(t);
+  return pct === undefined ? undefined : `cache served ${pct}% of input tokens`;
 }
 
 /** Share of prompt-side tokens served from cache — the single most explanatory cost fact a session has. `undefined` when there is no per-turn usage (Cursor) or no prompt tokens at all. */
@@ -89,7 +93,8 @@ function withoutSeconds(utc: string): string {
   return utc.replace(/:\d{2} UTC$/u, " UTC");
 }
 
-function compactDuration(duration: string): string {
+/** `15h 53m 20s` → `15h 53m` — a stat line doesn't need seconds. */
+export function compactDuration(duration: string): string {
   return duration.replace(/ \d{2}s$/u, "");
 }
 

--- a/test/pr/body.test.ts
+++ b/test/pr/body.test.ts
@@ -53,19 +53,20 @@ describe("renderPrBody header + rows (#39 fixes)", () => {
     expect(body.match(/```/g)).toHaveLength(2);
   });
 
-  it("suppresses the role at N=1 (SPEC-0026 R1) — the row is the model mix alone", () => {
+  it("suppresses the role at N=1 and the redundant 100% share (SPEC-0026 R1, round 2)", () => {
     const body = renderPrBody({ contributors: [builder()], excludedCount: 0 });
     expect(body).not.toContain("builder ·");
-    expect(body).toMatch(/^claude-opus-4-8 100%\.+\$1\.50$/m);
-    // provenance line: session id + slice header, demoted below the row.
-    expect(body).toContain("abc123 · session slice: turns 2–4 of 6");
-    // the slice line is NOT a markdown headline.
-    expect(body).not.toContain("🧾 **aireceipts**");
+    expect(body).not.toContain("100%");
+    expect(body).toMatch(/^claude-opus-4-8\.+\$1\.50$/m);
+    // Round 2: a real slice keeps its line (it changes the number's meaning); the id does not.
+    expect(body).toContain("session slice: turns 2–4 of 6");
+    expect(body).not.toContain("abc123");
   });
 
   it("keeps the role prefix whenever rows need telling apart (N≥2)", () => {
     const body = renderPrBody({ contributors: [builder(), builder({ sessionId: "def456" })], excludedCount: 0 });
-    expect(body).toContain("builder · claude-opus-4-8 100%");
+    expect(body).toContain("builder · claude-opus-4-8");
+    expect(body).not.toContain("100%");
   });
 
   it("shows each model with its rounded share for a multi-model session (no role at N=1)", () => {
@@ -74,12 +75,12 @@ describe("renderPrBody header + rows (#39 fixes)", () => {
     expect(body).toMatch(/^claude-opus-4-8 80% · claude-haiku-4-5 20%\.*\$1\.50$/m);
   });
 
-  it("keeps long provenance inside the 50-column receipt", () => {
+  it("carries no session ids in the fence (round 2) and every line fits 50 columns", () => {
     const body = renderPrBody({
       contributors: [builder({ sessionId: "rollout-2026-07-02T18-06-36-019f2583-6862-71c3-9abf-0eb4244ae5b0" })],
       excludedCount: 0,
     });
-    expect(body).toContain("session: rollout-2026-07-02T18-06-36-019f2583-6…");
+    expect(body).not.toContain("rollout-2026-07-02T18-06-36");
     for (const line of fencedLines(body)) {
       expect([...line].length).toBeLessThanOrEqual(50);
     }
@@ -93,7 +94,7 @@ describe("renderPrBody header + rows (#39 fixes)", () => {
       ],
       excludedCount: 0,
     });
-    expect(body).toContain("orchestrator · claude-opus-4-8 100%..........$1.50");
+    expect(body).toContain("orchestrator · claude-opus-4-8...............$1.50");
     expect(body).toContain("codex · no model reported.............5,000 tokens");
   });
 });
@@ -189,19 +190,38 @@ describe("SPEC-0026 R2 · aggregate cache line", () => {
   });
 });
 
-describe("SPEC-0026 R3 · honest helper label", () => {
+describe("SPEC-0026 R3 (round 2) · helpers group under one explanatory header", () => {
   const fullSlice = { kind: "full" as const, startTurn: 0, endTurn: 5, turnCount: 6, label: FULL_FALLBACK_LABEL };
+  const helper = (id: string, usd: number, durationMs?: number) =>
+    builder({ sessionId: id, slice: fullSlice, basis: "helper", role: "codex", usd, durationMs, modelMix: [mix("gpt-5.5", 1)] });
 
-  it("relabels a helper-credited full session: no commits to slice by", () => {
-    const body = renderPrBody({ contributors: [builder({ slice: fullSlice, basis: "helper" })], excludedCount: 0 });
-    expect(body).toContain(HELPER_FULL_LABEL);
+  it("renders helpers as muted rows under CODEX HELPERS with duration as the one per-row fact", () => {
+    const body = renderPrBody(
+      { contributors: [builder(), helper("h1", 1.74, 18 * 60_000), helper("h2", 0.3, 4 * 60_000)], excludedCount: 0 },
+    );
+    const lines = fencedLines(body);
+    const header = lines.findIndex((l) => l.includes(`CODEX HELPERS (2) — ${HELPER_FULL_LABEL}`));
+    expect(header).toBeGreaterThan(-1);
+    expect(lines[header + 1]).toMatch(/gpt-5\.5 · 18m\.+\$1\.74/);
+    expect(lines[header + 2]).toMatch(/gpt-5\.5 · 4m\.+\$0\.30/);
+    // The explainer lives once on the header — never per row, never the old long label.
+    expect(body).not.toContain("no commits to slice by");
     expect(body).not.toContain(FULL_FALLBACK_LABEL);
+    // Helpers are grouped after authors; the author row keeps its slice line.
+    expect(body).toContain("session slice: turns 2–4 of 6");
   });
 
-  it("keeps the anchored fallback label byte-for-byte", () => {
+  it("an anchored full-session author renders a bare row — no explainer, no helper header", () => {
     const body = renderPrBody({ contributors: [builder({ slice: fullSlice, basis: "anchor" })], excludedCount: 0 });
-    expect(body).toContain(FULL_FALLBACK_LABEL);
-    expect(body).not.toContain(HELPER_FULL_LABEL);
+    expect(body).not.toContain("CODEX HELPERS");
+    expect(body).not.toContain(FULL_FALLBACK_LABEL);
+    expect(body).toMatch(/^claude-opus-4-8\.+\$1\.50$/m);
+  });
+
+  it("an all-helper receipt still renders the group (header explains the whole set)", () => {
+    const body = renderPrBody({ contributors: [helper("h1", 1.74)], excludedCount: 0 });
+    expect(body).toContain(`CODEX HELPERS (1) — ${HELPER_FULL_LABEL}`);
+    expect(body).toContain("1 session behind this PR");
   });
 });
 
@@ -259,12 +279,15 @@ describe("SPEC-0026 R5 · collapsed full receipts", () => {
     expect(body).toContain(big);
   });
 
-  it("drops the whole section when even omission notes cannot fit", () => {
+  it("drops the whole section when even omission notes cannot fit — and the hint says command, not section", () => {
     const rollup = renderPrReceiptText({ contributors: [builder()], excludedCount: 0 });
     // 800 sessions × ~100-char labels → omission notes alone exceed the cap.
     const many = Array.from({ length: 800 }, (_, i) => detail(`session-${i}-${"L".repeat(90)}`, "small"));
     const body = renderPrBody({ contributors: [builder()], excludedCount: 0 }, { details: many });
     expect(body).not.toContain("<details>");
+    // The dropped section must not leave a dangling "section below" hint.
+    expect(body).toContain("details: npx aireceipts --session <id>");
+    expect(body).not.toContain("section below");
     expect(body).toContain(rollup);
   });
 });

--- a/test/pr/body.test.ts
+++ b/test/pr/body.test.ts
@@ -75,6 +75,14 @@ describe("renderPrBody header + rows (#39 fixes)", () => {
     expect(body).toMatch(/^claude-opus-4-8 80% · claude-haiku-4-5 20%\.*\$1\.50$/m);
   });
 
+  it("a real mix never rounds to 100%/0% (>99%/<1%, the cache line's rule)", () => {
+    const view = builder({ modelMix: [mix("claude-opus-4-8", 0.996), mix("claude-haiku-4-5", 0.004)] });
+    const body = renderPrBody({ contributors: [view], excludedCount: 0 });
+    expect(body).toContain(">99%");
+    expect(body).not.toContain("100%");
+    expect(body).not.toContain(" 0%");
+  });
+
   it("carries no session ids in the fence (round 2) and every line fits 50 columns", () => {
     const body = renderPrBody({
       contributors: [builder({ sessionId: "rollout-2026-07-02T18-06-36-019f2583-6862-71c3-9abf-0eb4244ae5b0" })],

--- a/test/pr/run.test.ts
+++ b/test/pr/run.test.ts
@@ -92,9 +92,10 @@ describe("R3 render-first ordering", () => {
     const code = await runPr({ post: true, session: "agent-child1" }, deps);
     expect(code).toBe(0);
     expect(out[0].startsWith(DOGFOOD_MARKER)).toBe(true);
-    // Explicit selection renders a single-contributor body; the child stem shows on the provenance line.
+    // Explicit selection renders a single-contributor body; round 2 moved the
+    // child stem + slice reason to the details section's stat line.
     expect(out[0]).toContain("1 session behind this PR");
-    expect(out[0]).toContain("session: agent-child1");
+    expect(out[0]).toContain("agent-child1");
     expect(out[0]).toContain("entire session (slice unavailable)");
     expect(ghCalls.some((c) => c.includes("issues/26/comments"))).toBe(true);
     expect(err.join("\n")).toContain("posted receipt (created) to PR #26");

--- a/test/pr/run.test.ts
+++ b/test/pr/run.test.ts
@@ -383,6 +383,35 @@ describe("SPEC-0027 --artifact (e2e through runPr)", () => {
     expect(err.join("\n")).toContain("Permission denied");
   });
 
+  it("details order mirrors the fence: author receipts before helper receipts", async () => {
+    // A codex helper (no writes, current worktree) that STARTED BEFORE the
+    // anchored author must still render after it in the details section.
+    const author = (await loadById("claude-code", ANCHORS))!;
+    const helper = {
+      id: CODEX_BRANCH,
+      source: "codex" as const,
+      filePath: CODEX_BRANCH,
+      cwd: "/home/dev/repo",
+      startedAt: (author.startedAt ?? 0) - 60_000,
+      endedAt: Date.parse("2026-06-28T10:02:10.000Z"),
+      totals: author.totals,
+    };
+    const byId = new Map<string, unknown>([[author.id, author]]);
+    const { deps, out } = await makeDeps({
+      listSessions: async () => [author, helper],
+      loadSession: async (summary) =>
+        summary.source === "codex" ? loadById("codex", CODEX_BRANCH) : ((byId.get(summary.id) ?? null) as never),
+    });
+    const code = await runPr({ post: false }, deps);
+    expect(code).toBe(0);
+    const body = out[0];
+    const authorLabel = body.indexOf("builder · claude-anchors");
+    const helperLabel = body.indexOf("codex · codex-branch-commit");
+    expect(authorLabel).toBeGreaterThan(-1);
+    expect(helperLabel).toBeGreaterThan(-1);
+    expect(authorLabel).toBeLessThan(helperLabel);
+  });
+
   it("without --artifact nothing publishes and the body is unchanged", async () => {
     const { run: runGit, gitCalls } = gitWithPlumbing();
     const { run: runGh } = ghWithPr(7);


### PR DESCRIPTION
## What this adds

The round-2 fence grammar you iterated to on the design page and approved ("this looks good") — repackaged onto a fresh branch because #63 merged while it was in flight.

## See it

Receipt comment below shows it live on this PR's own sessions. Design record + approved mockups: linked in `specs/SPEC-0026-pr-comment-polish.md` (round 2 section).

## What changed

- **Fence = story**: committing sessions are top-level rows (slice lines stay); helpers group under `CODEX HELPERS (N) — no commits`, one muted row each: `model · duration · cost`.
- **No ids in the fence**; the details stat line becomes the full provenance record (`role · id · slice/no-commits · turns · duration · in/out · % cached`, self-labeling) and the `--session` hint moves next to the ids. Fence hint points at the section and falls back to the command whenever no section follows — a hint never dangles (honesty edge found during implementation).
- **`100%` never renders**: suppressed for single-model mixes; real mixes render `>99%`/`<1%` instead of rounding to 100/0 (cache line's rule).
- **Subagent names sanitized**: fork-boilerplate titles fall back to `agent-<id>` (masthead rule reused).
- **Details/artifact order mirrors the fence** (authors first, helpers after) so the size cap sheds helpers before authors.

## What to review, in order

1. Fence split + grouping (`src/pr/body.ts` `prBlocks`/`helperGroupBlocks`) — basis is the only key; no author can land in the helper group.
2. Hint-never-dangles ordering in `renderPrBody` (section decided first, conservative budget).
3. Deliberate test flips (7 rewritten + 3 new regressions) — matched to the spec's round-2 design record; Codex S6 confirmed "specced flip, not weakened" for the R1 set.

## Evidence

Gates unmasked exit 0: tsc · eslint · vitest **911/911** · goldens 90 byte-identical (only `goldens/html/pr-artifact.html` regenerated) · spec-lint 27 · hygiene. Codex S6 review: 3 findings — 2 accepted (order mirror, share rounding), 1 rejected with spec clarification (cost column is the receipt's currency, not the row's 'one fact'). Dispositions in the spec.

## Notes

Cherry-picked from the briefly re-created `feat/m4-receipt-artifacts` (now deleted — it shadowed the merged #63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)