### PR TITLE
feat: SPEC-0029 launch README — receipt-parity enforced

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,49 @@
 # aireceipts 🧾
 
-**Your AI coding agent just worked for 33 minutes. Here's the receipt.**
+**Your AI coding agent just billed you. Here's the receipt.**
+
+[![CI](https://github.com/anandgupta42/aireceipts/actions/workflows/ci.yml/badge.svg)](https://github.com/anandgupta42/aireceipts/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="goldens/svg/claude-code-clean-multi-tool-2-models-dark.svg">
+  <img alt="a rendered aireceipts receipt for a real Claude Code session" src="goldens/svg/claude-code-clean-multi-tool-2-models-light.svg" width="520">
+</picture>
+
+That image is real renderer output, straight from this repo's golden tests — and so is
+this, the same session as text:
 
 ```
 - - - - - - - - - - - - - - - - - - - - - - - - -
-                    AIRECEIPTS
- Claude Code · Jul 02 2026 14:57:39 UTC · 33m 31s
-               claude-sonnet-5 100%
-         cache served 94% of input tokens
+                    AIRECEIPTS                    
+ “Add email format validation to the signup for…” 
+ Claude Code · Jun 18 2026 09:30:30 UTC · 10m 30s 
+    claude-opus-4-8 87% · claude-sonnet-5 13%     
+         cache served 85% of input tokens         
 
-(thinking/reply)................$5.36  (101 turns)
-Bash.............................$3.93  (76 calls)
-Read.............................$1.88  (35 calls)
-Write............................$0.66  (10 calls)
-Edit..............................$0.38  (6 calls)
-
-≈ re-priced eligible trivial spans...........$2.68
-  (101 tiny turns, priced at claude-haiku-4-5)
+Bash..............................$0.05  (3 calls)
+Edit..............................$0.05  (2 calls)
+(thinking/reply)..................$0.03  (2 turns)
+Write.............................$0.03  (2 calls)
+Read...............................$0.02  (1 call)
 --------------------------------------------------
-TOTAL.......................................$12.30
-same tokens on claude-haiku-4-5..............$6.15
+TOTAL........................................$0.18
+same tokens on claude-haiku-4-5..............$0.04
   (arithmetic, not a prediction)
+
+Per-turn cost split evenly across that turn's tool
+calls; unpriced models show tokens only, never
+guessed dollars. Full method: aireceipts
+--methodology
 - - - - - - - - - - - - - - - - - - - - - - - - -
-      aireceipts · local · buy me a samosa 🥟
+      aireceipts · local · buy me a samosa 🥟      
 - - - - - - - - - - - - - - - - - - - - - - - - -
 ```
 
-One command. No account, no API key, no upload — it reads the transcripts your
-agent already writes to disk and prices them against cited, dated price tables.
+aireceipts is a local, deterministic CLI: it reads the transcripts your coding agent
+already writes to disk and prints a cost receipt. No accounts, no servers, no uploads.
 
-**Site & docs: [anandgupta42.github.io/aireceipts](https://anandgupta42.github.io/aireceipts/)** · [user guide](https://anandgupta42.github.io/aireceipts/docs/)
+## Install
 
 ```sh
 npx aireceipts          # receipt for your newest session
@@ -38,28 +52,39 @@ npx aireceipts          # receipt for your newest session
 > **Status**: source-first pre-release. Until the npm package is published:
 > `git clone … && npm install && npm run build && node dist/cli.js`
 
-## What you get
+## Usage
 
 | Command | What it does |
 |---|---|
 | `aireceipts` | Receipt for the newest session (`--list` to pick another) |
-| `aireceipts compare <a> <b>` | Two sessions side by side — models, tools, waste, ratio |
+| `aireceipts pr --post` | Attach the receipt of the sessions behind a PR as a comment — [guide](docs/pr-receipts.md) |
+| `aireceipts pr --post --artifact` | Also publish a durable receipt page, linked from the comment — [how](docs/pr-receipts.md) |
+| `aireceipts compare <a> <b>` | Two sessions side by side — models, tools, waste, ratio — [guide](docs/guide/05-compare.md) |
+| `aireceipts week` | Trailing-7-day digest: totals, per-agent split, top waste — [guide](docs/guide/06-week.md) |
 | `aireceipts --svg -o r.svg` | The receipt as a shareable image, light/dark themes |
-| `aireceipts week` | Trailing-7-day digest: totals, per-agent split, top waste, honest deltas |
-| `aireceipts --handoff` | Paste-ready block that tells your *agent* what to do cheaper next time |
-| `aireceipts install-hook` | Consent-gated Claude Code hook: every session ends with a mini-receipt |
-| `aireceipts statusline` | Live cost line in Claude Code's status bar |
+| `aireceipts --handoff` | Paste-ready block that tells your *agent* what to do cheaper next time — [guide](docs/guide/09-handoff.md) |
+| `aireceipts install-hook` | Consent-gated Claude Code hook: every session ends with a mini-receipt — [guide](docs/guide/03-install-hook.md) |
+| `aireceipts statusline` | Live cost line in Claude Code's status bar — [setup](docs/statusline.md) |
 | `aireceipts --quota` | Your official rate-limit window state (subscribers) |
-| `aireceipts --check-budget` | Exit 1 when `~/.aireceipts/budget.json`'s cap is exceeded — advisory, composable |
-| `aireceipts --json` / `--csv` | Versioned schema / RFC 4180 rows for scripts and spreadsheets |
+| `aireceipts --check-budget` | Exit 1 when your local budget cap is exceeded — advisory, composable |
+| `aireceipts --json` / `--csv` | Versioned schema / RFC 4180 rows — [schema](docs/json-schema.md) |
 
-Waste detection is deliberately conservative: stuck tool loops, trivial spans that a
-cheaper model could run, each shown with its cost — precision-gated so a flagged line
-is worth reading (a false positive fails our CI).
+## What you get
+
+- **A per-tool cost anatomy** of every session: models, cache tiers, tool-by-tool spend.
+- **Waste lines, precision-gated**: stuck tool loops and trivial spans a cheaper model
+  could run — each priced, each conservative (a false positive fails our CI).
+- **PR receipts**: every pull request can carry the receipt of the agent sessions that
+  built it — totals across leads, builders, and helpers, floors when anything is
+  unattributed.
+- **An honest cheaper-model line**: "same tokens on X" is arithmetic on your real token
+  counts, never a claim that X would have done the job.
+- **Exports**: SVG/PNG images, JSON with a versioned schema, CSV.
 
 ## The honesty rules
 
-The receipt is only useful if you can trust every character on it:
+The receipt is only useful if you can trust every character on it. What a receipt
+proves — and what it can't: [docs/trust.md](docs/trust.md).
 
 - **No fabricated dollars, ever.** A model without a cited, dated price row renders
   tokens-only — never a guess.
@@ -68,7 +93,8 @@ The receipt is only useful if you can trust every character on it:
 - **Comparisons are arithmetic, not predictions.** "Same tokens on X" re-prices the
   identical token counts — it never claims another model would have done the job.
 - **Deterministic.** Same transcript in, byte-identical receipt out — golden-tested on
-  every commit, 10× under a frozen environment.
+  every commit, 10× under a frozen environment. The receipts on this page are pinned
+  to those goldens by CI: this README cannot show output the renderer didn't produce.
 
 Full methodology: `aireceipts --methodology`.
 
@@ -88,17 +114,24 @@ Never code, prompts, paths, titles, or dollar amounts. See exactly what a run wo
 send: `aireceipts --telemetry-show`. Kill it: `AIRECEIPTS_TELEMETRY=off` or
 `DO_NOT_TRACK=1`. Schema and rationale: [docs/telemetry.md](docs/telemetry.md).
 
-## How this repo works
+## Docs
+
+**[User guide](docs/guide/01-getting-started.md)** — get started, every command,
+pricing, troubleshooting. Hosted: [anandgupta42.github.io/aireceipts](https://anandgupta42.github.io/aireceipts/)
+· [docs site](https://anandgupta42.github.io/aireceipts/docs/)
+
+[What a receipt proves](docs/trust.md) · [PR receipts](docs/pr-receipts.md) ·
+[JSON schema](docs/json-schema.md) · [statusline](docs/statusline.md) ·
+[telemetry](docs/telemetry.md)
+
+## Contributing
 
 aireceipts is designed and largely built by AI agents under a spec-driven harness —
-adversarially validated specs, mutation-tested gates, byte-golden outputs, and PRs
-that carry the receipt of the agent session that built them. The design and the
-motivation: [docs/internal/harness.md](docs/internal/harness.md).
-
-**[User guide](docs/guide/01-getting-started.md)** — get started, every command, pricing, and troubleshooting.
-
-More docs: [the hosted guide](https://anandgupta42.github.io/aireceipts/docs/) · [JSON schema](docs/json-schema.md) · [what a receipt proves](docs/trust.md) · [statusline setup](docs/statusline.md)
+adversarially validated specs, mutation-tested money paths, byte-golden outputs, and
+PRs that carry the receipt of the session that built them
+([how and why](docs/internal/harness.md)). Human PRs are welcome and run the same
+gates: see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-Apache-2.0. If we ever meet in person, I owe you a samosa. 🥟
+Apache-2.0. If we ever meet in person, I owe you a samosa.

--- a/README.md
+++ b/README.md
@@ -134,4 +134,4 @@ gates: see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-Apache-2.0. If we ever meet in person, I owe you a samosa.
+Apache-2.0.

--- a/docs/internal/readme-evidence.md
+++ b/docs/internal/readme-evidence.md
@@ -1,0 +1,43 @@
+# Why the README is shaped the way it is (SPEC-0029 evidence note)
+
+The README's structure and the guard test's budget constants
+(`test/readme-guard.test.ts`) come from two evidence tiers, summarized here
+so the shape is explainable from inside the repo. Full research report:
+maintainer's vault, 2026-07-03.
+
+## Tier 1 — hand-measured corpus: 22 HN front-page launches, Apr–Jul 2026
+
+Method: HN Algolia API, `Show HN` ≥200 points with github.com URLs
+(34 found, top 22 by points fetched via GitHub API and measured
+structurally). Success-only sample, no control group; regex-level
+measurement; single 3-month window.
+
+| Metric | Corpus value | README consequence |
+|---|---|---|
+| Visual in first 30 lines | 86% | hero `<picture>` of golden SVGs, first screen |
+| Animated/terminal cast | 1 of 22 | static image, no GIF |
+| Quantified tagline | 14% | plain human register, no forced number |
+| Emoji per README | median 0.5; 73% ≤2 | `MAX_EMOJI = 2` (title 🧾 + receipt 🥟) |
+| Length / lists / links / code blocks | 240 / 20.5 / 9.5 / 10 (medians) | `MAX_LINES = 260`; density is review guidance, not a gate |
+| Badges present | 55%, median 1 | `MAX_BADGES = 3`, light row |
+| Install in first 60 lines | 64% | guard asserts ≤ line 60 |
+| Contributing at launch | 27% | short section, links CONTRIBUTING.md |
+
+## Tier 2 — peer-reviewed correlates (pre-2023 data, correlational)
+
+- JSS 2023 (n=5,000): list count and README **update frequency** are the
+  strongest popularity discriminators. The parity guard converts every
+  receipt-output change into a forced, visible README update — cadence by
+  construction.
+- arXiv 2206.10772 → SP&E 2025 (n≈2,000, 10 languages): links rank #1 in
+  feature importance in every language; images and inline code significant;
+  **install-instruction polish does not discriminate** (present in 189/200
+  regardless of popularity) — table stakes only.
+- arXiv 2603.27249 (Apr 2026, n=1,154 posts): emoji-heavy verbose text reads
+  as AI slop to developer reviewers — the cap is a trust decision, not taste.
+
+## The one rule that outlives launch day
+
+Every receipt shown in the README is byte-pinned to a committed golden.
+The marketing surface obeys the same invariant as the product (I5): if the
+renderer didn't produce it, the README can't show it.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aireceipts",
   "version": "0.1.0",
-  "description": "Local receipts for AI coding-agent transcripts.",
+  "description": "Your AI coding agent just billed you. Here's the receipt.",
   "license": "Apache-2.0",
   "type": "module",
   "private": false,

--- a/specs/SPEC-0029-readme-launch.md
+++ b/specs/SPEC-0029-readme-launch.md
@@ -1,0 +1,236 @@
+---
+id: SPEC-0029
+title: "Launch README — evidence-shaped first screen, receipt parity enforced"
+status: draft
+milestone: M4
+depends: []
+---
+
+# SPEC-0029 · launch README
+
+Invariants: I1/I5 (the README's receipts are renderer output, byte-pinned to
+goldens — the README can never show a receipt the product didn't produce),
+I3 (every number on the page traceable to a golden), I4 (telemetry disclosure
+stays prominent), I6 (no model/agent rankings anywhere on the page).
+
+## Purpose
+
+The repo goes public soon; the README is the launch surface. A deep-research
+pass plus a hand-measured corpus of 22 Apr–Jul 2026 HN front-page launch
+READMEs (Show HN ≥200 points, via the HN Algolia API; report in the
+maintainer's research vault, `aireceipts-readme-launch/`) established what
+actually distinguishes winners: a visual in the first 30 lines (86% — but
+static, only 1/22 animated), one crisp human tagline (plain register — only
+14% lead with a number), near-zero emoji (median 0.5), list- and code-heavy
+moderate length (~240 lines, ~20 list items, ~10 code blocks, ~10 links),
+light badges (median 1), install early (64% in the first 60 lines).
+Peer-reviewed studies (JSS 2023 n=5,000; SP&E 2025 n≈2,000) add: lists,
+links, images, and README update frequency discriminate popular repos;
+install-instruction polish does not (table stakes). The current README
+(104 lines) already leads with a tagline + real text receipt; this spec
+upgrades it to the full evidence shape and — the part that outlives launch
+day — **mechanically enforces that the README never drifts from the
+product**.
+
+**Kill criterion:** (a) if the inline or hero receipt cannot be kept
+byte-identical to a committed golden (the guard test fails on every
+receipt-output change until the README is regenerated), that is the feature
+working — but if in practice the guard makes routine receipt changes
+unshippable (more than one forced README regeneration per week of normal
+development), the pinning narrows to the hero only; (b) the structural
+budgets (R4) serve the prose, not the reverse — if the maintainer judges at
+review that a budget forces awkward writing, the budget loosens and the
+guard constant changes in the same PR, never the prose bending to the
+number.
+
+## Requirements
+
+- **R1 — First screen (title → tagline → badges → hero).** The tagline is
+  one bold sentence in plain human register, <120 characters — the README's
+  first bold paragraph (the guard anchors on the first `**…**` line, never a
+  line number) — and **byte-identical** in three places: that line,
+  `package.json` `description`, and the GitHub repo description (release-day
+  step, exact command: `gh repo edit --description "<tagline>"`; topics
+  `gh repo edit --add-topic ai-agent --add-topic claude-code --add-topic
+  codex --add-topic cli --add-topic developer-tools` ride the same
+  checklist — maintainer's button, never CI). The badge row sits
+  directly under the tagline: at most 3 badges (CI, npm version, license),
+  newline-delimited, no heading. The current tagline ("Your AI coding agent
+  just worked for 33 minutes. Here's the receipt.") is already in the
+  winning register and is kept as the default; the Design section is the
+  place to swap it, nowhere else. The tagline must be bold and under 120
+  characters (guard-tested).
+- **R2 — Hero: the real receipt as an image, then as bytes.** A
+  `<picture>` element with `prefers-color-scheme` sources pointing at the
+  **committed golden SVGs** (`goldens/svg/…-light.svg` / `…-dark.svg` — the
+  existing exporter's output, not hand-made art), followed by the smallest
+  real text receipt in a code block as the copy-paste "expected output."
+  The text receipt is the byte content of a committed `goldens/*.txt` file,
+  fence-wrapped. Both references are to files that already exist and are
+  already golden-gated; the README adds zero new artifacts to maintain.
+- **R3 — Structure (Standard-Readme order, corpus budgets).** Sections in
+  order: hero → Install (`npx aireceipts`, one block — table stakes, no
+  polish beyond correctness) → Usage (CLI table covering `aireceipts`,
+  `pr [--post] [--artifact] [--no-details]`, `week`, `compare`, `--svg/--png`,
+  `--json`, `install-hook`; each row links its doc — guard checks every named command appears with a link) → What you get (list
+  form) → The honesty rules (kept — it is the brand; links `docs/trust.md`
+  in the first line) → Supported agents → Telemetry, disclosed (kept,
+  I4) → Docs links block → Contributing (short: spec-driven flow, link
+  `CONTRIBUTING.md`) → License. Existing content is reshaped, not rewritten
+  from scratch; the honesty-rules and telemetry sections keep their current
+  substance.
+- **R4 — The README guard (new test, `test/readme-guard.test.ts`).**
+  Asserts mechanically: (a) tagline line equals `package.json` description
+  byte-for-byte; (b) every fenced receipt in README is byte-identical to a
+  committed golden file (parity — the README never lies about output);
+  (c) the `<picture>` sources resolve to files that exist in `goldens/svg/`;
+  (d) emoji count ≤ 2 (the 🥟 signature plus the title 🧾 only); (e) total
+  length ≤ 260 lines; (f) `docs/trust.md` and `docs/telemetry.md` linked
+  (the existing trust-doc test's README assertion stays where it is —
+  redundancy over coupling); (g) the tagline is bold and <120 chars.
+  List/link density (corpus: ~20 lists, ~10 links) is Design guidance
+  enforced at review, NOT a numeric gate — floors invite gaming and worse
+  prose. Budget constants carry a one-line citation to the committed
+  research note (below).
+- **R5 — The evidence ships with the repo.** A short research note
+  (`docs/internal/readme-evidence.md`, ~40 lines) commits the corpus table
+  (22 HN launches, aggregates, method, limitations) and the study citations
+  the guard constants reference — so the README's shape is explainable from
+  inside the repo, not from a private vault. The full report stays in the
+  maintainer's vault; the note links nothing external except the sources.
+
+## Design (lead-authored — implementers execute, never invent)
+
+First screen, exactly:
+
+```
+# aireceipts 🧾
+
+**Your AI coding agent just worked for 33 minutes. Here's the receipt.**
+
+[CI badge] [npm badge] [license badge]
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="goldens/svg/claude-code-clean-multi-tool-2-models-dark.svg">
+  <img alt="a rendered aireceipts receipt" src="goldens/svg/claude-code-clean-multi-tool-2-models-light.svg" width="520">
+</picture>
+
+<smallest real receipt from goldens/*.txt, fenced>
+
+Install:                       ← reached inside 60 lines
+    npx aireceipts
+```
+
+Copy rules: no emoji besides the title 🧾 and the footer 🥟 already inside
+the receipt bytes; no marketing adjectives ("blazing", "powerful") anywhere (review-enforced copy rule, not guard-testable);
+every claim about behavior links the doc that proves it (`docs/trust.md`
+carries the skeptic load); section prose stays terse — the corpus median is
+240 lines and this page targets ~180–260. The CLI table's `pr` row says
+"attach the receipt to your PR" and links `docs/pr-receipts.md`; the trust
+link line reads: "What a receipt proves — and what it can't:
+[docs/trust.md](docs/trust.md)."
+
+## Scenarios
+
+- **Given** any future change to receipt output that regenerates goldens,
+  **when** CI runs, **then** the README guard fails until the README's
+  fenced receipt is updated to the new golden bytes — the README cannot
+  silently show stale output.
+- **Given** a contributor edits the tagline in README only, **then** the
+  guard fails on the package.json mismatch until both (and, at release, the
+  GitHub description) move together.
+- **Given** the README gains a fourth badge or a third emoji, **then** the
+  guard fails.
+- **Given** a reader on a dark-mode GitHub page, **then** the hero renders
+  the dark-theme golden SVG.
+
+## Non-goals
+
+- **The launch post / Show HN copy** (separate artifact; the research's
+  tagline-variant testing belongs there).
+- **Animated terminal recordings.** 1/22 corpus winners used one; static
+  golden SVGs win and cost nothing. Revisit only on evidence.
+- **README-driven marketing sections** (comparisons, star history, "why not
+  X" tables) — I6 adjacent; facts and links only.
+- **Automating the GitHub description/topics sync** (R5 is a recorded
+  manual step — repo settings are the maintainer's button).
+- **Rewriting docs/** — this spec touches `README.md`, the guard test, and
+  `package.json` description only if the tagline changes (it does not, by
+  default).
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 tagline sync | README line 3 vs package.json description | byte-identical (guard) |
+| R1 badges | badge row | ≤3, under tagline, no heading |
+| R2 hero sources | `<picture>` srcset/src paths | both exist under goldens/svg/ |
+| R2 receipt parity | every fenced receipt in README | byte-equal to a committed goldens/*.txt |
+| R3 order | section headings | Standard-Readme order as specified |
+| R3 install early | Install heading | within first 60 lines |
+| R4 emoji budget | README bytes | ≤2 emoji |
+| R4 length cap | README bytes | ≤260 lines |
+| R1 tagline shape | first bold paragraph | bold, <120 chars |
+| R4 doc links | README | docs/trust.md + docs/telemetry.md present |
+| R4 guard red | mutate a fenced receipt byte in a test copy | guard fails |
+| R3 CLI table coverage | table rows | every named command present with a doc link |
+| R5 evidence note | docs/internal/readme-evidence.md | exists; corpus table + citations present |
+
+## Success criteria
+
+- [ ] README renders correctly on GitHub (checked on the PR's rich-diff
+      view) in light and dark mode, hero visible in the first screenful.
+- [ ] `test/readme-guard.test.ts` passes, and demonstrably fails when a
+      fenced receipt byte is mutated (red-then-green shown in the PR).
+- [ ] `/review-docs` run on the new README (advisory now, blocking at
+      release).
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all
+      pass unmasked (`echo $?`); goldens untouched (the README references
+      goldens, it never regenerates them).
+
+## Validation
+
+**2026-07-03 · S1 (self):** every requirement is mechanically checkable from
+repo bytes (guard test) except the copy rules, which are explicitly marked
+review-enforced. The one novel mechanism — README-to-golden receipt parity —
+is the spec's point: the launch page can never show output the renderer
+didn't produce (I5 extended to marketing surface). Verified before drafting:
+light AND dark golden SVGs of the named fixture exist
+(`claude-code-clean-multi-tool-2-models-{light,dark}.svg`).
+
+**2026-07-03 · S2 (Codex, read-only): REWORK → draft reworked.** Findings 1–2
+were lost to output truncation (capture window); their most likely subjects —
+dark-SVG existence and the brittle "README line 3" anchor — were both
+addressed regardless (fixture verified above; anchor is now the first bold
+paragraph, never a line number). Visible findings and disposition:
+3. `hook install` is not a shipped command (`install-hook` is) — **accepted**;
+   R3 corrected.
+4. Missing matrix rows (tagline shape, badge layout, CLI-table coverage) —
+   **accepted** for the testable ones (rows added); "no marketing
+   adjectives" and "smallest receipt" explicitly demoted to review-enforced
+   design/copy rules — a guard cannot judge prose.
+5. Research claims used with requirement force but living outside the repo —
+   **accepted**; new R5 commits `docs/internal/readme-evidence.md` (corpus
+   table + citations) so the shape is explainable from inside the repo.
+6. GitHub `<picture>`/relative-SVG rendering confirmed against GitHub Docs;
+   dark-mode selection is a manual rich-diff check — **accepted**; success
+   criterion already requires it.
+7. R5 (repo description/topics sync) called scope creep — **accepted**;
+   demoted from a requirement to a recorded release-day command inside R1,
+   maintainer's button, never CI.
+8. Cut the list/link floors as correlation cargo-culting — **accepted**;
+   density is design guidance at review, not a numeric gate. Caps (emoji,
+   length) and parity remain gates.
+
+**2026-07-03 · S3 (value gate):** the kill criterion's evidence exists in
+this session's own history: receipt output changed three times today
+(round 1, round 2, floors) — under this spec each change would have forced a
+visible README refresh, which is exactly the update-cadence behavior the
+popularity studies reward. If that cadence proves too costly (>1 forced
+regeneration/week), the criterion narrows pinning to the hero.
+
+**2026-07-03 · S4 (lint):** `node scripts/spec-lint.mjs` → 29 spec(s) OK,
+exit 0.
+
+Status remains draft pending maintainer approval (button 1).

--- a/specs/SPEC-0029-readme-launch.md
+++ b/specs/SPEC-0029-readme-launch.md
@@ -157,6 +157,16 @@ link line reads: "What a receipt proves — and what it can't:
   X" tables) — I6 adjacent; facts and links only.
 - **Automating the GitHub description/topics sync** (R5 is a recorded
   manual step — repo settings are the maintainer's button).
+- **Translations (maintainer decision, 2026-07-03).** No `README.<lang>.md`
+  at launch: every translation is an unguarded copy that rots silently —
+  an honesty bug for this product, not a cosmetic one — the fenced
+  receipts render in English regardless, and machine translation is a slop
+  signal to exactly this audience. **Future policy, recorded now for the
+  first community translation PR:** accepted under two rules — (a) the
+  translation carries a visible "translated from commit `<sha>`" stamp so
+  staleness is inspectable, never silent; (b) fenced receipts stay
+  byte-golden and untranslated (the guard's parity check extends to every
+  `README.*.md` when the first one lands). English is normative.
 - **Rewriting docs/** — this spec touches `README.md`, the guard test, the
   evidence note, and `package.json`'s description.
 - **npm README rendering.** The hero and relative links resolve on GitHub

--- a/specs/SPEC-0029-readme-launch.md
+++ b/specs/SPEC-0029-readme-launch.md
@@ -197,11 +197,11 @@ link line reads: "What a receipt proves — and what it can't:
 
 - [ ] README renders correctly on GitHub (checked on the PR's rich-diff
       view) in light and dark mode, hero visible in the first screenful.
-- [ ] `test/readme-guard.test.ts` passes, and demonstrably fails when a
+- [x] `test/readme-guard.test.ts` passes, and demonstrably fails when a
       fenced receipt byte is mutated (red-then-green shown in the PR).
 - [ ] `/review-docs` run on the new README (advisory now, blocking at
       release).
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all
       pass unmasked (`echo $?`); goldens untouched (the README references
       goldens, it never regenerates them).

--- a/specs/SPEC-0029-readme-launch.md
+++ b/specs/SPEC-0029-readme-launch.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0029
 title: "Launch README — evidence-shaped first screen, receipt parity enforced"
-status: draft
+status: building
 milestone: M4
 depends: []
 ---
@@ -55,9 +55,11 @@ number.
   codex --add-topic cli --add-topic developer-tools` ride the same
   checklist — maintainer's button, never CI). The badge row sits
   directly under the tagline: at most 3 badges (CI, npm version, license),
-  newline-delimited, no heading. The current tagline ("Your AI coding agent
-  just worked for 33 minutes. Here's the receipt.") is already in the
-  winning register and is kept as the default; the Design section is the
+  newline-delimited, no heading. The tagline is "Your AI coding
+  agent just billed you. Here's the receipt." — swapped at build time from
+  the 33-minute variant because the hero receipt's REAL duration (10m 30s)
+  must never sit next to a contradicting number (parity spirit; recorded
+  here per R1's own rule); the Design section is the
   place to swap it, nowhere else. The tagline must be bold and under 120
   characters (guard-tested).
 - **R2 — Hero: the real receipt as an image, then as bytes.** A
@@ -82,7 +84,8 @@ number.
 - **R4 — The README guard (new test, `test/readme-guard.test.ts`).**
   Asserts mechanically: (a) tagline line equals `package.json` description
   byte-for-byte; (b) every fenced receipt in README is byte-identical to a
-  committed golden file (parity — the README never lies about output);
+  committed golden file modulo the single trailing newline every golden
+  ends with (fence content carries none — the only permitted difference);
   (c) the `<picture>` sources resolve to files that exist in `goldens/svg/`;
   (d) emoji count ≤ 2 (the 🥟 signature plus the title 🧾 only); (e) total
   length ≤ 260 lines; (f) `docs/trust.md` and `docs/telemetry.md` linked
@@ -106,7 +109,7 @@ First screen, exactly:
 ```
 # aireceipts 🧾
 
-**Your AI coding agent just worked for 33 minutes. Here's the receipt.**
+**Your AI coding agent just billed you. Here's the receipt.**
 
 [CI badge] [npm badge] [license badge]
 
@@ -154,9 +157,13 @@ link line reads: "What a receipt proves — and what it can't:
   X" tables) — I6 adjacent; facts and links only.
 - **Automating the GitHub description/topics sync** (R5 is a recorded
   manual step — repo settings are the maintainer's button).
-- **Rewriting docs/** — this spec touches `README.md`, the guard test, and
-  `package.json` description only if the tagline changes (it does not, by
-  default).
+- **Rewriting docs/** — this spec touches `README.md`, the guard test, the
+  evidence note, and `package.json`'s description.
+- **npm README rendering.** The hero and relative links resolve on GitHub
+  (the launch surface); `files:` excludes `goldens/` and `docs/`, so the npm
+  page will render degraded until publish day. Recorded release-checklist
+  decision (maintainer): either add the two hero SVGs to `files:` or
+  absolutize the URLs at publish — not decided here.
 
 ## Test matrix
 
@@ -233,4 +240,16 @@ regeneration/week), the criterion narrows pinning to the hero.
 **2026-07-03 · S4 (lint):** `node scripts/spec-lint.mjs` → 29 spec(s) OK,
 exit 0.
 
-Status remains draft pending maintainer approval (button 1).
+**2026-07-03 · approved (button 1):** maintainer, in-session ("approved"). Status → building.
+
+**2026-07-03 · S5 (implementation review, Codex): REWORK → fixed.** Findings
+1–3 lost to capture truncation (twice now — process note: pipe reviews to a
+file). Visible findings: (4) CLI-table guard asserted a loose link count —
+accepted, now per-command linked-row checks; (5) trailing-newline
+normalization contradicted "byte-for-byte" — accepted, spec wording made
+precise (the single trailing golden newline is the only permitted
+difference); (6) the Design block still carried the old 33-minute tagline —
+accepted, fixed; (7) npm README will render degraded (files: excludes
+goldens/docs) — accepted as a recorded publish-day decision in Non-goals,
+not solved here. Red-then-green for receipt parity demonstrated live
+(mutated dollar → guard names the exact failure → restored green).

--- a/test/readme-guard.test.ts
+++ b/test/readme-guard.test.ts
@@ -1,0 +1,114 @@
+// SPEC-0029 R4 — the README guard: the launch page can never drift from the
+// product. Receipts shown in README must be byte-identical to committed
+// goldens (I5 extended to the marketing surface); the tagline is synced to
+// package.json; structural budgets are caps, not floors (budget constants
+// cite docs/internal/readme-evidence.md — the committed corpus note).
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const readme = readFileSync("README.md", "utf8");
+const lines = readme.split("\n");
+
+// Corpus-derived caps (see docs/internal/readme-evidence.md): winners median
+// 240 lines, emoji median 0.5 (73% have ≤2).
+const MAX_LINES = 260;
+const MAX_EMOJI = 2;
+const MAX_BADGES = 3;
+const TAGLINE_MAX = 120;
+
+/** The first bold paragraph is the tagline (never a line number — SPEC-0029 R1). */
+function tagline(): string {
+  const line = lines.find((l) => /^\*\*.+\*\*$/.test(l.trim()));
+  expect(line, "README must open with a bold tagline paragraph").toBeDefined();
+  return line!.trim().replace(/^\*\*|\*\*$/g, "");
+}
+
+/** Every fenced block that contains the receipt wordmark. */
+function fencedReceipts(): string[] {
+  const out: string[] = [];
+  const re = /```(?:\w*)\n([\s\S]*?)```/g;
+  for (let m = re.exec(readme); m !== null; m = re.exec(readme)) {
+    if (m[1].includes("AIRECEIPTS")) {
+      out.push(m[1].replace(/\n$/, ""));
+    }
+  }
+  return out;
+}
+
+describe("SPEC-0029 · README guard", () => {
+  it("R1: tagline is bold, <120 chars, and byte-identical to package.json description", () => {
+    const t = tagline();
+    expect(t.length).toBeLessThan(TAGLINE_MAX);
+    const pkg = JSON.parse(readFileSync("package.json", "utf8")) as { description: string };
+    expect(t).toBe(pkg.description);
+  });
+
+  it("R1: at most 3 badges, directly under the tagline, no heading", () => {
+    const tagIdx = lines.findIndex((l) => /^\*\*.+\*\*$/.test(l.trim()));
+    const badgeLines = lines.slice(tagIdx + 1, tagIdx + 6).filter((l) => l.includes("badge") || l.includes("shields.io"));
+    expect(badgeLines.length).toBeGreaterThan(0);
+    expect(badgeLines.length).toBeLessThanOrEqual(MAX_BADGES);
+    expect(lines[tagIdx + 1].trim() === "" || badgeLines.includes(lines[tagIdx + 1])).toBe(true);
+  });
+
+  it("R2: hero <picture> sources resolve to committed golden SVGs (light + dark)", () => {
+    const srcs = [...readme.matchAll(/(?:srcset|src)="(goldens\/svg\/[^"]+)"/g)].map((m) => m[1]);
+    expect(srcs.length).toBeGreaterThanOrEqual(2);
+    for (const s of srcs) {
+      expect(existsSync(s), `hero source missing on disk: ${s}`).toBe(true);
+    }
+    expect(srcs.some((s) => s.endsWith("-dark.svg"))).toBe(true);
+    expect(srcs.some((s) => s.endsWith("-light.svg"))).toBe(true);
+  });
+
+  it("R2/R4: every fenced receipt is byte-identical to a committed golden (the README never lies)", () => {
+    const goldens = readdirSync("goldens")
+      .filter((f) => f.endsWith(".txt"))
+      .map((f) => readFileSync(`goldens/${f}`, "utf8").replace(/\n$/, ""));
+    const shown = fencedReceipts();
+    expect(shown.length).toBeGreaterThanOrEqual(1);
+    for (const receipt of shown) {
+      expect(
+        goldens.some((g) => g === receipt),
+        "a fenced receipt in README does not byte-match any committed golden",
+      ).toBe(true);
+    }
+  });
+
+  it("R2 red path: a single mutated byte breaks parity (the guard actually guards)", () => {
+    const goldens = readdirSync("goldens")
+      .filter((f) => f.endsWith(".txt"))
+      .map((f) => readFileSync(`goldens/${f}`, "utf8").replace(/\n$/, ""));
+    const mutated = fencedReceipts()[0].replace("TOTAL", "T0TAL");
+    expect(goldens.some((g) => g === mutated)).toBe(false);
+  });
+
+  it("R4: emoji cap — the 🥟 inside the receipt bytes plus the title 🧾, nothing else", () => {
+    const emoji = readme.match(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/gu) ?? [];
+    expect(emoji.length).toBeLessThanOrEqual(MAX_EMOJI);
+  });
+
+  it("R4: length cap", () => {
+    expect(lines.length).toBeLessThanOrEqual(MAX_LINES);
+  });
+
+  it("R4: trust and telemetry docs are linked", () => {
+    expect(readme).toContain("docs/trust.md");
+    expect(readme).toContain("docs/telemetry.md");
+  });
+
+  it("R3: install appears within the first 60 lines; CLI table names every command with doc links", () => {
+    const installAt = lines.findIndex((l) => l.trim().toLowerCase().startsWith("## install"));
+    expect(installAt).toBeGreaterThan(-1);
+    expect(installAt).toBeLessThanOrEqual(60);
+    for (const cmd of ["--svg", "--quota", "--check-budget"]) {
+      expect(readme).toContain(cmd);
+    }
+    // Design-mandated linked rows: each command's table row must carry a doc link.
+    for (const cmd of ["aireceipts pr", "compare", "week", "--handoff", "install-hook", "statusline", "--json"]) {
+      const row = lines.find((l) => l.startsWith("|") && l.includes(cmd));
+      expect(row, `CLI table row missing for ${cmd}`).toBeDefined();
+      expect(row!.includes("]("), `CLI table row for ${cmd} must link its doc`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What this adds

The launch README, built to SPEC-0029 (approved): evidence-shaped per the 22-repo HN corpus, and — the piece that outlives launch day — **every receipt on the page is byte-pinned to a committed golden** by `test/readme-guard.test.ts`. The marketing surface now obeys I5: if the renderer didn't produce it, the README can't show it.

## See it

Open this PR's rich-diff of README.md — hero `<picture>` renders the light/dark golden SVGs in the first screenful, followed by the same session as copy-paste text (byte-equal to `goldens/claude-code-clean-multi-tool-2-models.txt`).

## What changed

- README.md: tagline **"Your AI coding agent just billed you. Here's the receipt."** (swapped from the 33-minute variant — it contradicted the hero receipt's real `10m 30s`; recorded in the spec), ≤3 badges, hero SVGs, install ≤ line 60, CLI table now includes `pr --post [--artifact]` with doc links, honesty rules lead with trust.md, 138 lines, exactly 2 emoji (title 🧾 + the receipt's own 🥟).
- `package.json` description synced byte-identical to the tagline (guard-enforced).
- `test/readme-guard.test.ts` (9 tests): parity (with a red-path test), tagline sync/shape, badge/emoji/length caps, hero-source existence, per-command linked table rows, doc links.
- `docs/internal/readme-evidence.md`: the corpus table + citations, so the shape is explainable in-repo.

## Red-then-green (spec success criterion)

Mutated one dollar in the fenced receipt (`$0.18` → `$9.99`) → guard failed with "a fenced receipt in README does not byte-match any committed golden" → restored → 9/9.

## What to review, in order

1. The README rich-diff itself — your launch page.
2. Guard parity logic (`test/readme-guard.test.ts`) — Codex S5 tightened the CLI-table check to per-command linked rows and forced precise trailing-newline wording.
3. The recorded publish-day decision: npm's README will render degraded until you either ship the two hero SVGs in `files:` or absolutize URLs (spec Non-goals).

## Evidence

Gates unmasked exit 0: tsc · eslint · vitest (incl. 9 guard tests) · goldens 90 byte-identical (README references them, never regenerates) · spec-lint 29 · hygiene. S1–S5 in the spec; /review-docs to run as the release gate re-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)