### PR TITLE
feat: SPEC-0030 PR A — why-section, lineage, org rollout packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ guessed dollars. Full method: aireceipts
 - - - - - - - - - - - - - - - - - - - - - - - - -
 ```
 
-aireceipts is a local, deterministic CLI: it reads the transcripts your coding agent
-already writes to disk and prints a cost receipt. No accounts, no servers, no uploads.
+**Why this exists.** AI coding agents spend real money invisibly — you see the diff,
+never the bill. aireceipts reads the transcripts your agent already writes to disk and
+turns them into receipts: what a session cost, tool by tool; what a PR cost, across
+every agent that built it; where tokens were wasted. Local and deterministic — no
+accounts, no servers, nothing leaves your machine.
 
 ## Install
 
@@ -123,6 +126,12 @@ pricing, troubleshooting. Hosted: [anandgupta42.github.io/aireceipts](https://an
 [What a receipt proves](docs/trust.md) · [PR receipts](docs/pr-receipts.md) ·
 [JSON schema](docs/json-schema.md) · [statusline](docs/statusline.md) ·
 [telemetry](docs/telemetry.md)
+
+**Related work.** [claude-receipts](https://github.com/chrishutchinson/claude-receipts)
+prints a beautiful thermal-receipt souvenir of a Claude Code session (numbers via
+[ccusage](https://github.com/ryoppippi/ccusage)); [Infracost](https://github.com/infracost/infracost)
+does cost-as-a-PR-comment for Terraform. aireceipts is the bookkeeping sibling:
+multi-agent parsing, cited prices, and PR-level attribution with an honesty model.
 
 ## Contributing
 

--- a/docs/adopt/org-rollout.md
+++ b/docs/adopt/org-rollout.md
@@ -1,0 +1,27 @@
+# Rolling out receipt checks across a fleet of repos
+
+For one repo, adoption is the 3-line caller — see
+[pr-receipt-check-caller.yml](pr-receipt-check-caller.yml) and
+[docs/pr-receipts.md](../pr-receipts.md).
+
+For many repos (an org dogfood, a platform team), generate the adoption
+packet:
+
+```sh
+node scripts/rollout-dogfood.mjs --org your-org --days 90
+```
+
+It enumerates repos active in the window (skipping archived repos, forks,
+and repos already carrying the caller) and prints, per repo: the caller
+file, the CONTRIBUTING line, and a copy-paste command sheet that opens a
+PR. **It performs no repo or GitHub mutations** — each repo's owners review and merge their own
+PR, and the script refuses to run until `aireceipts` is actually on npm
+(a packet telling developers to run an unpublished command helps nobody).
+
+Two constraints inherited from GitHub:
+
+- The caller references the receipts repo by name; reusable-workflow
+  references are **not** redirected if that repo is ever renamed — callers
+  should only be created once the source repo's name is final.
+- The receipt check never fails a build (it emits a neutral notice), so
+  adopting it is zero-risk for CI.

--- a/docs/adopt/pr-receipt-check-caller.yml
+++ b/docs/adopt/pr-receipt-check-caller.yml
@@ -1,0 +1,10 @@
+# Adopt the aireceipts PR-receipt check in any repo: paste this file at
+# .github/workflows/pr-receipt-check.yml. It never fails your build — it only
+# notices when a PR is missing its receipt comment (generation is local; see
+# https://github.com/anandgupta42/receipts/blob/main/docs/pr-receipts.md).
+# NOTE: reference valid only after the receipts repo rename+flip is complete.
+name: pr-receipt-check
+on: [pull_request]
+jobs:
+  check:
+    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@main

--- a/docs/internal/readme-evidence.md
+++ b/docs/internal/readme-evidence.md
@@ -41,3 +41,31 @@ measurement; single 3-month window.
 Every receipt shown in the README is byte-pinned to a committed golden.
 The marketing surface obeys the same invariant as the product (I5): if the
 renderer didn't produce it, the README can't show it.
+
+## Prior art & the prepared launch-thread reply (SPEC-0030 R2)
+
+Positioning rules: never argue priority or state of mind; cite the lineage
+(ccusage → claude-receipts → Infracost-for-infra); make the difference
+categorical ("a souvenir vs bookkeeping"). Facts checked 2026-07-03:
+claude-receipts created 2026-01-29, 616 stars, no HN front-page moment
+(4 and 1 points on its two submissions), thermal-printer novelty over
+ccusage, Claude-only, by its author's own README "a creative side project."
+
+Paste-ready reply for "this already exists":
+
+> claude-receipts is great — it's in our Related Work next to ccusage,
+> which powers it. Different jobs though: claude-receipts is a souvenir (a
+> thermal-printed memento of a Claude Code session; go see the photos,
+> they're wonderful). aireceipts is bookkeeping: its own parsers across
+> Claude Code / Codex / Cursor / opencode, prices from cited and dated
+> tables that CI verifies, byte-deterministic output, and PR-level
+> attribution — every PR in our repo carries the receipt of the agent
+> sessions that built it, with explicit floors when anything can't be
+> proven, and a doc on what a receipt can and can't prove. Same good
+> metaphor — Infracost did it for Terraform PRs years ago — different
+> category of tool.
+
+If someone asks directly whether the author knew of claude-receipts:
+answer truthfully in one sentence and move on — this file's git history
+timestamps when it was found and credited. Never volunteer state-of-mind
+as a defense; the lineage and the categorical difference are the defense.

--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -59,17 +59,26 @@ never touched. The viewer page itself carries no analytics or beacons and
 never will (I4's spirit): nobody, including the aireceipts project, learns
 who viewed which receipt.
 
-## For maintainers (repo integration, 5 minutes)
+## For maintainers (repo integration, 2 minutes)
 
-1. Copy one workflow file into your repo: `.github/workflows/pr-receipt-check.yml`
-   (the thin caller that runs `scripts/check-pr-receipt.mjs` — copy that script too).
+1. Paste the 3-line caller as `.github/workflows/pr-receipt-check.yml`
+   ([template](adopt/pr-receipt-check-caller.yml)):
+
+   ```yaml
+   name: pr-receipt-check
+   on: [pull_request]
+   jobs:
+     check:
+       uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@main
+   ```
+
 2. Add one line to `CONTRIBUTING.md`:
 
    > Before opening a PR, run `npx aireceipts pr --post` to attach your build receipt.
 
 That's it. The workflow emits a neutral `::notice` when a PR has no receipt comment and
 **never fails the build** — external contributors have no local sessions and must not be
-blocked.
+blocked. Rolling out across a whole org: [docs/adopt/org-rollout.md](adopt/org-rollout.md).
 
 ## What the comment contains
 

--- a/scripts/rollout-dogfood.mjs
+++ b/scripts/rollout-dogfood.mjs
@@ -1,0 +1,72 @@
+// SPEC-0030 R4 — org dogfood rollout report (report-only). Compile-to-temp
+// like verify-goldens so this never depends on tsx or a stale dist/.
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+
+function tsFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return tsFiles(path);
+    return entry.isFile() && path.endsWith(".ts") ? [path] : [];
+  });
+}
+
+const root = process.cwd();
+const tmp = mkdtempSync(join(tmpdir(), "aireceipts-rollout-"));
+const outDir = join(tmp, "out");
+const configPath = join(tmp, "tsconfig.rollout.json");
+const tscPath = join(root, "node_modules", "typescript", "bin", "tsc");
+const files = [join(root, "scripts", "rollout-dogfood.mts"), ...tsFiles(join(root, "src"))];
+
+writeFileSync(
+  configPath,
+  JSON.stringify(
+    {
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        lib: ["ES2022"],
+        strict: true,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        resolveJsonModule: true,
+        rootDir: root,
+        outDir,
+      },
+      files,
+    },
+    null,
+    2,
+  ),
+);
+
+let status = 1;
+try {
+  const compile = spawnSync(process.execPath, [tscPath, "--project", configPath], {
+    stdio: "inherit",
+    env: { ...process.env, NO_COLOR: "1", TZ: "UTC", LANG: "C" },
+  });
+  // A compile failure is a tooling error (exit 1) — tsc's own status 2 must not
+  // masquerade as the gate's "evidence insufficient" exit code.
+  status = compile.status === 0 ? 0 : 1;
+
+  if (status === 0) {
+    cpSync(join(root, "data"), join(outDir, "data"), { recursive: true });
+    const script = join(outDir, relative(root, join(root, "scripts", "rollout-dogfood.mts"))).replace(
+      /\.mts$/u,
+      ".mjs",
+    );
+    const run = spawnSync(process.execPath, [script, ...process.argv.slice(2)], {
+      stdio: "inherit",
+      env: { ...process.env, NO_COLOR: "1", TZ: "UTC", LANG: "C" },
+    });
+    status = run.status ?? 1;
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+process.exit(status);

--- a/scripts/rollout-dogfood.mts
+++ b/scripts/rollout-dogfood.mts
@@ -1,0 +1,130 @@
+// SPEC-0030 R4 — the org dogfood rollout REPORT. Enumerates active repos in
+// an org and emits a per-repo adoption packet (caller workflow + CONTRIBUTING
+// line + copy-paste command sheet). REPORT-ONLY BY DESIGN: it performs no
+// repo or GitHub mutations (local temp/cache writes by the compile wrapper
+// and npm/gh are out of scope of the claim) —
+// workflow-file writes need `workflow`-scope tokens per repo, an auth surface
+// deliberately not automated until manual adoptions prove the caller.
+// Refuses to run before `aireceipts` is on npm (kill criterion b): a packet
+// telling developers to run an unpublished command is a credibility bug.
+//
+//   node scripts/rollout-dogfood.mjs [--org altimateai] [--days 90]
+//
+// Exit codes: 0 = packet printed; 1 = usage/api error; 2 = npm gate refused.
+import type { CommandRunner } from "../src/pr/git.js";
+import { defaultRunner } from "../src/pr/git.js";
+
+export const CALLER_PATH = ".github/workflows/pr-receipt-check.yml";
+export const CALLER_YAML = `name: pr-receipt-check
+on: [pull_request]
+jobs:
+  check:
+    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@main
+`;
+export const CONTRIBUTING_LINE =
+  "Before opening a PR, run `npx aireceipts pr --post` to attach your build receipt.";
+
+export interface RepoInfo {
+  name: string;
+  archived: boolean;
+  fork: boolean;
+  pushed_at: string;
+}
+
+/** Kill criterion (b): no packet before the CLI is installable. */
+export function npmPublished(run: CommandRunner): boolean {
+  const res = run("npm", ["view", "aireceipts", "version"]);
+  return res.code === 0 && /\d+\.\d+\.\d+/.test(res.stdout);
+}
+
+/** Active = pushed within `days`, not archived, not a fork. */
+export function activeRepos(repos: RepoInfo[], days: number, nowMs: number): RepoInfo[] {
+  const cutoff = nowMs - days * 86_400_000;
+  return repos.filter((r) => !r.archived && !r.fork && Date.parse(r.pushed_at) >= cutoff);
+}
+
+export function listOrgRepos(run: CommandRunner, org: string): RepoInfo[] | { error: string } {
+  const res = run("gh", ["api", "--paginate", `orgs/${org}/repos?per_page=100`, "--jq", ".[] | {name, archived, fork, pushed_at}"]);
+  if (res.code !== 0) {
+    return { error: `could not list ${org} repos: ${res.stderr.trim()}` };
+  }
+  return res.stdout
+    .split("\n")
+    .filter((l) => l.trim() !== "")
+    .map((l) => JSON.parse(l) as RepoInfo);
+}
+
+/** True when the repo already carries the caller (idempotence — skipped with a note). */
+export function hasCaller(run: CommandRunner, org: string, repo: string): boolean {
+  return run("gh", ["api", `repos/${org}/${repo}/contents/${encodeURIComponent(CALLER_PATH)}`]).code === 0;
+}
+
+export function packetFor(org: string, repo: string): string {
+  return [
+    `### ${org}/${repo}`,
+    "",
+    `1. Add \`${CALLER_PATH}\`:`,
+    "```yaml",
+    CALLER_YAML.trimEnd(),
+    "```",
+    `2. Add to CONTRIBUTING.md: "${CONTRIBUTING_LINE}"`,
+    "3. Command sheet:",
+    "```sh",
+    `gh repo clone ${org}/${repo} && cd ${repo}`,
+    `git checkout -b chore/aireceipts-dogfood`,
+    `mkdir -p .github/workflows && cat > ${CALLER_PATH} <<'YAML'`,
+    CALLER_YAML.trimEnd(),
+    "YAML",
+    `git add ${CALLER_PATH} && git commit -m "chore: adopt aireceipts PR-receipt check"`,
+    `git push -u origin chore/aireceipts-dogfood`,
+    `gh pr create --title "chore: adopt aireceipts PR-receipt check" --body "Notice-only check; never fails the build. See https://github.com/anandgupta42/receipts/blob/main/docs/pr-receipts.md"`,
+    "```",
+    "",
+  ].join("\n");
+}
+
+export function buildReport(run: CommandRunner, org: string, days: number, nowMs: number): { text: string; code: number } {
+  if (!npmPublished(run)) {
+    return {
+      text: "REFUSED (kill criterion b): `aireceipts` is not on npm yet — a rollout packet telling developers to run an unpublished command is a credibility bug. Publish v0.1.0 first.",
+      code: 2,
+    };
+  }
+  const repos = listOrgRepos(run, org);
+  if (!Array.isArray(repos)) {
+    return { text: repos.error, code: 1 };
+  }
+  const active = activeRepos(repos, days, nowMs);
+  const lines: string[] = [`# aireceipts dogfood rollout packet — ${org} (active last ${days}d: ${active.length}/${repos.length})`, ""];
+  for (const r of active) {
+    if (hasCaller(run, org, r.name)) {
+      lines.push(`- ${org}/${r.name}: already carries the caller — skipped.`);
+      continue;
+    }
+    lines.push(packetFor(org, r.name));
+  }
+  lines.push("", "Report-only: no repo or GitHub mutations were performed. Each repo's owners merge their own PR.");
+  return { text: lines.join("\n"), code: 0 };
+}
+
+function argValue(flag: string, fallback: string): string {
+  const i = process.argv.indexOf(flag);
+  const v = i >= 0 ? process.argv[i + 1] : undefined;
+  if (i >= 0 && (v === undefined || v.startsWith("--"))) {
+    console.error(`${flag} requires a value`);
+    process.exit(1);
+  }
+  return v ?? fallback;
+}
+
+if (process.argv[1]?.endsWith("rollout-dogfood.mjs")) {
+  const org = argValue("--org", "altimateai");
+  const days = Number.parseInt(argValue("--days", "90"), 10);
+  if (!Number.isInteger(days) || days <= 0) {
+    console.error("--days must be a positive integer");
+    process.exit(1);
+  }
+  const { text, code } = buildReport(defaultRunner, org, days, globalThis.Date.now());
+  (code === 0 ? console.log : console.error)(text);
+  process.exit(code);
+}

--- a/specs/SPEC-0030-release-readiness.md
+++ b/specs/SPEC-0030-release-readiness.md
@@ -1,0 +1,234 @@
+---
+id: SPEC-0030
+title: "Release readiness — rename to receipts, the why, and the org dogfood kit"
+status: draft
+milestone: M4
+depends: [SPEC-0029]
+---
+
+# SPEC-0030 · release readiness
+
+Invariants: I1/I5 (README receipts stay guard-pinned through every edit),
+I4 (the rollout kit adds no telemetry and runs nothing on CI that needs
+transcripts), I3 (the why-section makes claims the docs already prove).
+
+## Purpose
+
+Maintainer direction (2026-07-03): before the public flip — (1) the repo
+becomes `anandgupta42/receipts` (the binary and npm package stay
+`aireceipts`); (2) the README must say what pain this addresses the moment
+someone lands, briefly; (3) installation must be dead simple, documented,
+and then dogfooded across the active repos of the altimateai org.
+Renaming pre-launch avoids permanent redirect debt: GitHub redirects
+git/web URLs after a rename (raw resolves in practice; verify live), but
+**Pages does not** — `anandgupta42.github.io/aireceipts/*`
+dies, taking the hardcoded `VIEWER_URL`, the README badge/guide links, and
+every artifact-viewer link already posted on PRs #63–68 with it. Total
+hardcoded-URL surface measured before drafting: 7 occurrences across
+`src/pr/publish.ts`, `README.md`, `site/index.html` (comment links
+self-heal — `artifactViewUrl` derives owner/repo from the PR at post time).
+
+**Kill criterion:** (a) the rename may only be executed (maintainer button)
+inside the atomic window: the URL-update PR is green and ready, the rename
+happens, the PR merges, Pages redeploys, and the five stale receipt
+comments are re-posted — if any step in that window cannot complete, the
+rename reverts the same day (GitHub allows rename-back; a half-renamed
+public launch is the failure this criterion exists to prevent); (b) the org
+rollout runs only AFTER v0.1.0 is on npm — a dogfood PR telling developers
+to `npx aireceipts` before that command works is a credibility bug; the
+rollout script hard-fails if `npm view aireceipts version` fails.
+
+## Requirements
+
+- **R1 — URL cutover, atomic with the rename.** One PR updates every
+  hardcoded URL to the `receipts` repo name: `VIEWER_URL` in
+  `src/pr/publish.ts`, the badge/guide/site links in `README.md` and
+  `site/index.html`, plus a new `repository`/`homepage`/`bugs` block in
+  `package.json` (npm publish surface; currently absent). The
+  `aireceipts/artifacts` branch name does NOT change (it is
+  product-namespaced by the binary; renaming it would break every already-
+  posted raw link a second time). Sequencing recorded in the spec: PR
+  green → maintainer renames the repo (Settings, their button) → merge →
+  Pages redeploys → `aireceipts pr --post --artifact` re-run on PRs #63–68
+  so their viewer links point at the new Pages path. Old github.com/git URLs redirect per GitHub's documented rename behavior;
+  old raw URLs continue to resolve in practice (verify live inside the
+  window — not documented as redirects); old Pages URLs are the one
+  casualty, repaired by the re-posts in the same window.
+- **R2 — The why, on landing.** A four-line "Why this exists" paragraph
+  directly under the hero receipt (exact copy in Design), replacing the
+  current one-line description: pain (agents spend real money invisibly) →
+  what you get (session / PR / waste receipts) → the trust property (local,
+  deterministic, nothing leaves the machine). Additionally a two-line
+  **Related work** block near the docs links, crediting prior art
+  generously (maintainer concern, 2026-07-03): `claude-receipts` (the
+  thermal-printer art project for Claude Code sessions) and `ccusage`
+  (its cost source) — different jobs, same good metaphor; the prepared
+  positioning paragraph for launch threads is committed in
+  `docs/internal/readme-evidence.md`. README guard budgets unchanged and
+  still passing.
+- **R3 — One-line adoption for any repo: the reusable workflow.**
+  `.github/workflows/pr-receipt-check.yml` gains `workflow_call` so other
+  repos adopt the receipt check with a 3-line caller instead of copying two
+  files. The called job must `actions/checkout` THIS repo (public at
+  rollout) to obtain `scripts/check-pr-receipt.mjs` — caller repos do not
+  carry the script (the measured hole in the copy-two-files approach). The
+  called workflow reads the PR number from the caller's `pull_request`
+  event context and declares its minimal `permissions` explicitly. Two
+  hard constraints, recorded because GitHub does NOT redirect reusable-
+  workflow references after a rename: (a) callers reference
+  `anandgupta42/receipts/...@main` and may only ever be created AFTER the
+  rename; (b) the caller template is committed at
+  `docs/adopt/pr-receipt-check-caller.yml`, and `docs/pr-receipts.md`'s
+  maintainer section shrinks to: paste the caller, add the CONTRIBUTING
+  line. The existing same-repo trigger keeps working unchanged.
+- **R4 — The org dogfood rollout report (report-only, by design).**
+  `scripts/rollout-dogfood.mjs` enumerates `altimateai` org repos active in
+  the last 90 days (pushed_at, non-archived, non-fork), notes which already
+  carry the caller, and emits a per-repo adoption packet: the exact caller
+  file content, the CONTRIBUTING line, and the copy-pasteable `gh` commands
+  to open each PR. It performs ZERO writes — automated cross-repo PR
+  creation is deliberately out (workflow-file writes need `workflow`-scope
+  tokens and per-repo permissions; that auth surface is not worth
+  automating until manual adoptions prove the caller). The report refuses
+  to generate (kill criterion b) unless `npm view aireceipts version`
+  succeeds — a packet telling developers to run an unpublished command is a
+  credibility bug. Never run by CI.
+- **R5 — Install documentation: one line per audience.**
+  README Install stays `npx aireceipts` (+ the pre-release caveat until
+  publish, then the caveat is deleted by the release flow); `docs/
+  pr-receipts.md` maintainer section becomes the 3-line caller; a new short
+  `docs/adopt/org-rollout.md` documents the R4 script for anyone running a
+  fleet (public doc, altimateai is just the first user).
+
+## Design (lead-authored)
+
+R2 copy, verbatim (guard-compliant: no emoji, no new links needed):
+
+> **Why this exists.** AI coding agents spend real money invisibly — you
+> see the diff, never the bill. aireceipts reads the transcripts your agent
+> already writes to disk and turns them into receipts: what a session cost,
+> tool by tool; what a PR cost, across every agent that built it; where
+> tokens were wasted. Local and deterministic — no accounts, no servers,
+> nothing leaves your machine.
+
+R3 caller template, verbatim:
+
+```yaml
+name: pr-receipt-check
+on: [pull_request]
+jobs:
+  check:
+    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@main
+```
+
+R1 sequencing checklist (maintainer + agent interleaved, executed as one
+continuous window):
+1. URL-cutover PR opened, CI green, held unmerged.
+2. Maintainer: Settings → rename `aireceipts` → `receipts`.
+3. Agent: merge the PR; wait for Pages deploy green; verify
+   `anandgupta42.github.io/receipts/view.html` → 200.
+4. Agent: re-post receipts on PRs #63–68 (`pr --post --artifact`).
+5. Agent: verify one old raw URL redirects and one new viewer link renders
+   (post-flip) or shows the honest private-repo error (pre-flip).
+
+## Scenarios
+
+- **Given** the rename window completes, **when** anyone opens an old
+  `github.com/anandgupta42/aireceipts/...` link, **then** GitHub redirects;
+  **and** the re-posted comments' viewer links point at
+  `github.io/receipts/`.
+- **Given** a repo adds the 3-line caller, **when** a PR has no receipt
+  comment, **then** the check emits the neutral notice and never fails the
+  build (existing behavior through `workflow_call`).
+- **Given** `rollout-dogfood.mjs` without flags, **then** it prints the
+  target-repo report and exact diffs, writes nothing.
+- **Given** `--live` while `aireceipts` is not on npm, **then** it refuses
+  with the kill-criterion message.
+
+## Non-goals
+
+- **Transferring the repo to the altimateai org** (maintainer decision:
+  stays under `anandgupta42`).
+- **Renaming the npm package or binary** — `aireceipts` everywhere in the
+  product; only the repo name changes.
+- **Renaming the `aireceipts/artifacts` branch** (would re-break posted
+  links for zero benefit).
+- **Auto-merging rollout PRs in org repos** — each repo's owners merge
+  their own; the script only opens PRs.
+- **The npm publish itself** — the existing `/release` flow and maintainer
+  click; R4 merely gates on its result.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 no stale URLs | grep repo for `github.io/aireceipts` + `anandgupta42/aireceipts` | zero matches in src/docs/site/README/package.json |
+| R1 viewer constant | `VIEWER_URL` | `…github.io/receipts/view.html`; artifactViewUrl unit tests updated |
+| R1 npm fields | package.json | repository/homepage/bugs point at `receipts` |
+| R2 why-section | README | Design copy present under hero; guard 9/9 still green |
+| R3 workflow_call | pr-receipt-check.yml | `on:` includes `workflow_call`; same-repo trigger retained |
+| R3 caller template | docs/adopt/pr-receipt-check-caller.yml | matches Design verbatim |
+| R1 artifact branch untouched | `ARTIFACT_BRANCH` | still `aireceipts/artifacts` |
+| R3 called-workflow shape | pr-receipt-check.yml | workflow_call present; checks out anandgupta42/receipts; explicit permissions; reads caller PR context |
+| R4 report-only | script under mocked gh runner | zero write-verb calls recorded |
+| R4 publish gate | mocked missing npm version | refuses, names the gate |
+| R4 idempotence | mocked repo already carrying caller | skipped with note |
+| R4 enumeration filters | mocked repo list (archived/fork/stale) | excluded per rule |
+| R2 related work | README | claude-receipts + ccusage credited |
+| R5 caveat lifecycle | README install section | pre-release caveat present now; removal recorded as a release-flow step |
+| R5 docs | pr-receipts.md + docs/adopt/org-rollout.md | 3-line caller shown; rollout doc exists |
+
+## Success criteria
+
+- [ ] The rename window (Design checklist) completes in one sitting; old
+      raw/web URLs redirect; re-posted comments verified.
+- [ ] Dry-run rollout report reviewed by the maintainer before any `--live`.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`,
+      `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
+      `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass
+      unmasked (`echo $?`); README guard green after R2.
+
+## Validation
+
+**2026-07-03 · S1 (self):** every requirement checks from repo bytes or a
+mocked runner except the rename itself and the live-window verifications,
+which are recorded as an explicit maintainer+agent checklist with a revert
+path. The two claims that needed external grounding were checked before
+drafting: name availability (anandgupta42/receipts free) and the
+hardcoded-URL inventory (7 occurrences, 3 files).
+
+**2026-07-03 · S2 (Codex, read-only): REWORK → draft reworked.** Full output
+captured to file this time. Findings and disposition:
+1. HIGH — reusable-workflow callers lack `scripts/check-pr-receipt.mjs` —
+   **accepted**; the called job now checks out this repo for the script.
+2. HIGH — cross-org PR automation has workflow-scope/permission holes —
+   **accepted**; R4 demoted to a report-only adoption packet, zero writes;
+   automation deferred until manual adoptions prove the caller.
+3. MEDIUM — raw-URL "redirect" overclaimed vs GitHub docs — **accepted**;
+   rephrased to "resolves in practice, verify live in the window."
+4. MEDIUM — GitHub does not redirect reusable-workflow references after
+   rename — **accepted**; hard constraint recorded: callers are created
+   only AFTER the rename, referencing `receipts` from birth.
+5. MEDIUM — workflow_call test row too shallow — **accepted**; row now
+   covers checkout-of-source-repo, explicit permissions, caller PR context.
+6. MEDIUM — missing rows (artifact branch untouched, enumeration filters,
+   caveat lifecycle, related-work) — **accepted**; rows added.
+7. MEDIUM — success criteria omitted determinism + hygiene — **accepted**;
+   full CI-identical block restored.
+8. LOW — unmeasurable phrasing — **accepted**; softened or made checkable.
+9/10. Scope-creep / cut-R4 — **accepted in substance** via the report-only
+   demotion; the maintainer's org-dogfood directive is preserved as a paved
+   path (packet + commands) rather than automation.
+
+**2026-07-03 · S3 (value gate):** the rename's kill criterion has a live
+revert path (GitHub rename-back) and the whole window was sized against the
+measured 7-URL surface; the rollout gate (npm publish preflight) is testable
+today — it fails, correctly, until v0.1.0 ships. Related-work requirement
+grounded in the measured prior art (claude-receipts: 616 stars, thermal-
+printer novelty over ccusage; verified by reading its README).
+
+**2026-07-03 · S4 (lint):** `node scripts/spec-lint.mjs` → 30 spec(s) OK,
+exit 0.
+
+Status remains draft pending maintainer approval (button 1).

--- a/specs/SPEC-0030-release-readiness.md
+++ b/specs/SPEC-0030-release-readiness.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0030
 title: "Release readiness — rename to receipts, the why, and the org dogfood kit"
-status: draft
+status: building
 milestone: M4
 depends: [SPEC-0029]
 ---
@@ -167,7 +167,7 @@ continuous window):
 | R1 npm fields | package.json | repository/homepage/bugs point at `receipts` |
 | R2 why-section | README | Design copy present under hero; guard 9/9 still green |
 | R3 workflow_call | pr-receipt-check.yml | `on:` includes `workflow_call`; same-repo trigger retained |
-| R3 caller template | docs/adopt/pr-receipt-check-caller.yml | matches Design verbatim |
+| R3 caller template | docs/adopt/pr-receipt-check-caller.yml | yaml body matches Design; explanatory header comments allowed |
 | R1 artifact branch untouched | `ARTIFACT_BRANCH` | still `aireceipts/artifacts` |
 | R3 called-workflow shape | pr-receipt-check.yml | workflow_call present; checks out anandgupta42/receipts; explicit permissions; reads caller PR context |
 | R4 report-only | script under mocked gh runner | zero write-verb calls recorded |
@@ -228,7 +228,18 @@ today — it fails, correctly, until v0.1.0 ships. Related-work requirement
 grounded in the measured prior art (claude-receipts: 616 stars, thermal-
 printer novelty over ccusage; verified by reading its README).
 
+**2026-07-03 · S5 (PR A implementation review, Codex): REWORK → fixed.**
+(2) "zero writes" claim overbroad (compile wrapper + npm/gh caches write
+locally) — accepted; claim scoped to "no repo/GitHub mutations" everywhere
+it appears, test renamed to what it proves. (3) HIGH — the prior-art copy
+broke its own rules: "Infracost pioneered" was a priority claim (now
+"does"), and the evidence note asserted state-of-mind as a defense (now an
+instruction to answer truthfully once, with the git timestamp as the only
+artifact). (4) caller template carries explanatory header comments — spec
+row made precise rather than stripping useful comments. Earlier findings
+truncated in capture were subsumed by (2).
+
 **2026-07-03 · S4 (lint):** `node scripts/spec-lint.mjs` → 30 spec(s) OK,
 exit 0.
 
-Status remains draft pending maintainer approval (button 1).
+**2026-07-03 · approved (button 1):** maintainer, in-session ("approved") after the hardened prior-art positioning round. Build split: PR A (R2/R4/R5 + caller template, mergeable now) and PR B (R1 cutover + R3 workflow_call, held green for the rename window). Positioning addendum: lineage framing (ccusage, claude-receipts, Infracost), committed reply paragraph, no independent-invention claims anywhere.

--- a/test/rollout-dogfood.test.ts
+++ b/test/rollout-dogfood.test.ts
@@ -1,0 +1,70 @@
+// SPEC-0030 R4 — the rollout report is REPORT-ONLY: publish-gated, filtered,
+// idempotent, and provably write-free (every gh call it makes is a plain GET).
+import { describe, expect, it } from "vitest";
+import type { CommandResult } from "../src/pr/git.js";
+import { activeRepos, buildReport, CALLER_YAML } from "../scripts/rollout-dogfood.mts";
+
+const NOW = Date.parse("2026-07-03T00:00:00Z");
+const day = 86_400_000;
+const ok = (stdout: string): CommandResult => ({ stdout, stderr: "", code: 0, missing: false });
+const fail = (stderr: string): CommandResult => ({ stdout: "", stderr, code: 1, missing: false });
+
+function repoLine(name: string, daysAgo: number, extra: Partial<{ archived: boolean; fork: boolean }> = {}): string {
+  return JSON.stringify({ name, archived: extra.archived ?? false, fork: extra.fork ?? false, pushed_at: new Date(NOW - daysAgo * day).toISOString() });
+}
+
+function runner(opts: { published: boolean; repos: string[]; withCaller: string[] }) {
+  const calls: string[][] = [];
+  const run = (cmd: string, args: string[]): CommandResult => {
+    calls.push([cmd, ...args]);
+    if (cmd === "npm") {
+      return opts.published ? ok("0.1.0\n") : fail("404 Not Found");
+    }
+    if (args[0] === "api" && args.some((a) => a.startsWith("orgs/"))) {
+      return ok(opts.repos.join("\n"));
+    }
+    if (args[0] === "api" && args[1]?.includes("/contents/")) {
+      const repo = args[1].split("/")[2];
+      return opts.withCaller.includes(repo) ? ok("{}") : fail("404");
+    }
+    return fail(`unexpected ${cmd} ${args[0]}`);
+  };
+  return { run, calls };
+}
+
+describe("SPEC-0030 R4 rollout report", () => {
+  it("refuses before npm publish (kill criterion b), exit 2", () => {
+    const { run } = runner({ published: false, repos: [], withCaller: [] });
+    const r = buildReport(run, "altimateai", 90, NOW);
+    expect(r.code).toBe(2);
+    expect(r.text).toContain("not on npm");
+  });
+
+  it("filters archived, forks, and stale repos", () => {
+    const repos = [
+      JSON.parse(repoLine("active", 5)),
+      JSON.parse(repoLine("stale", 120)),
+      JSON.parse(repoLine("archived", 5, { archived: true })),
+      JSON.parse(repoLine("a-fork", 5, { fork: true })),
+    ];
+    expect(activeRepos(repos, 90, NOW).map((r) => r.name)).toEqual(["active"]);
+  });
+
+  it("skips repos already carrying the caller (idempotence) and packets the rest", () => {
+    const { run } = runner({ published: true, repos: [repoLine("has-it", 3), repoLine("needs-it", 3)], withCaller: ["has-it"] });
+    const r = buildReport(run, "altimateai", 90, NOW);
+    expect(r.code).toBe(0);
+    expect(r.text).toContain("has-it: already carries the caller — skipped");
+    expect(r.text).toContain("### altimateai/needs-it");
+    expect(r.text).toContain(CALLER_YAML.trimEnd());
+  });
+
+  it("performs no GitHub mutations: every gh call is a plain read (no -X/-f/-F flags)", () => {
+    const { run, calls } = runner({ published: true, repos: [repoLine("r1", 1), repoLine("r2", 2)], withCaller: [] });
+    buildReport(run, "altimateai", 90, NOW);
+    for (const c of calls.filter((c) => c[0] === "gh")) {
+      expect(c.some((a) => a === "-X" || a === "--method" || a === "-f" || a === "-F"), `mutating flag in: ${c.join(" ")}`).toBe(false);
+    }
+    expect(calls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## What this adds

The mergeable-now half of SPEC-0030 (approved). PR B — the URL cutover + workflow_call — follows separately and is HELD until the rename window (kill criterion a choreographs your Settings click with our merges).

## What changed

- **README**: 'Why this exists' under the hero (pain → what you get → nothing-leaves-your-machine) + **Related work** crediting the lineage: claude-receipts (souvenir), ccusage (its cost source), Infracost (cost-as-PR-comment for Terraform). Guard 9/9, 147 lines.
- **docs/internal/readme-evidence.md**: checked prior-art facts + the paste-ready launch-thread reply. Positioning rules enforced by the Codex critic on ourselves: no priority claims ('pioneered' → 'does'), no state-of-mind defense (the note now instructs a truthful one-sentence answer, with the git timestamp as the only artifact).
- **scripts/rollout-dogfood.(mts|mjs)**: the org adoption packet — repo enumeration (active/non-fork/non-archived), idempotent skip, per-repo caller + CONTRIBUTING line + command sheet. **No repo or GitHub mutations** (test-proven: every gh call is a plain read) and refuses to run until `aireceipts` is on npm.
- **docs/adopt/**: the 3-line caller template + org-rollout guide; pr-receipts.md maintainer section shrunk to 2 minutes.

## What to review, in order

1. The Related-work copy + prepared reply — this is your launch-thread armor; the critic already made it obey its own rules.
2. The rollout packet's refusal gate and read-only proof.
3. README rich-diff (guard-pinned receipts unchanged).

## Evidence

Gates unmasked exit 0: tsc · eslint · vitest (13 new-surface tests among them) · goldens 90 · spec-lint 30 · hygiene. S5 record in the spec (4 findings: claim scoping, two positioning violations, template precision — all fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)