### PR TITLE
feat: SPEC-0041 real-session discovery filter

### DIFF
--- a/src/aggregate/week.ts
+++ b/src/aggregate/week.ts
@@ -42,14 +42,29 @@ export interface PartitionedWindows {
 }
 
 /**
+ * SPEC-0041 R2 — the "real session" floor for aggregate windows: false exactly
+ * when a summary is empty on EVERY axis (no turns, no tool calls, no tokens).
+ * An all-zero artifact cannot contribute waste, cost, tokens, or duration —
+ * dropping it changes only session counts, never a priced number. A session
+ * with any tokens or tool calls stays in, even with zero turns. `--list` does
+ * NOT apply this (listing is inventory; windows are statistics).
+ */
+export function isAggregatableSession(s: SessionSummary): boolean {
+  const t = s.totals;
+  return t.turnCount > 0 || t.toolCallCount > 0 || t.tokens.total > 0;
+}
+
+/**
  * R1: bucket summaries into the current/prior windows by `endedAt`. A session
  * with no `endedAt` is excluded from both windows — never guessed into one.
+ * SPEC-0041 R2: all-zero artifacts are floored out here, the single seam both
+ * window consumers (week digest, handoff recurrence) route through.
  */
 export function partitionWindows(summaries: SessionSummary[], bounds: WindowBounds): PartitionedWindows {
   const current: SessionSummary[] = [];
   const prior: SessionSummary[] = [];
   for (const s of summaries) {
-    if (s.endedAt === undefined) {
+    if (s.endedAt === undefined || !isAggregatableSession(s)) {
       continue;
     }
     if (s.endedAt >= bounds.curStart && s.endedAt < bounds.curEnd) {

--- a/src/parse/children.ts
+++ b/src/parse/children.ts
@@ -50,6 +50,23 @@ export function isChildPath(filePath: string): boolean {
 }
 
 /**
+ * SPEC-0041 R1 — true for ANY path under a `subagents/` directory, regardless
+ * of basename. `parseChildPath()` only recognizes `agent-<id>.jsonl` children,
+ * which let non-session artifacts that live under the same tree (e.g.
+ * `<session>/subagents/workflows/wf_x/journal.jsonl`) leak into top-level
+ * listings as sessions. Top-level discovery excludes on this predicate; parent
+ * linkage and rollup discovery still use `parseChildPath`/`discoverChildFiles`.
+ *
+ * When `rootDir` is given, only segments BELOW the root are considered — an
+ * ancestor directory that happens to be named `subagents` (e.g. a home dir
+ * `/Users/subagents/...`) must never exclude a whole corpus.
+ */
+export function isUnderSubagents(filePath: string, rootDir?: string): boolean {
+  const scoped = rootDir !== undefined ? path.relative(rootDir, filePath) : filePath;
+  return scoped.split(path.sep).includes(SUBAGENTS_SEGMENT);
+}
+
+/**
  * Discover the subagent transcripts of a parent transcript on disk, in sorted
  * path order (deterministic). Returns absolute file paths under
  * `<parentDir>/<parentStem>/subagents/`. Empty when the parent has no children.

--- a/src/parse/claudeCode.ts
+++ b/src/parse/claudeCode.ts
@@ -1,6 +1,6 @@
 import type { AgentSource, Compaction, ListSessionsOptions, Session, SessionAdapter, SessionSummary, ToolCall, Turn } from "./types.js";
 import { claudeCodeFidelity } from "./fidelity/claudeCode.js";
-import { isChildPath, parseChildPath } from "./children.js";
+import { isUnderSubagents, parseChildPath } from "./children.js";
 import { lazyClaudeCodeSummary, nodeDiscoveryFs, type DiscoveryFs } from "./discovery.js";
 import {
   addUsage,
@@ -389,7 +389,11 @@ export class ClaudeCodeAdapter implements SessionAdapter {
     const all = await listFiles(this.root, (name) => name.endsWith(".jsonl"));
     // R1c: subagent transcripts are excluded from top-level selection — they roll
     // up into their parent's receipt, never appear as standalone sessions.
-    const files = all.filter((file) => !isChildPath(file));
+    // SPEC-0041 R1: the exclusion covers ANY `.jsonl` under `subagents/`, not
+    // just `agent-*.jsonl` — workflow journals etc. are not sessions. Scoped
+    // below the adapter root so an ancestor dir named `subagents` never
+    // excludes the whole corpus.
+    const files = all.filter((file) => !isUnderSubagents(file, this.root));
     const results = await mapWithConcurrency(files, 16, async (file) => {
       try {
         const stat = await this.discoveryFs.stat(file);

--- a/test/fixtures/claude-code-discovery/s-all-zero.jsonl
+++ b/test/fixtures/claude-code-discovery/s-all-zero.jsonl
@@ -1,0 +1,1 @@
+{"type":"user","timestamp":"2026-07-01T12:10:00.000Z","cwd":"/home/dev/app5","message":{"role":"user","content":"(user closed the terminal before any reply)"}}

--- a/test/fixtures/claude-code-discovery/s-parent.jsonl
+++ b/test/fixtures/claude-code-discovery/s-parent.jsonl
@@ -1,0 +1,2 @@
+{"type":"user","timestamp":"2026-07-01T12:00:00.000Z","cwd":"/home/dev/app5","message":{"role":"user","content":"tidy the readme"}}
+{"type":"assistant","timestamp":"2026-07-01T12:00:04.000Z","message":{"role":"assistant","model":"claude-haiku-4-5","content":[{"type":"text","text":"done"}],"usage":{"input_tokens":900,"output_tokens":40}}}

--- a/test/fixtures/claude-code-discovery/s-parent/subagents/agent-w1.jsonl
+++ b/test/fixtures/claude-code-discovery/s-parent/subagents/agent-w1.jsonl
@@ -1,0 +1,2 @@
+{"type":"user","timestamp":"2026-07-01T12:00:01.000Z","isSidechain":true,"message":{"role":"user","content":"child task"}}
+{"type":"assistant","timestamp":"2026-07-01T12:00:02.000Z","message":{"role":"assistant","model":"claude-haiku-4-5","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":120,"output_tokens":8}}}

--- a/test/fixtures/claude-code-discovery/s-parent/subagents/workflows/wf_a/journal.jsonl
+++ b/test/fixtures/claude-code-discovery/s-parent/subagents/workflows/wf_a/journal.jsonl
@@ -1,0 +1,2 @@
+{"type":"journal","timestamp":"2026-07-01T12:00:03.000Z","entry":{"step":"wave-1","note":"workflow bookkeeping, not a session"}}
+{"type":"journal","timestamp":"2026-07-01T12:00:05.000Z","entry":{"step":"wave-2","note":"more bookkeeping"}}

--- a/test/parse/discovery-filter.test.ts
+++ b/test/parse/discovery-filter.test.ts
@@ -1,0 +1,122 @@
+// SPEC-0041 — real-session discovery filter: (R1) any `.jsonl` under a
+// `subagents/` segment is excluded from top-level listing regardless of
+// basename; (R2) all-zero artifacts are floored out of aggregate windows via
+// the exported `isAggregatableSession` predicate; (R3) `--list`-level listing
+// keeps real-but-all-zero transcripts visible. Committed fixture tree at
+// test/fixtures/claude-code-discovery/ reproduces the observed journal noise.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { ClaudeCodeAdapter } from "../../src/parse/claudeCode.js";
+import { discoverChildFiles, isUnderSubagents, parseChildPath } from "../../src/parse/children.js";
+import { aggregateWindow, computeDelta, isAggregatableSession, partitionWindows, windowBounds } from "../../src/aggregate/week.js";
+import type { SessionSummary } from "../../src/parse/types.js";
+
+const ROOT = path.join(process.cwd(), "test/fixtures/claude-code-discovery");
+const adapter = new ClaudeCodeAdapter({ root: ROOT });
+
+function summaryWith(totals: { turnCount: number; toolCallCount: number; tokensTotal: number }, endedAt?: number): SessionSummary {
+  return {
+    id: `s-${totals.turnCount}-${totals.toolCallCount}-${totals.tokensTotal}`,
+    source: "claude-code",
+    filePath: "/tmp/x.jsonl",
+    endedAt,
+    totals: {
+      turnCount: totals.turnCount,
+      toolCallCount: totals.toolCallCount,
+      tokens: { input: totals.tokensTotal, output: 0, cacheRead: 0, cacheCreation: 0, total: totals.tokensTotal },
+    },
+  };
+}
+
+describe("SPEC-0041 R1 — descendant exclusion by path", () => {
+  it("excludes the workflow journal from listSessions() while keeping the parent", async () => {
+    const rows = await adapter.listSessions({ full: true });
+    const basenames = rows.map((r) => path.basename(r.filePath)).sort();
+    expect(basenames).toEqual(["s-all-zero.jsonl", "s-parent.jsonl"]);
+  });
+
+  it("excludes ANY .jsonl at any depth under subagents/, not just agent-*.jsonl", () => {
+    expect(isUnderSubagents(path.join(ROOT, "s-parent/subagents/workflows/wf_a/journal.jsonl"))).toBe(true);
+    expect(isUnderSubagents(path.join(ROOT, "s-parent/subagents/agent-w1.jsonl"))).toBe(true);
+    expect(isUnderSubagents(path.join(ROOT, "s-parent.jsonl"))).toBe(false);
+    // adversarial: a session whose own name merely CONTAINS the word
+    expect(isUnderSubagents(path.join(ROOT, "my-subagents-notes.jsonl"))).toBe(false);
+  });
+
+  it("adversarial: an ANCESTOR directory named `subagents` never excludes the corpus (root-scoped)", async () => {
+    // e.g. a user whose home path contains /subagents/ — only segments BELOW
+    // the adapter root count.
+    const trickyRoot = path.join("/Users", "subagents", ".claude", "projects");
+    const file = path.join(trickyRoot, "proj", "s1.jsonl");
+    expect(isUnderSubagents(file, trickyRoot)).toBe(false);
+    expect(isUnderSubagents(file)).toBe(true); // unscoped would have excluded it
+    expect(isUnderSubagents(path.join(trickyRoot, "proj", "s1", "subagents", "x.jsonl"), trickyRoot)).toBe(true);
+  });
+
+  it("keeps parseChildPath's linkage contract: agent children map, journals do not", () => {
+    const child = parseChildPath(path.join(ROOT, "s-parent/subagents/agent-w1.jsonl"));
+    expect(child?.agentId).toBe("w1");
+    expect(child?.parentSessionId).toBe("s-parent");
+    expect(parseChildPath(path.join(ROOT, "s-parent/subagents/workflows/wf_a/journal.jsonl"))).toBeNull();
+  });
+
+  it("leaves rollup discovery untouched: exactly the agent child, never the journal", async () => {
+    const children = await discoverChildFiles(path.join(ROOT, "s-parent.jsonl"));
+    expect(children.map((c) => path.basename(c))).toEqual(["agent-w1.jsonl"]);
+  });
+});
+
+describe("SPEC-0041 R2 — all-zero floor for aggregate windows", () => {
+  it("isAggregatableSession is false exactly for the all-zero artifact", () => {
+    expect(isAggregatableSession(summaryWith({ turnCount: 0, toolCallCount: 0, tokensTotal: 0 }))).toBe(false);
+    expect(isAggregatableSession(summaryWith({ turnCount: 0, toolCallCount: 0, tokensTotal: 5 }))).toBe(true);
+    expect(isAggregatableSession(summaryWith({ turnCount: 0, toolCallCount: 2, tokensTotal: 0 }))).toBe(true);
+    expect(isAggregatableSession(summaryWith({ turnCount: 1, toolCallCount: 0, tokensTotal: 0 }))).toBe(true);
+  });
+
+  it("partitionWindows floors the all-zero artifact but keeps a token-bearing zero-turn session", () => {
+    const now = Date.parse("2026-07-04T12:00:00.000Z");
+    const bounds = windowBounds(now);
+    const inWindow = now - 60_000;
+    const real = summaryWith({ turnCount: 2, toolCallCount: 3, tokensTotal: 1000 }, inWindow);
+    const tokenBearing = summaryWith({ turnCount: 0, toolCallCount: 0, tokensTotal: 77 }, inWindow);
+    const allZero = summaryWith({ turnCount: 0, toolCallCount: 0, tokensTotal: 0 }, inWindow);
+    const { current } = partitionWindows([real, tokenBearing, allZero], bounds);
+    expect(current).toHaveLength(2);
+    expect(current.map((s) => s.id)).not.toContain(allZero.id);
+  });
+
+  it("week-window sessionCount drops by exactly the artifact while token inputs are unchanged", () => {
+    const now = Date.parse("2026-07-04T12:00:00.000Z");
+    const bounds = windowBounds(now);
+    const inWindow = now - 60_000;
+    const real = summaryWith({ turnCount: 2, toolCallCount: 3, tokensTotal: 1000 }, inWindow);
+    const allZero = summaryWith({ turnCount: 0, toolCallCount: 0, tokensTotal: 0 }, inWindow);
+    const with_ = partitionWindows([real, allZero], bounds).current;
+    const without = partitionWindows([real], bounds).current;
+    expect(with_).toEqual(without); // identical inputs → identical week totals downstream
+  });
+
+  it("pins the deliberate delta flip: a prior window holding ONLY all-zero artifacts is `no prior data`", async () => {
+    // Before this spec, an artifact-only prior window made hasPrior true with
+    // zero substance; after, it is honestly empty. Pinned as deliberate (I5:
+    // the week output change is asserted, not incidental).
+    const now = Date.parse("2026-07-04T12:00:00.000Z");
+    const bounds = windowBounds(now);
+    const priorTs = bounds.priorStart + 60_000;
+    const allZero = { ...summaryWith({ turnCount: 0, toolCallCount: 0, tokensTotal: 0 }, priorTs), turns: [] };
+    const { prior } = partitionWindows([allZero], bounds);
+    const priorAgg = await aggregateWindow(prior as never, false);
+    const currentAgg = await aggregateWindow([], false);
+    expect(computeDelta(currentAgg, priorAgg).hasPrior).toBe(false);
+  });
+});
+
+describe("SPEC-0041 R3 — listing stays inventory", () => {
+  it("the all-zero (non-zero-byte) transcript remains visible in the session list", async () => {
+    const rows = await adapter.listSessions({ full: true });
+    const allZero = rows.find((r) => path.basename(r.filePath) === "s-all-zero.jsonl");
+    expect(allZero).toBeDefined();
+    expect(isAggregatableSession(allZero!)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this adds

Discovery stops counting non-session artifacts as sessions: any `.jsonl` under a `subagents/` segment (below the adapter root) is excluded from top-level listing, and an exported `isAggregatableSession()` predicate floors all-zero artifacts out of aggregate windows (week digest + handoff recurrence) while `--list` stays a full inventory.

## Why it matters to users

`--list` on a real corpus carried dozens of workflow-journal rows ("0 tool calls, start time unknown") a user can't meaningfully select, every full listing paid parse work for them, and any "across your recent sessions" count was wrong.

## See it

Live acceptance on the maintainer corpus:

```
list rows: 2665 → 2576
newly excluded: 89 files — every one a subagents/workflows/**/journal.jsonl artifact
```

No genuine session excluded (kill criterion clear).

## What changed

- `src/parse/children.ts` — new `isUnderSubagents(file, root)` predicate (root-scoped: an ancestor dir literally named `subagents` never nukes a corpus)
- `src/parse/claudeCode.ts` — top-level listing filters on it (was: `agent-*.jsonl` basenames only)
- `src/aggregate/week.ts` — `isAggregatableSession()` + floor inside `partitionWindows`, the single seam week + handoff route through
- `test/fixtures/claude-code-discovery/` — committed tree reproducing the journal noise + an all-zero transcript; 10 tests

## What to review, in order

1. `src/aggregate/week.ts:52-76` — the floor predicate and its placement; the one deliberate output consequence (artifact-only prior window → honest `no prior data`) is pinned by test.
2. `src/parse/children.ts:52-67` — root-scoping of the exclusion predicate.
3. `test/parse/discovery-filter.test.ts` — incl. the `subagents`-ancestor adversarial case.

## Evidence

- `tsc`/`eslint`/`verify-goldens`/`hygiene` all 0, unmasked; affected suites green (433 passed; the 1 failure is the pre-existing `opencode 100 combinations` timeout that fails on clean `origin/main` on this machine and passes in CI).
- Spec: SPEC-0041 (approved) — Validation records S2 (6 findings, incl. a killed wrong premise), spec-PR critic round (4), and this build's critic round (4: root-scoping trap, week-delta flip pinning, downstream/rollup assertion strength) — all applied.

## Notes

Branched pre-#106; will rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)