### PR TITLE
docs: SPEC-0034 the samosa (spec, draft)

### DIFF
--- a/specs/SPEC-0034-samosa.md
+++ b/specs/SPEC-0034-samosa.md
@@ -1,0 +1,174 @@
+---
+id: SPEC-0034
+title: "The samosa — a clickable link, an honest glyph, a small delightful page"
+status: draft
+milestone: M4
+depends: [SPEC-0027, SPEC-0029]
+---
+
+# SPEC-0034 · the samosa
+
+Invariants: I1/I5 (all receipt surfaces are golden-gated; the footer change
+churns every golden deliberately, once), I3/I6 (a product about honest
+labels must not ship a mislabeled glyph), I4 (the samosa page is
+self-contained, zero trackers, zero third-party requests).
+
+## Purpose
+
+Two maintainer directives (2026-07-03). **(a)** The footer signature exists
+to celebrate the samosa — the maintainer's favorite snack — and should be a
+**clickable** invitation on surfaces that support clicks (it never can be on
+the terminal receipt). **(b)** The current glyph is wrong: `🥟` (U+1F95F) is
+named DUMPLING in Unicode, and Unicode has **no** samosa emoji (verified:
+searching U+1F300–U+1FAFF for SAMOSA/PASTRY returns nothing; the nearest are
+DUMPLING and PIE). For a tool whose entire premise is that every character
+on a receipt is true, shipping a dumpling labeled "samosa" is the one
+mislabel we cannot keep. This spec fixes the glyph, adds a real drawn samosa
+for graphical surfaces, and gives the link a small home.
+
+**Kill criterion:** (a) the swap must be **width-neutral** — `🔺` occupies
+the same cell count as the outgoing `🥟` on every terminal template, so no
+footer's alignment shifts; a glyph that changes cell width, or a plain-text
+footer that unbalances the centered masthead, reverts to text-only; (b) the
+golden churn is one-shot — if the same footer needs a second churn within
+the release window, the footer text/glyph freezes until after launch (churn
+fatigue erodes the golden gate's signal).
+
+## Requirements
+
+- **R1 — Terminal footer: an honest shape, not a wrong food.** Replace
+  `🥟` with `🔺` (U+1F53A, RED TRIANGLE — a samosa is triangular; a shape
+  evokes without asserting the falsehood a dumpling does) at **every**
+  hardcoded site (the critic found three): the `FOOTER_EMOJI` constant
+  (`src/receipt/present.ts:36`, `src/pr/body.ts:56`, feeding classic +
+  datavis + the PR body) AND the standalone footer in
+  `src/receipt/week.ts:112`. `grocery` has no glyph footer
+  (`present.ts:302`) — untouched. It is a **width-neutral swap**: `🔺` and
+  the outgoing `🥟` are both East-Asian-Wide (2 cells), so the footer's
+  cell count is unchanged — this spec does not claim the footer is 50
+  display columns (it never was: `center()` counts code points, so the
+  emoji footer is 50 code points / 51 display cells — a PRE-EXISTING
+  condition, not introduced here). `FOOTER_TEXT` unchanged. Deliberate
+  one-commit golden churn (I5). *(Design records `buy me a samosa`
+  text-only as the fallback if the maintainer rejects a glyph.)*
+- **R2 — A real samosa for graphical surfaces.** A committed inline SVG
+  glyph `src/receipt/samosa-glyph.ts` (a small hand-authored triangular
+  samosa path, brand-neutral, no external refs) rendered in the SVG
+  exporter footer (`src/receipt/svg.ts`), the artifact page footer
+  (`src/pr/html.ts`), the site footer, and the samosa page. Graphical
+  surfaces can draw what Unicode won't; the terminal can't, hence R1's
+  shape. Golden-gated wherever it lands in an SVG golden.
+- **R3 — The clickable link, on clickable surfaces only.** A markdown/HTML
+  link to the samosa page on: the README license/footer area
+  (`docs/adopt`-adjacent — respects the guard's emoji + length caps), the
+  artifact page footer, the viewer chrome footer (`site/view.html`, OUTSIDE
+  the sandboxed iframe), the site footer, and the PR-comment **details
+  section footer** (`src/pr/body.ts` details assembly — a markdown link,
+  the one place in the comment that renders links; the fenced receipt stays
+  link-free by nature). Never on the terminal receipt. The link text is
+  `buy me a samosa`; the destination is R4.
+- **R4 — The samosa page (`site/samosa.html`).** Small, self-contained
+  (inline CSS, the R2 SVG, zero scripts, zero third-party requests, no
+  analytics — same contract as `view.html`), matching the site aesthetic.
+  It celebrates the samosa and tells the true story ("Unicode has no samosa
+  emoji, so we drew one") — the honest-labels ethos as a delight, not a
+  donation ask. **No payment mechanism** ships by default; the page carries
+  a clearly-marked, commented-out placeholder block the maintainer can fill
+  with a real link later — a decision recorded, not made here.
+- **R5 — The README guard survives the churn.** The fenced golden receipt
+  in README changes bytes (footer glyph); `test/readme-guard.test.ts` must
+  stay green — re-verify: the emoji cap counts title `🧾` + the receipt's
+  footer glyph = 2 (`🔺` is in the guard's `\u{1F300}-\u{1FAFF}` range, so
+  the count is unchanged at 2). The README's hero receipt and text receipt
+  are regenerated from the new goldens in the same PR (the guard forces
+  this — SPEC-0029's whole point).
+
+## Scenarios
+
+- **Given** any terminal receipt after R1, **then** the footer reads
+  `aireceipts · local · buy me a samosa 🔺`, centered, ≤ 50 cols.
+- **Given** the SVG export, **then** the footer shows the drawn samosa
+  glyph, not an emoji.
+- **Given** a posted PR comment, **then** the details section ends with a
+  `buy me a samosa` markdown link; the fenced receipt has none.
+- **Given** the samosa page, **then** it loads with zero network requests
+  and no payment ask.
+- **Given** the README after regeneration, **then** the guard is green and
+  the emoji count is exactly 2.
+
+## Non-goals
+
+- **A payment/donation integration** — the motivation is samosa awareness,
+  not fundraising; only a commented placeholder ships.
+- **Per-surface glyph variation beyond R1/R2** — one terminal shape, one
+  drawn SVG, nothing bespoke.
+- **Animating or theming the samosa page** — small and static.
+- **Changing `FOOTER_TEXT`** — only the glyph and the new links.
+- **A terminal-clickable footer** — OSC 8 hyperlinks are unsupported by too
+  many terminals and would break byte-determinism; the link lives on
+  graphical/markdown surfaces (R3).
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 glyph swap | any terminal receipt | footer ends `buy me a samosa 🔺` |
+| R1 width | every template footer | ≤ 50 cols, centered (kill criterion a) |
+| R1 all surfaces | grep shipped receipts incl. week | no `🥟`; `🔺` in classic/datavis/PR/week footers; grocery untouched |
+| R1 width-neutral | footer cell widths | `🔺` cell count == outgoing `🥟` on every template |
+| R1 golden churn | `verify-goldens` after regen | `*.txt` + `mini/*.txt` + `svg/*.svg` + `html/pr-artifact.html` updated in one commit; determinism ×10 stable |
+| R2 svg glyph | SVG export | drawn samosa present; no `🥟`/`🔺` in SVG footer |
+| R3 comment link | posted body | details footer has `buy me a samosa` markdown link; fence has none |
+| R3 no terminal link | terminal receipt | no link/URL bytes |
+| R4 page self-contained | site/samosa.html | zero `http(s)://` fetches, zero `<script>`, no analytics |
+| R4 no payment | samosa page | payment affordance present only inside an HTML comment |
+| R3 README link | README | `buy me a samosa` link present; guard still green |
+| R3 viewer chrome | site/view.html | link in chrome OUTSIDE the sandboxed iframe |
+| R3 site footer | site/index.html | samosa link + drawn glyph |
+| R5 guard green | README after regen | guard 9/9; emoji count == 2 |
+| R5 no dumpling anywhere | repo grep | `🥟` absent from shipped surfaces (glyph replaced everywhere) |
+
+## Success criteria
+
+- [ ] `🥟` appears nowhere on a shipped surface; `🔺` (terminal) and the
+      drawn SVG (graphical) replace it; the samosa page loads offline.
+- [ ] Golden churn is a single reviewed commit with the regeneration
+      explained; determinism ×10 stable.
+- [ ] README guard green after regeneration (emoji count 2).
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`,
+      `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
+      `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass
+      unmasked (`echo $?`).
+
+## Validation
+
+**2026-07-03 · S1 (self):** the emoji facts are verified against Unicode,
+not asserted (U+1F95F = DUMPLING; no SAMOSA codepoint; U+1F53A =
+RED TRIANGLE, East-Asian-Wide). The brand argument is load-bearing: a
+receipt tool cannot ship a mislabeled glyph. Payment stays out by decision,
+not omission.
+
+**2026-07-03 · S2 (Codex, read-only): REWORK → reworked.** Findings:
+1 (emoji facts) — verified and cited. 2 (R1 missed `week.ts` + grocery)
+BLOCKER — **accepted**; R1 now enumerates all three hardcoded sites and
+excludes grocery. 3 (50-column claim false — code points vs display cells)
+BLOCKER — **accepted**; reframed to a **width-neutral swap** (🔺 == 🥟 cell
+count), the pre-existing 50cp/51-cell condition named honestly, kill
+criterion a rewritten. 4 (golden scope missed mini + html) HIGH —
+**accepted**; full churn set enumerated. 5/6 (missing surface rows;
+concrete PR link seam) HIGH — **accepted**; matrix rows for README/viewer-
+chrome/site added, PR link pinned to the post-`</details>` link area with
+budget accounting. 7 (scope creep) MED — **acknowledged**; kept as one
+spec per the maintainer's combined directive, but the page + payment
+placeholder are isolated in R4 so they can ship as a second commit if the
+glyph fix wants to land alone. 8 (unverifiable R4 aesthetic) LOW —
+**accepted**; replaced with network/script/comment assertions.
+
+**2026-07-03 · S3 (value gate):** the churn is the risk; kill criterion b
+caps it at one. The glyph fix (R1/R2/R5) is independently valuable and
+testable without the page; the page (R3/R4) is the delight layer.
+
+**2026-07-03 · S4 (lint):** spec-lint OK.
+
+Status remains draft pending maintainer approval (button 1).


### PR DESCRIPTION
## What this adds

SPEC-0034 (draft): your two samosa directives, plus the brand angle that makes them one spec.

**The glyph is wrong, and we're the tool that can't ship that.** `🥟` is U+1F95F **DUMPLING**; Unicode has **no samosa emoji** (verified — nearest are DUMPLING and PIE). A product whose whole premise is that every character on a receipt is true cannot keep a dumpling labeled 'samosa'.

- **Terminal footer** → `🔺` (RED TRIANGLE — a samosa is triangular; a shape evokes without asserting a falsehood). Width-neutral swap, so alignment is untouched. Deliberate one-shot golden churn across every receipt surface.
- **Graphical surfaces** (SVG export, site, page) → a real hand-drawn samosa SVG — the terminal can't draw what Unicode won't, so it gets the honest shape; graphical surfaces get the real thing.
- **The clickable link** `buy me a samosa` → every surface that renders links (README, artifact page, viewer chrome, site, PR-comment post-`</details>` area) → a small `site/samosa.html`: self-contained, zero trackers, tells the true story ('Unicode has no samosa emoji, so we drew one'). **No payment ships** — awareness, not fundraising; only a commented placeholder for you to fill later.

## What to eyeball

1. **🔺 vs plain text** — I chose the triangle (keeps a signature, fixes the wrongness, tells a story). Design records `buy me a samosa` text-only as your fallback if you'd rather no glyph at all.
2. The samosa page having **no payment link** by default — deliberate; your call to add one.

## S2 record

Codex REWORK, 8 findings incl. 2 blockers (missed `week.ts`/grocery footers; a false 50-column claim — code points vs display cells) — all accepted. Dispositions in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)