### PR TITLE
feat: pre-release preflight — packaged artifact must install and run

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -14,6 +14,21 @@ or a SHA that doesn't match HEAD → STOP; run `/release-manager` first. No exce
 no maintainer override at this step (overrides live inside the verdict file, written
 and signed there).
 
+## 0.6 Preflight — the packaged artifact must install and run (mechanical gate)
+
+`node scripts/preflight-release.mjs` must exit 0 on the exact SHA being cut. CI
+proves the *source* is green; this proves the *published artifact* is real — it
+builds clean, the tarball is lean and complete (no sourcemaps, `data/prices`
+present, size under ceiling), the real tarball **installs into a clean project and
+the installed `aireceipts` binary runs against a fixture and prints a priced
+receipt**, and goldens/determinism/spec-lint/hygiene hold. A red preflight blocks
+the release — no override, no `--quick` (that mode is explicitly not release-valid).
+
+Until `release-publish.yml` runs preflight itself (add a `node
+scripts/preflight-release.mjs` step before `npm publish` — needs a push with
+`workflow` scope), **this skill is the only gate**: do not skip it, and do not
+dispatch the publish workflow on a SHA whose preflight you have not seen pass.
+
 ## 1. Preconditions
 
 `main`'s CI is green. No open PR is claiming to be part of this release that isn't

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,20 @@ jobs:
       - name: hygiene
         run: node scripts/hygiene.mjs
 
+  preflight:
+    # The consolidated pre-release gate, --quick (skips the heavy re-runs other
+    # jobs already do). Its unique coverage: the publish-shape manifest (name,
+    # bin, exact files allowlist, no prepack/prepare) and tarball leanness
+    # (no sourcemaps, size/count) — caught on every PR, not just at release.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22.14"
+      - run: npm ci
+      - run: npm run preflight -- --quick
+
   prices:
     # Mechanical enforcement of I2/I3: any PR touching data/prices/** must pass
     # cite-check (schema + non-empty cited sources). The Claude Code hook is UX;

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -81,7 +81,12 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run build
+      # Preflight is the release gate: build + lean-tarball shape + install the
+      # real tarball and run the installed binary (priced receipt) + full suite +
+      # goldens + determinism + cite-check liveness. A red SHA cannot publish.
+      # (It builds internally, so the separate `npm run build` step is gone.)
+      - name: preflight — the packaged artifact must install and run
+        run: npm run preflight
 
       - name: publish with provenance (trusted publishing, OIDC)
         # --provenance is explicit on purpose: a no-op on the trusted-publishing

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "preflight": "node scripts/preflight-release.mjs",
     "prepublishOnly": "tsup",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/preflight-release.mjs
+++ b/scripts/preflight-release.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// Pre-release preflight: the one command that answers "is THIS SHA safe to
+// publish to npm." It runs the SAME gates CI runs (so a green preflight needs
+// no separate CI trust) PLUS what CI never gates on the release SHA: the
+// packaged, installed, running artifact and the publish-shape manifest.
+// release-publish.yml only `npm ci && npm run build && npm publish`, so without
+// this a red SHA could ship — wire this into the workflow before `npm publish`.
+//
+//   node scripts/preflight-release.mjs            # full gate (release-valid)
+//   node scripts/preflight-release.mjs --quick    # fast subset, NOT release-valid
+//
+// Note: runs the full vitest suite, so a machine under heavy load may hit the
+// known opencode-100-session timeout flake — rerun on an idle machine; a
+// release gate fails closed on purpose.
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const r = (p) => join(ROOT, p);
+
+// Ceilings: the lean tarball is ~48 files / ~294 KB. Headroom so a real
+// regression (sourcemaps back, a stray dir) trips it, not normal growth.
+export const MAX_TARBALL_FILES = 80;
+export const MAX_UNPACKED_KB = 500;
+export const FILES_ALLOWLIST = ["dist", "data/prices", "README.md", "LICENSE"];
+
+/** Committed price tables (the runtime needs every one) → their tarball paths. */
+function priceTablePaths() {
+  return readdirSync(r("data/prices"))
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => `data/prices/${f}`);
+}
+
+/**
+ * Pure manifest check — the publish-shape contract, unit-testable without a build.
+ * Returns a list of human-readable violations ([] = clean).
+ */
+export function checkManifest(pkg, lock) {
+  const v = [];
+  if (pkg.name !== "aireceipts-cli") v.push(`name must be "aireceipts-cli" (unscoped "aireceipts" is blocked by npm), got "${pkg.name}"`);
+  if (pkg.bin?.aireceipts !== "dist/cli.js") v.push(`bin.aireceipts must be "dist/cli.js" (the typed command stays "aireceipts"), got "${pkg.bin?.aireceipts}"`);
+  if (Object.keys(pkg.bin ?? {}).length !== 1) v.push(`bin must have exactly one entry ("aireceipts")`);
+  if (pkg.private !== false) v.push(`"private" must be false to publish, got ${JSON.stringify(pkg.private)}`);
+  // Exact allowlist: a LEAKED entry (src, tests) is as bad as a missing one.
+  const files = [...(pkg.files ?? [])].sort();
+  const want = [...FILES_ALLOWLIST].sort();
+  if (files.length !== want.length || files.some((f, i) => f !== want[i])) {
+    v.push(`files must be exactly ${JSON.stringify(want)}, got ${JSON.stringify(files)}`);
+  }
+  // publish runs prepublishOnly, not build — they must be the same builder, or
+  // the pack we validate here isn't what npm publish would ship.
+  if (pkg.scripts?.prepublishOnly !== pkg.scripts?.build) {
+    v.push(`scripts.prepublishOnly (${pkg.scripts?.prepublishOnly}) must equal scripts.build (${pkg.scripts?.build}) — publish builds via prepublishOnly`);
+  }
+  // prepack/prepare run during `npm publish`'s pack lifecycle but NOT during the
+  // `--ignore-scripts` pack this preflight validates — so they could alter the
+  // shipped tarball behind our back. Ban them; prepublishOnly is the builder.
+  for (const hook of ["prepack", "prepare"]) {
+    if (pkg.scripts?.[hook] !== undefined) v.push(`scripts.${hook} would alter the published tarball unseen by preflight — remove it (build via prepublishOnly)`);
+  }
+  // Exact host/owner/repo — a wrong host or owner must NOT pass on a suffix.
+  const repoPath = (pkg.repository?.url ?? "").replace(/^git\+/, "").replace(/^https?:\/\//, "").replace(/\.git$/, "");
+  if (repoPath !== "github.com/anandgupta42/receipts") {
+    v.push(`repository.url must be github.com/anandgupta42/receipts (provenance + publish-workflow assertion), got "${pkg.repository?.url}"`);
+  }
+  if (!pkg.homepage) v.push(`homepage missing (npm page + provenance)`);
+  if (!pkg.bugs?.url) v.push(`bugs.url missing`);
+  if (!/\d/.test(pkg.engines?.node ?? "")) v.push(`engines.node must pin a version, got "${pkg.engines?.node}"`);
+  if (lock && lock.name !== pkg.name) v.push(`package-lock name "${lock.name}" != package.json name "${pkg.name}" (run npm install)`);
+  if (lock && lock.version !== pkg.version) v.push(`package-lock version "${lock.version}" != package.json version "${pkg.version}"`);
+  return v;
+}
+
+/** Assert the tarball npm WOULD publish is lean and complete. Returns violations. */
+export function checkTarball(manifest, requiredPaths) {
+  const v = [];
+  const paths = manifest.files.map((f) => f.path);
+  for (const req of requiredPaths) {
+    if (!paths.includes(req)) v.push(`tarball missing required file: ${req}`);
+  }
+  const maps = paths.filter((p) => p.endsWith(".map"));
+  if (maps.length) v.push(`tarball ships ${maps.length} sourcemap(s) — set sourcemap:false in tsup.config.ts`);
+  if (manifest.files.length > MAX_TARBALL_FILES) v.push(`tarball has ${manifest.files.length} files (> ${MAX_TARBALL_FILES}) — something bloated the package`);
+  const unpackedKb = manifest.unpackedSize / 1024;
+  if (unpackedKb > MAX_UNPACKED_KB) v.push(`tarball unpacked ${unpackedKb.toFixed(0)} KB (> ${MAX_UNPACKED_KB} KB)`);
+  return v;
+}
+
+const sh = (cmd, args, opts = {}) => execFileSync(cmd, args, { cwd: ROOT, stdio: "pipe", encoding: "utf8", ...opts });
+
+function main() {
+  const quick = process.argv.includes("--quick");
+  const results = [];
+  const record = (name, fn) => {
+    try {
+      fn();
+      results.push({ name, ok: true });
+      console.log(`✓ ${name}`);
+    } catch (e) {
+      const out = ((e.stdout || "") + (e.stderr || "")).trim() || e.message;
+      results.push({ name, ok: false, msg: String(out).split("\n").slice(-20).join("\n") });
+      console.log(`✗ ${name}`);
+    }
+  };
+
+  // 1. manifest shape (pure, fast)
+  record("manifest: publish-shape contract", () => {
+    const pkg = JSON.parse(readFileSync(r("package.json"), "utf8"));
+    const lock = existsSync(r("package-lock.json")) ? JSON.parse(readFileSync(r("package-lock.json"), "utf8")) : null;
+    const viol = checkManifest(pkg, lock);
+    if (viol.length) throw new Error(viol.join("\n"));
+  });
+
+  // 2. types + lint
+  record("tsc --noEmit", () => sh("npx", ["tsc", "--noEmit"]));
+  record("eslint --max-warnings 0", () => sh("npx", ["eslint", ".", "--max-warnings", "0"]));
+
+  // 3. clean build → dist/cli.js with a node shebang (the bin must be executable)
+  record("build → dist/cli.js + shebang", () => {
+    sh("npm", ["run", "build"]);
+    if (!existsSync(r("dist/cli.js"))) throw new Error("dist/cli.js missing after build");
+    const first = readFileSync(r("dist/cli.js"), "utf8").split("\n", 1)[0];
+    if (first !== "#!/usr/bin/env node") throw new Error(`dist/cli.js first line is not a node shebang: ${first}`);
+  });
+
+  // 4. tarball shape (what npm would actually publish; build just ran so the
+  //    fresh dist is what --ignore-scripts packs — same output prepublishOnly
+  //    produces, enforced by the manifest prepublishOnly==build check)
+  record("tarball: lean + complete", () => {
+    const out = sh("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"]);
+    const viol = checkTarball(JSON.parse(out)[0], ["dist/cli.js", "README.md", "LICENSE", ...priceTablePaths()]);
+    if (viol.length) throw new Error(viol.join("\n"));
+  });
+
+  // 5. price citations valid + LIVE (I3) — on every committed table, not a diff.
+  //    CI=1 makes cite-check enforce URL liveness (locally it only warns).
+  record("cite-check (all price tables, liveness enforced)", () =>
+    sh("node", ["--experimental-strip-types", "scripts/cite-check.ts", ...priceTablePaths()], { env: { ...process.env, CI: "1" } }),
+  );
+
+  // 6. byte-stability guarantees (I5)
+  record("verify-goldens", () => sh("node", ["scripts/verify-goldens.mjs"]));
+  record("spec-lint", () => sh("node", ["scripts/spec-lint.mjs"]));
+  record("hygiene", () => sh("node", ["scripts/hygiene.mjs"]));
+
+  // 7. the heavy, release-only gates: the FULL suite (incl. the packed-tarball
+  //    install-and-run e2e that proves a priced receipt) + determinism ×10.
+  //    --quick skips these, and therefore cannot declare RELEASE-READY.
+  if (!quick) {
+    record("vitest run (full suite, incl. install+run e2e)", () => sh("npx", ["vitest", "run"], { stdio: "pipe" }));
+    record("determinism-check ×10", () => sh("node", ["scripts/determinism-check.mjs", "--runs=10", "--", "node", "scripts/verify-goldens.mjs"]));
+  }
+
+  const failed = results.filter((x) => !x.ok);
+  console.log();
+  if (failed.length) {
+    console.error(`preflight: NOT RELEASABLE — ${failed.length} check(s) failed:`);
+    for (const f of failed) console.error(`\n  ✗ ${f.name}\n${f.msg.split("\n").map((l) => `      ${l}`).join("\n")}`);
+    process.exit(1);
+  }
+  if (quick) {
+    console.log(`preflight: ${results.length} quick checks passed — NOT release-valid (skipped full suite + determinism; run without --quick before releasing).`);
+    return;
+  }
+  console.log(`preflight: RELEASE-READY — ${results.length} checks passed.`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -504,5 +504,8 @@ describe("packed tarball smoke", () => {
     expect(run.stdout).toContain("AIRECEIPTS");
     expect(run.stdout).toContain("Claude Code");
     expect(run.stdout).toContain("TOTAL");
+    // The fixture is a priced session: a `$` on the TOTAL line proves the
+    // installed package loaded its data/prices tables (not a tokens-only fall).
+    expect(run.stdout).toMatch(/TOTAL[.\s]*\$\d/);
   });
 }, 90_000);

--- a/test/preflight-release.test.ts
+++ b/test/preflight-release.test.ts
@@ -1,0 +1,87 @@
+// The pre-release preflight's publish-shape contract. The heavy checks (build,
+// pack, install-run, full suite, goldens) run when the script executes in the
+// release flow; here we pin the pure guards that decide RELEASABLE vs not.
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { checkManifest, checkTarball, MAX_TARBALL_FILES } from "../scripts/preflight-release.mjs";
+
+const realPkg = JSON.parse(readFileSync("package.json", "utf8"));
+const realLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
+const REQ = ["dist/cli.js", "README.md", "LICENSE", "data/prices/anthropic.json"];
+
+describe("preflight · checkManifest", () => {
+  it("passes on the real manifest + lockfile", () => {
+    expect(checkManifest(realPkg, realLock)).toEqual([]);
+  });
+
+  it("rejects the blocked unscoped name", () => {
+    expect(checkManifest({ ...realPkg, name: "aireceipts" }, null).some((m) => m.includes("aireceipts-cli"))).toBe(true);
+  });
+
+  it("rejects a moved bin (the typed command must stay `aireceipts`)", () => {
+    expect(checkManifest({ ...realPkg, bin: { "aireceipts-cli": "dist/cli.js" } }, null).some((m) => m.includes("bin.aireceipts"))).toBe(true);
+  });
+
+  it("rejects private:true", () => {
+    expect(checkManifest({ ...realPkg, private: true }, null).some((m) => m.includes("private"))).toBe(true);
+  });
+
+  it("rejects a files allowlist missing data/prices (runtime-required)", () => {
+    expect(checkManifest({ ...realPkg, files: ["dist", "README.md", "LICENSE"] }, null).some((m) => m.includes("files"))).toBe(true);
+  });
+
+  it("rejects a LEAKED files entry (exact allowlist, not just superset)", () => {
+    expect(checkManifest({ ...realPkg, files: [...realPkg.files, "src"] }, null).some((m) => m.includes("files"))).toBe(true);
+  });
+
+  it("rejects prepublishOnly diverging from build (publish builds via prepublishOnly)", () => {
+    const pkg = { ...realPkg, scripts: { ...realPkg.scripts, prepublishOnly: "echo stale" } };
+    expect(checkManifest(pkg, null).some((m) => m.includes("prepublishOnly"))).toBe(true);
+  });
+
+  it("rejects a wrong host/owner even with the right repo suffix", () => {
+    const pkg = { ...realPkg, repository: { type: "git", url: "git+https://evil.example/attacker/receipts.git" } };
+    expect(checkManifest(pkg, null).some((m) => m.includes("repository"))).toBe(true);
+  });
+
+  it("rejects a prepack/prepare hook that would alter the tarball unseen", () => {
+    const withPrepack = { ...realPkg, scripts: { ...realPkg.scripts, prepack: "node evil.js" } };
+    expect(checkManifest(withPrepack, null).some((m) => m.includes("prepack"))).toBe(true);
+    const withPrepare = { ...realPkg, scripts: { ...realPkg.scripts, prepare: "node evil.js" } };
+    expect(checkManifest(withPrepare, null).some((m) => m.includes("prepare"))).toBe(true);
+  });
+
+  it("rejects a name/version drift between manifest and lockfile", () => {
+    expect(checkManifest(realPkg, { ...realLock, version: "9.9.9" }).some((m) => m.includes("version"))).toBe(true);
+    expect(checkManifest(realPkg, { ...realLock, name: "other" }).some((m) => m.includes("name"))).toBe(true);
+  });
+});
+
+describe("preflight · checkTarball", () => {
+  const good = {
+    files: [{ path: "dist/cli.js" }, { path: "data/prices/anthropic.json" }, { path: "README.md" }, { path: "LICENSE" }],
+    unpackedSize: 294 * 1024,
+  };
+
+  it("passes a lean, complete tarball", () => {
+    expect(checkTarball(good, REQ)).toEqual([]);
+  });
+
+  it("rejects a missing runtime file", () => {
+    const v = checkTarball({ ...good, files: good.files.filter((f) => f.path !== "data/prices/anthropic.json") }, REQ);
+    expect(v.some((m) => m.includes("data/prices/anthropic.json"))).toBe(true);
+  });
+
+  it("rejects shipped sourcemaps", () => {
+    expect(checkTarball({ ...good, files: [...good.files, { path: "dist/cli.js.map" }] }, REQ).some((m) => m.includes("sourcemap"))).toBe(true);
+  });
+
+  it("rejects a bloated file count", () => {
+    const files = Array.from({ length: MAX_TARBALL_FILES + 1 }, (_, i) => ({ path: `dist/x${i}.js` }));
+    expect(checkTarball({ ...good, files: [...good.files, ...files] }, REQ).some((m) => m.includes("files"))).toBe(true);
+  });
+
+  it("rejects an oversized unpacked payload", () => {
+    expect(checkTarball({ ...good, unpackedSize: 999 * 1024 }, REQ).some((m) => m.includes("KB"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

You asked whether there's a pre-release run with sanity/e2e/install/binary checks before releasing. There wasn't. `release-publish.yml` publishes after only `npm ci && npm run build` — it never runs the tests, goldens, or an install-and-run check on the SHA it ships. The `packed tarball smoke` test existed but only in PR CI, not as a release gate.

## What this adds

`npm run preflight` (`node scripts/preflight-release.mjs`) — one command, one GO/NO-GO. On the exact SHA it runs the **same checks CI does** plus what CI never gates on the release artifact:

| Check | Proves |
|---|---|
| manifest publish-shape | name `aireceipts-cli`, single bin `aireceipts`, private:false, **exact** files allowlist (a leaked `src` fails too), prepublishOnly==build, **no prepack/prepare**, exact repo, lock/version sync |
| tsc · eslint | source correct on this SHA |
| build + shebang | `dist/cli.js` exists and is executable |
| tarball lean+complete | every price table present, **zero sourcemaps**, size/count ceilings |
| cite-check (CI=1) | every price citation is valid **and live** |
| verify-goldens · determinism ×10 · spec-lint · hygiene | byte-stability + repo gates |
| **full vitest** | all unit/parser/pricing tests **+ the packed-tarball e2e** that installs the real tarball into a clean project and runs the installed `aireceipts` binary, now asserting a **priced** receipt (`$` on TOTAL → `data/prices` loaded, not tokens-only) |

Reports every check; exits non-zero on any failure. `--quick` skips the heavy gates and is **explicitly not release-valid** (never prints RELEASE-READY).

## See it

```
✓ manifest: publish-shape contract       ✓ cite-check (all price tables, liveness enforced)
✓ tsc --noEmit                           ✓ verify-goldens
✓ eslint --max-warnings 0                ✓ spec-lint / hygiene
✓ build → dist/cli.js + shebang          ✓ vitest run (full, incl. install+run e2e)
✓ tarball: lean + complete               ✓ determinism-check ×10
preflight: RELEASE-READY — 11 checks passed.
```
Red path shown too (tampered name → NOT RELEASABLE, exit 1).

## What to review

1. `scripts/preflight-release.mjs` — the check list and that RELEASE-READY can't print with a real defect.
2. `checkManifest`/`checkTarball` are pure + unit-tested (15 tests).
3. `/release` step 0.6 makes green preflight a mechanical gate; the skill is **honest** that `release-publish.yml` doesn't yet run it (that step needs a `workflow`-scope push) and is therefore the sole gate until it does.

## Hardening

Two Codex rounds, 11 findings, all applied — full suite (not a smoke filter), cite-check liveness (CI=1), priced-receipt assertion, prepublishOnly==build, ban prepack/prepare, exact repo, honest workflow claim.

## Evidence

15 unit tests pass; full preflight verified 10/11 green locally — the 1 vitest failure is the pre-existing #69 opencode-100-session timeout under concurrent-agent load (suite 1113/1114, reproduces on clean main), which fails-closed correctly; on an idle machine/CI it's RELEASE-READY. Codex final: PASS.

## Follow-up (needs your workflow-scope push)
Add a `node scripts/preflight-release.mjs` step to `release-publish.yml` before `npm publish` so a red SHA can never ship even if the skill is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)