### PR TITLE
chore: lean npm artifact — drop sourcemaps, guard publish freshness

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "prepublishOnly": "tsup",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,7 +13,10 @@ export default defineConfig({
   target: "node20",
   platform: "node",
   clean: true,
-  sourcemap: true,
+  // No sourcemaps in the published artifact: they were 70% of the npm tarball
+  // and nothing (tests run on src via vitest; the determinism check runs the
+  // built cli.js) consumes them at runtime. A bundled end-user CLI ships JS only.
+  sourcemap: false,
   dts: false,
   banner: {
     js: "#!/usr/bin/env node",


### PR DESCRIPTION
## What this adds

Pre-publish hygiene: the npm tarball was **70% sourcemaps**. Cutting them makes the package **69% smaller** with zero behavior change.

| | before | after |
|---|---|---|
| files | 88 | 48 |
| unpacked | 973 KB | 294 KB |
| packed download | 269 KB | 78 KB |
| `.map` files | 40 (677 KB) | 0 |

Nothing consumes the maps — vitest runs on `src`, the determinism check runs the built `cli.js`, end users get a bundled CLI.

## What changed

- `tsup.config.ts`: `sourcemap: false`.
- `package.json`: `prepublishOnly: tsup` so `npm publish` can never ship a stale `dist`. Deliberately **not** `prepack` — `prepack` runs during `npm pack` and tsup's log pollutes `npm pack --json`, which the `packed tarball smoke` e2e parses (it caught exactly that when I first tried `prepack`).

## What to review

1. The hook choice (`prepublishOnly` vs `prepack`) — Codex confirmed it's correct and doesn't pollute the publish path CI uses.
2. `files` allowlist unchanged and still runtime-correct: `data/prices` is read from disk via `import.meta.url`, asserted present by the smoke test.

## Evidence

tsc/eslint/goldens(90)/determinism×10/spec-lint(39)/hygiene all green; `packed tarball smoke` passes; Codex review PASS (0 findings). The one failing test is the pre-existing #69 opencode 100-session timeout under load (reproduces on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)