### PR TITLE
chore: ledger sweep — 12 built specs shipped, with evidence

### DIFF
--- a/specs/SPEC-0026-pr-comment-polish.md
+++ b/specs/SPEC-0026-pr-comment-polish.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0026
 title: "PR comment polish — leaner N=1, cache line, honest helper label, details on demand"
-status: building
+status: shipped
 milestone: M3
 depends: [SPEC-0023, SPEC-0024]
 ---
@@ -306,3 +306,5 @@ cache-formatter extraction behaviorally identical, R5 assembly order correct.
 **2026-07-03 · approved (button 1):** maintainer, in-session — *"SPEC-0026 -
 approved."* Status → building. Build base: PR #63's branch (SPEC-0027 impl),
 so R5's details section can also give 0027's link line its final home.
+
+**2026-07-04 · shipped:** merged via #63 #66; ledger sweep pre-release.

--- a/specs/SPEC-0027-receipt-artifacts.md
+++ b/specs/SPEC-0027-receipt-artifacts.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0027
 title: "Published receipt artifact — opt-in HTML page on a dedicated branch, linked from the comment"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0023, SPEC-0026]
 ---
@@ -242,3 +242,5 @@ with spec-27 implementation."* Status → building. Build note: SPEC-0026 is
 still a draft, so the R3 link line lands directly after the fenced receipt
 until 0026 ships its details section (placement-only deviation, flagged in
 the implementation PR).
+
+**2026-07-04 · shipped:** merged via #63; ledger sweep pre-release.

--- a/specs/SPEC-0028-cost-fidelity.md
+++ b/specs/SPEC-0028-cost-fidelity.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0028
 title: "Cost fidelity — floor totals, per-adapter reconciliation, plausibility tripwires, trust doc"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0023]
 ---
@@ -263,3 +263,5 @@ file ignoring `AIRECEIPTS_HOME`, unlike budget and summary-cache. Fix: the
 path now honors `homeOverride ?? AIRECEIPTS_HOME ?? homedir()` at call
 time (src/telemetry/notice.ts). Not an assertion change — the failing
 tests were right.
+
+**2026-07-04 · shipped:** merged via #65; ledger sweep pre-release.

--- a/specs/SPEC-0029-readme-launch.md
+++ b/specs/SPEC-0029-readme-launch.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0029
 title: "Launch README — evidence-shaped first screen, receipt parity enforced"
-status: building
+status: shipped
 milestone: M4
 depends: []
 ---
@@ -263,3 +263,5 @@ accepted, fixed; (7) npm README will render degraded (files: excludes
 goldens/docs) — accepted as a recorded publish-day decision in Non-goals,
 not solved here. Red-then-green for receipt parity demonstrated live
 (mutated dollar → guard names the exact failure → restored green).
+
+**2026-07-04 · shipped:** merged via #68 #71(guard evolution) #78; ledger sweep pre-release.

--- a/specs/SPEC-0030-release-readiness.md
+++ b/specs/SPEC-0030-release-readiness.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0030
 title: "Release readiness — rename to receipts, the why, and the org dogfood kit"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0029]
 ---
@@ -243,3 +243,5 @@ truncated in capture were subsumed by (2).
 exit 0.
 
 **2026-07-03 · approved (button 1):** maintainer, in-session ("approved") after the hardened prior-art positioning round. Build split: PR A (R2/R4/R5 + caller template, mergeable now) and PR B (R1 cutover + R3 workflow_call, held green for the rename window). Positioning addendum: lineage framing (ccusage, claude-receipts, Infracost), committed reply paragraph, no independent-invention claims anywhere.
+
+**2026-07-04 · shipped:** merged via #71 #72 (rename window executed 2026-07-04); ledger sweep pre-release.

--- a/specs/SPEC-0031-per-commit-costs.md
+++ b/specs/SPEC-0031-per-commit-costs.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0031
 title: "Per-commit cost attribution — the ledger cut at commit boundaries"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0023, SPEC-0026, SPEC-0027]
 ---
@@ -211,3 +211,5 @@ exit 0.
    `totalTokens`/`totalUsd`, which are pure per-turn sums.
 Critic's independent conclusion: "I did not find a token/USD additivity
 bug in the row math." Gates re-run green after rework.
+
+**2026-07-04 · shipped:** merged via #79; ledger sweep pre-release.

--- a/specs/SPEC-0032-message-anchor.md
+++ b/specs/SPEC-0032-message-anchor.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0032
 title: "Commit-message fallback anchor — credit the author whose SHA never printed"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0023, SPEC-0024, SPEC-0028]
 ---
@@ -199,3 +199,5 @@ accepted.**
 4. MEDIUM — the R5 rendering test was decorative — now asserts the note is
    inside the fenced receipt, indented as a provenance note, ≤50 cols, and
    never coexists with a slice note.
+
+**2026-07-04 · shipped:** merged via #86; ledger sweep pre-release.

--- a/specs/SPEC-0033-launch-hardening.md
+++ b/specs/SPEC-0033-launch-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0033
 title: "OSS launch hardening — pinned supply chain, least privilege, priced contributions"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0030] # draft in flight (PR #70) — R5 interlocks with its rename
 ---
@@ -314,3 +314,5 @@ alone — those SHAs were fetched and cross-checked against `gh api
 repos/<owner>/<repo>/commits/<tag>` during the build (S5). All gates re-run
 green after the fixes (tsc/eslint/vitest 970 tests/goldens/spec-lint/hygiene
 all exit 0; actionlint 0; zizmor real-repo run exit 0).
+
+**2026-07-04 · shipped:** merged via #81; ledger sweep pre-release.

--- a/specs/SPEC-0034-samosa.md
+++ b/specs/SPEC-0034-samosa.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0034
 title: "The samosa — a clickable link, an honest glyph, a small delightful page"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0027, SPEC-0029]
 ---
@@ -241,3 +241,5 @@ a negative test assertion). Side effect: `build-docs-site.mjs` now throws
 on manifest gaps and `NAV_SECTIONS` was missing `trust.md` +
 `adopt/org-rollout.md` (pre-existing on `origin/main`, blocked this
 regen) — both added to the nav.
+
+**2026-07-04 · shipped:** merged via #91; ledger sweep pre-release.

--- a/specs/SPEC-0035-share-links.md
+++ b/specs/SPEC-0035-share-links.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0035
 title: "Shareable receipts — intent-only share, zero third parties, no leak"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0027]
 ---
@@ -255,3 +255,5 @@ comment's own instruction):** "Maintainer confirmation (in-session,
 the AI agents actually cost.' — is approved verbatim as the one string that
 ships under the author's name." This exact string is what R3/`SHARE_TEXT`
 ships; it is not edited anywhere in this build.
+
+**2026-07-04 · shipped:** merged via #87; ledger sweep pre-release.

--- a/specs/SPEC-0037-one-command-pr-receipt.md
+++ b/specs/SPEC-0037-one-command-pr-receipt.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0037
 title: "One-command PR receipt finalizer"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0019, SPEC-0036]
 ---
@@ -244,3 +244,5 @@ branch.** 6 findings:
 6. MEDIUM — the wiring test pins prose ordering, not the operational story —
    **accepted as scoped**: that is exactly what a docs-slice test can pin;
    the operational assertions live in the unbuilt e2e slice's rows.
+
+**2026-07-04 · shipped:** merged via #90; ledger sweep pre-release.

--- a/specs/SPEC-0038-attribution-fidelity.md
+++ b/specs/SPEC-0038-attribution-fidelity.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0038
 title: "Attribution fidelity — anchors are authorship, receipts never double-count"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0024, SPEC-0032]
 ---
@@ -274,3 +274,5 @@ committed. (b) not triggered: the fork marker is reliable (P3) — forks
 render post-fork turns, not exclusions. The two vitest failures on this
 loaded machine are upstream #69 stress timeouts, reproduced byte-identically
 on an unmodified baseline tree mid-build.
+
+**2026-07-04 · shipped:** merged via #94 (backfill demonstrated); ledger sweep pre-release.


### PR DESCRIPTION
## What this adds

Pre-release ledger truth: every spec merged this cycle flips `building` → `shipped`, each with its merge-PR evidence appended in-file (0026–0035, 0037, 0038 — including 0038's live backfill demonstration link). SPEC-0039 stays `building` until its in-flight PR merges.

Deliberately NOT flipped: the historical 0001–0023 batch stays `approved` — their implementations shipped before the shipped-status convention existed, and flipping them without per-spec verification would be ledger theater. If you want them swept too, that's a separate verified pass.

## Evidence

spec-lint 39 OK; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)