### PR TITLE
feat: SPEC-0042 handoff resume packet — state header, coverage line, `--json`

### DIFF
--- a/docs/guide/09-handoff.md
+++ b/docs/guide/09-handoff.md
@@ -9,12 +9,34 @@ aireceipts --handoff "intermittently"
 
 ```
 handoff: Can you fix the flaky login test in src/auth/login.test.ts? It's failing intermittently in CI.
+Claude Code · Jun 15 2026 14:00:25 UTC · 4m 35s
+claude-opus-4-8 100%
+total $0.09 · 6 turns · 5 tool calls
 - Bash loop ×5: $0.08, 3m 45s wall-clock
+
+covers: 6 turns · 5 tool calls · 0 compactions · 1 waste lines
 ```
 
-The block names the session and lists the waste lines that fired, with what each
-one cost. Paste it into your next prompt (or your `CLAUDE.md`) so the agent knows
-what to avoid — here, a Bash command it re-ran five times over nearly four minutes.
+The block opens with the session's state — agent, when, how long, which models,
+what it cost, how many turns and tool calls (plus a compaction count when any
+fired) — then lists the waste lines with what each one cost, and closes with a
+`covers:` line stating exactly what the packet accounts for. Everything is
+extracted from the transcript, never summarized, so nothing can be paraphrased
+away. Paste it into your next prompt (or your `CLAUDE.md`) so the agent knows
+what to avoid — here, a Bash command it re-ran five times over nearly four
+minutes.
+
+## Machine-readable form
+
+Pass `--json` for the same packet as versioned JSON (schema in
+[docs/json-schema.md](../json-schema.md)) — for hooks, CI gates, or another
+agent's harness. It also carries `aggregates`: every waste class that fired in
+your trailing week with its distinct-session count, including classes still
+below the suggestion threshold — a near-miss is a fact, not a secret.
+
+```sh
+aireceipts --handoff "intermittently" --json
+```
 
 ## When there's nothing to say
 

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -150,6 +150,34 @@ Also carries `model`, `input`, and `output` (rates in USD per MTok) as documente
 
 `compare` also carries `schemaVersion` on its root.
 
+### Handoff envelope (`handoffJsonSchema`) — SPEC-0042
+
+`aireceipts --handoff <selector> --json`: the machine-readable resume packet. Always
+emits the full structure (empty arrays included). The attribution-only privacy fields
+(`cwd`, `gitBranch`, sidechain linkage) are structurally absent, same as every export.
+
+| Field | Type | Notes |
+|---|---|---|
+| `schemaVersion` | number | Same envelope as receipt/compare. |
+| `source` | string | Agent source enum. |
+| `sessionId` | string | Adapter-local session id. |
+| `title` | string \| null | Session title when known. |
+| `startedAtMs` | number \| null | Session start, epoch ms. |
+| `durationMs` | number \| null | Wall-clock span. |
+| `totals` | object | `tokens` (TokenUsage object) + `turnCount` + `toolCallCount`. |
+| `turnCount` | number | (totals) Assistant turns in the session. |
+| `toolCallCount` | number | (totals) Tool calls in the session. |
+| `wasteLines` | array | Same WasteLine union as the receipt. |
+| `suggestions` | array | Standing-rule suggestion strings (SPEC-0013), possibly empty. |
+| `threshold` | number | The distinct-session recurrence threshold in effect. |
+| `coverage` | object | What the packet covers, checkably: `turns`, `toolCalls`, `compactions`, `wasteLines` (all numbers). |
+| `turns` | number | (coverage) Turn count the packet covers. |
+| `toolCalls` | number | (coverage) Tool-call count the packet covers. |
+| `compactions` | number | (coverage) Compaction events in the session. |
+| `aggregates` | array | `{class, distinctSessionCount}` — exactly the waste classes that fired in the trailing recurrence window, below-threshold classes included (inspectable, not silent). |
+| `class` | string | (aggregates) Waste class name. |
+| `distinctSessionCount` | number | (aggregates) Distinct recent sessions the class fired in. |
+
 <!-- json-fields:end -->
 
 ## CSV

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -21,17 +21,18 @@ There are exactly three event types. Nothing else is ever recorded.
 | `cliVersion` | string | semver, e.g. `"0.3.1"` | From this package's own `package.json`. |
 | `os` | enum | `darwin` \| `linux` \| `win32` \| `other` | `process.platform`, collapsed to a closed set — never the raw platform string. |
 | `nodeMajor` | integer | e.g. `22` | Major Node version only. |
-| `commandClass` | enum | `receipt` \| `compare` \| `other` | Which subcommand ran — never the raw argv or any flag values. |
+| `commandClass` | enum | `receipt` \| `compare` \| `handoff` \| `other` | Which subcommand ran — never the raw argv or any flag values. |
 | `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `opencode` \| `unknown` | Which agent format was parsed, if known. |
 | `durationBucket` | enum | `<100ms` \| `100-500ms` \| `500ms-2s` \| `2-10s` \| `>10s` | Coarse bucket — never the raw millisecond count. |
 | `ok` | boolean | | Whether the run succeeded. |
+| `handoffFormat` | enum (optional) | `text` \| `json` | SPEC-0042: emission mode, present only on handoff-command runs — never content. |
 
 ### `cli_error` — one per uncaught error at the CLI's top level
 
 | Field | Type | Values | Notes |
 |---|---|---|---|
 | `errorClass` | enum | `parse_error` \| `io_error` \| `network_error` \| `validation_error` \| `unknown_error` | A small fixed taxonomy derived from the error's constructor name or a well-known Node error code — **never `error.message`**, which can contain a file path or other identifying text. |
-| `command` | enum | `receipt` \| `compare` \| `other` | Same closed taxonomy as `cli_run.commandClass`. |
+| `command` | enum | `receipt` \| `compare` \| `handoff` \| `other` | Same closed taxonomy as `cli_run.commandClass`. |
 | `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `opencode` \| `unknown` | |
 | `inPackage` | boolean | | Whether the error's top stack frame originated inside `aireceipts`'s own installed code (helps us tell "our bug" from "your environment") — the stack trace text itself is inspected internally and never leaves the process. |
 

--- a/goldens/cli/help.txt
+++ b/goldens/cli/help.txt
@@ -4,7 +4,7 @@ Usage:
   aireceipts [selector] [--json|--csv]  print a receipt (default: newest session)
   aireceipts --list [--json]            list sessions, newest first
   aireceipts compare <a> <b> [--json|--csv]  side-by-side (or stacked) comparison
-  aireceipts --handoff [selector] [--handoff-threshold N]
+  aireceipts --handoff [selector] [--handoff-threshold N] [--json]
                                         paste-ready block of fired waste lines;
                                          suggests CLAUDE.md rules for waste classes
                                          recurring in N+ recent sessions (default 3)

--- a/goldens/handoff-claude-code-loop-bash-5x.txt
+++ b/goldens/handoff-claude-code-loop-bash-5x.txt
@@ -1,0 +1,7 @@
+handoff: Can you fix the flaky login test in src/auth/login.test.ts? It's failing intermittently in CI.
+Claude Code · Jun 15 2026 14:00:25 UTC · 4m 35s
+claude-opus-4-8 100%
+total $0.09 · 6 turns · 5 tool calls
+- Bash loop ×5: $0.08, 3m 45s wall-clock
+
+covers: 6 turns · 5 tool calls · 0 compactions · 1 waste lines

--- a/scripts/goldens.mts
+++ b/scripts/goldens.mts
@@ -11,6 +11,7 @@ import type { ReceiptModel } from "../src/receipt/model.js";
 import { renderReceipt } from "../src/receipt/render.js";
 import { renderReceiptSvg, renderCompareSvg } from "../src/receipt/svg.js";
 import { renderMiniReceipt } from "../src/receipt/mini.js";
+import { renderHandoff } from "../src/receipt/handoff.js";
 import { TEMPLATE_NAMES } from "../src/receipt/blocks.js";
 import { renderPrArtifactHtml } from "../src/pr/html.js";
 import { renderPerCommitLines } from "../src/pr/perCommit.js";
@@ -77,6 +78,22 @@ for (const theme of ["light", "dark"] as const) {
 }
 const loopModel = await modelFor(LOOP.source, LOOP.path);
 check(`goldens/svg/compare-${nameOf(PRICED.path)}-vs-${nameOf(LOOP.path)}.svg`, renderCompareSvg(pricedModel, loopModel));
+
+// SPEC-0042 R1/R2 — the resume packet's state-header + coverage wording is
+// golden-pinned on the loop fixture (has waste, so the packet renders).
+{
+  const loopSession = await loadById(LOOP.source, LOOP.path);
+  if (!loopSession) {
+    console.error("goldens: failed to load loop session for handoff golden");
+    process.exit(1);
+  }
+  const counts = {
+    turns: loopSession.turns.length,
+    toolCalls: loopSession.totals.toolCallCount,
+    compactions: loopSession.compactions?.length ?? 0,
+  };
+  check(`goldens/handoff-${LOOP.source}-${nameOf(LOOP.path)}.txt`, renderHandoff(loopModel, [], counts) + "\n");
+}
 
 // SPEC-0020 R5: {grocery, datavis} × {terminal, SVG light} on the priced fixture
 // (4 new artifacts). classic's existing goldens above are the refactor's

--- a/specs/SPEC-0042-handoff-resume-packet.md
+++ b/specs/SPEC-0042-handoff-resume-packet.md
@@ -62,8 +62,9 @@ be wrong on a real session is an immediate fix or removal.
   schema composes it in-module), added to the `docs/json-schema.md` field-parity
   test like receipt/compare. Exact top-level fields (types by reference to the
   schemas already in `exportSchema.ts`):
-  `schemaVersion`, `source`, `sessionId`, `title` (nullable), `startedAt`
-  (nullable), `durationMs` (nullable), `totals` (the existing token-usage shape +
+  `schemaVersion`, `source`, `sessionId`, `title` (nullable), `startedAtMs`
+  (nullable, epoch ms — named to match the receipt/compare body's existing
+  field), `durationMs` (nullable), `totals` (the existing token-usage shape +
   `turnCount`, `toolCallCount`), `wasteLines` (existing `wasteLineSchema`),
   `suggestions: string[]`, `threshold: number`,
   `coverage: {turns, toolCalls, compactions, wasteLines}` (numbers), and
@@ -182,6 +183,17 @@ coverage); R6's empty contract clarified as the renderer's return value with the
 CLI's existing trailing newline; R3's JSON shape pinned to exact top-level field
 names (implementation may not add/rename without amending the spec); stale
 `handoff.ts:45` ref corrected to `:47`.
+
+**2026-07-04 · Implementation amendments (build-time critic round, 4 findings
+applied).** Pinned field renamed `startedAt` → `startedAtMs`: every ms-epoch
+field in the existing export bodies is `Ms`-suffixed (`receiptBody.startedAtMs`)
+and introducing the one unsuffixed exception would be the worse contract — list
+amended per R3's own rule. R1's omission contract is now literal: the header's
+agent/date/duration line is built from `format.ts` helpers with unknown parts
+OMITTED (no `start time unknown` placeholders; the receipt masthead's
+width-compaction behavior is not inherited). Telemetry allowlist tests extended
+(`handoff` class + `handoffFormat` accept/reject + pass-through). E2e asserts
+schema-parse + coverage values, not just key order.
 
 **2026-07-04 · Maintainer approval:** approved via direct maintainer directive in
 session ("go ahead and merge and also start implementing the specs") after both

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -3,7 +3,8 @@
 // 40 (above the default receipt, below every subcommand), matches `--handoff`.
 import { loadSession } from "../../index.js";
 import type { Session } from "../../parse/types.js";
-import { DEFAULT_HANDOFF_THRESHOLD, renderHandoff, standingRuleSuggestions } from "../../receipt/handoff.js";
+import { DEFAULT_HANDOFF_THRESHOLD, renderHandoff, standingRuleSuggestions, type HandoffCounts } from "../../receipt/handoff.js";
+import { toHandoffJson } from "../../receipt/json.js";
 import { buildReceiptModel } from "../../receipt/model.js";
 import { partitionWindows, windowBounds } from "../../aggregate/week.js";
 import { aggregateWaste, type WasteClassAggregate } from "../../aggregate/waste.js";
@@ -43,8 +44,21 @@ async function run(ctx: CommandContext): Promise<number> {
     return 1;
   }
   const model = await buildReceiptModel(session);
-  const suggestions = standingRuleSuggestions(await recentWasteAggregates(ctx.now()), threshold);
-  ctx.stdout.write(`${renderHandoff(model, suggestions)}\n`);
+  // SPEC-0042 R1/R2 — counts come from the loaded Session; the render stays pure.
+  const counts: HandoffCounts = {
+    turns: session.turns.length,
+    toolCalls: session.totals.toolCallCount,
+    compactions: session.compactions?.length ?? 0,
+  };
+  const aggregates = await recentWasteAggregates(ctx.now());
+  const suggestions = standingRuleSuggestions(aggregates, threshold);
+  // SPEC-0042 R3 — the global `--json` flag is honored (it was previously
+  // ignored here). JSON always emits the full structure, empty arrays included.
+  if (options.json) {
+    ctx.stdout.write(`${JSON.stringify(toHandoffJson(model, suggestions, threshold, counts, aggregates), null, 2)}\n`);
+    return 0;
+  }
+  ctx.stdout.write(`${renderHandoff(model, suggestions, counts)}\n`);
   return 0;
 }
 
@@ -56,7 +70,7 @@ export const command: CommandDef = {
   help: {
     order: 40,
     lines: [
-      "  aireceipts --handoff [selector] [--handoff-threshold N]",
+      "  aireceipts --handoff [selector] [--handoff-threshold N] [--json]",
       "                                        paste-ready block of fired waste lines;",
       "                                         suggests CLAUDE.md rules for waste classes",
       "                                         recurring in N+ recent sessions (default 3)",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,7 +25,14 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
   const started = Date.now();
   try {
     const code = await command.run(ctx);
-    recordCliRun({ command: command.name, agentType: undefined, durationMs: Date.now() - started, ok: code === 0 });
+    recordCliRun({
+      command: command.name,
+      agentType: undefined,
+      durationMs: Date.now() - started,
+      ok: code === 0,
+      // SPEC-0042 R5 — emission mode for the handoff command only (enum, never content).
+      ...(command.name === "handoff" ? { handoffFormat: options.json ? ("json" as const) : ("text" as const) } : {}),
+    });
     return code;
   } catch (err) {
     recordCliError({ command: command.name, agentType: undefined, err });

--- a/src/receipt/exportSchema.ts
+++ b/src/receipt/exportSchema.ts
@@ -138,6 +138,47 @@ export const receiptJsonSchema = z
   })
   .strict();
 
+/**
+ * SPEC-0042 R3 — `aireceipts --handoff <selector> --json`, the machine-readable
+ * resume packet. Top-level field names are pinned in the spec; the
+ * implementation may not add or rename fields without amending that list.
+ * `aggregates` carries exactly the classes `aggregateWaste` returned for the
+ * recurrence window (fired classes only, no padding) so a below-threshold
+ * recurring class is inspectable instead of silently absent. R4 privacy: the
+ * banned attribution-only fields (`cwd`, `gitBranch`, `isSidechain`,
+ * `parentSessionId`, `agentId`, `parentFilePath`) are structurally
+ * unrepresentable — `.strict()` rejects them.
+ */
+export const handoffJsonSchema = z
+  .object({
+    schemaVersion: z.literal(SCHEMA_VERSION),
+    source: z.enum(AGENT_SOURCES),
+    sessionId: z.string(),
+    title: z.string().nullable(),
+    startedAtMs: z.number().nullable(),
+    durationMs: z.number().nullable(),
+    totals: z
+      .object({
+        tokens: tokenUsageSchema,
+        turnCount: z.number(),
+        toolCallCount: z.number(),
+      })
+      .strict(),
+    wasteLines: z.array(wasteLineSchema),
+    suggestions: z.array(z.string()),
+    threshold: z.number(),
+    coverage: z
+      .object({
+        turns: z.number(),
+        toolCalls: z.number(),
+        compactions: z.number(),
+        wasteLines: z.number(),
+      })
+      .strict(),
+    aggregates: z.array(z.object({ class: z.string(), distinctSessionCount: z.number() }).strict()),
+  })
+  .strict();
+
 /** `aireceipts compare <a> <b> --json` — two receipt bodies plus a factual delta line (R3; no ranking field, I6). */
 export const compareJsonSchema = z
   .object({
@@ -201,5 +242,6 @@ export function collectFieldNames(schema: z.ZodTypeAny, into: Set<string> = new 
 /** The complete documented-field set across every JSON export surface — what the doc parity test asserts against. */
 export function allExportFieldNames(): Set<string> {
   const names = collectFieldNames(receiptJsonSchema);
-  return collectFieldNames(compareJsonSchema, names);
+  collectFieldNames(compareJsonSchema, names);
+  return collectFieldNames(handoffJsonSchema, names);
 }

--- a/src/receipt/handoff.ts
+++ b/src/receipt/handoff.ts
@@ -9,7 +9,7 @@
 // data (I1 — never model-generated); no line judges the agent or names a
 // model (I6).
 import type { WasteClassAggregate } from "../aggregate/waste.js";
-import { formatDuration, formatInt, formatUsd } from "./format.js";
+import { formatAbsoluteUtc, formatDuration, formatInt, formatUsd } from "./format.js";
 import type { ReceiptModel, WasteLine } from "./model.js";
 
 const TRIVIAL_SPANS_LABEL = "≈ re-priced eligible trivial spans";
@@ -73,26 +73,85 @@ export function standingRuleSuggestions(
 }
 
 /**
+ * SPEC-0042 R1/R2 — the session counts the resume-packet header and coverage
+ * line quote. Computed by the CLI from the loaded `Session` (turn/tool-call/
+ * compaction counts live there, not on `ReceiptModel`); the render stays pure.
+ */
+export interface HandoffCounts {
+  turns: number;
+  toolCalls: number;
+  compactions: number;
+}
+
+/**
+ * SPEC-0042 R1 — the state-header lines, rendered only when waste renders and
+ * counts were supplied. Every line quotes an existing model field or count —
+ * extraction, never narration (I1). A missing field omits its line, never a
+ * placeholder. Wording is golden-pinned.
+ */
+function stateHeaderLines(model: ReceiptModel, counts: HandoffCounts): string[] {
+  // R1 omission contract: unknown start/duration are OMITTED from the line —
+  // never a placeholder (deliberately NOT the receipt masthead's
+  // `start time unknown` treatment, and no width compaction).
+  const agentParts = [model.agentLabel];
+  if (model.startedAtMs !== undefined) {
+    agentParts.push(formatAbsoluteUtc(model.startedAtMs));
+  }
+  if (model.durationMs !== undefined) {
+    agentParts.push(formatDuration(model.durationMs));
+  }
+  const lines: string[] = [agentParts.join(" · ")];
+  if (model.modelMix.length > 0) {
+    lines.push(model.modelMix.map((m) => `${m.model} ${Math.round(m.tokenShare * 100)}%`).join(" · "));
+  }
+  const totalPart = model.totalUsd !== null ? `total $${formatUsd(model.totalUsd)}` : `total ${formatInt(model.sessionTotalTokens.total)} tok`;
+  lines.push(`${totalPart} · ${formatInt(counts.turns)} turns · ${formatInt(counts.toolCalls)} tool calls`);
+  if (counts.compactions > 0) {
+    lines.push(`compactions: ${formatInt(counts.compactions)}`);
+  }
+  return lines;
+}
+
+/** SPEC-0042 R2 — the packet states what it covers, checkably (fixed format, counts only). */
+function coverageLine(model: ReceiptModel, counts: HandoffCounts): string {
+  return `covers: ${formatInt(counts.turns)} turns · ${formatInt(counts.toolCalls)} tool calls · ${formatInt(counts.compactions)} compactions · ${formatInt(model.wasteLines.length)} waste lines`;
+}
+
+/**
  * Exactly `"nothing to hand off"` when nothing fired and nothing is suggested —
  * caller exits 0, per spec. `suggestions` (SPEC-0013 R3) appends a trailing,
  * clearly-labeled section only when non-empty; when it is empty the output is
  * byte-identical to pre-SPEC-0013 behavior (R5).
+ *
+ * SPEC-0042 R1/R2/R6: when `counts` is supplied AND at least one waste line
+ * renders, the block opens with the state header and closes with the coverage
+ * line. Suggestions-only output (zero waste) stays byte-identical to
+ * SPEC-0013 — the packet is a briefing about this session's problems, not a
+ * second receipt.
  */
-export function renderHandoff(model: ReceiptModel, suggestions: string[] = []): string {
+export function renderHandoff(model: ReceiptModel, suggestions: string[] = [], counts?: HandoffCounts): string {
   const hasWaste = model.wasteLines.length > 0;
   if (!hasWaste && suggestions.length === 0) {
     return "nothing to hand off";
   }
+  const packet = counts !== undefined && hasWaste;
   const lines: string[] = [];
   if (hasWaste) {
     const label = model.title ?? model.sessionId;
-    lines.push(`handoff: ${label}`, ...model.wasteLines.map(handoffBullet));
+    lines.push(`handoff: ${label}`);
+    if (packet && counts !== undefined) {
+      lines.push(...stateHeaderLines(model, counts));
+    }
+    lines.push(...model.wasteLines.map(handoffBullet));
   }
   if (suggestions.length > 0) {
     if (hasWaste) {
       lines.push("");
     }
     lines.push(SUGGESTION_HEADER, ...suggestions.map((s) => `- ${s}`));
+  }
+  if (packet && counts !== undefined) {
+    lines.push("", coverageLine(model, counts));
   }
   return lines.join("\n");
 }

--- a/src/receipt/json.ts
+++ b/src/receipt/json.ts
@@ -10,6 +10,8 @@ import type { SessionSummary, TokenUsage } from "../parse/types.js";
 import { compareDeltaLine } from "./compare.js";
 import { SCHEMA_VERSION } from "./exportSchema.js";
 import type { ModelMixEntry, PriceRowUsed, ReceiptModel, ToolRow, WasteLine } from "./model.js";
+import type { WasteClassAggregate } from "../aggregate/waste.js";
+import type { HandoffCounts } from "./handoff.js";
 
 function tokenUsageJson(t: TokenUsage) {
   return {
@@ -150,5 +152,44 @@ export function summaryToJson(summary: SessionSummary) {
     },
     filePath: summary.filePath,
     unpriceable: summary.unpriceable ?? false,
+  };
+}
+
+/**
+ * SPEC-0042 R3 — the machine-readable resume packet. Fixed key order = the
+ * schema (I5); validated against `handoffJsonSchema`. Always emits the full
+ * structure (empty arrays included) — machine consumers need shape, not
+ * sentinels (R6). `aggregates` is exactly what `aggregateWaste` returned for
+ * the recurrence window, below-threshold classes included.
+ */
+export function toHandoffJson(
+  model: ReceiptModel,
+  suggestions: string[],
+  threshold: number,
+  counts: HandoffCounts,
+  aggregates: WasteClassAggregate[],
+) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    source: model.source,
+    sessionId: model.sessionId,
+    title: model.title ?? null,
+    startedAtMs: model.startedAtMs ?? null,
+    durationMs: model.durationMs ?? null,
+    totals: {
+      tokens: tokenUsageJson(model.sessionTotalTokens),
+      turnCount: counts.turns,
+      toolCallCount: counts.toolCalls,
+    },
+    wasteLines: model.wasteLines.map(wasteLineJson),
+    suggestions,
+    threshold,
+    coverage: {
+      turns: counts.turns,
+      toolCalls: counts.toolCalls,
+      compactions: counts.compactions,
+      wasteLines: model.wasteLines.length,
+    },
+    aggregates: aggregates.map((a) => ({ class: a.class, distinctSessionCount: a.distinctSessionCount })),
   };
 }

--- a/src/telemetry/helpers.ts
+++ b/src/telemetry/helpers.ts
@@ -32,7 +32,7 @@ export function bucketDuration(ms: number): DurationBucketValue {
   return ">10s";
 }
 
-/** Maps a CLI subcommand name to R2's closed 3-value taxonomy — never the raw command line or its arguments. */
+/** Maps a CLI subcommand name to R2's closed 4-value taxonomy — never the raw command line or its arguments. */
 export function toCommandClass(command: string): CommandClassValue {
   const normalized = command.trim().toLowerCase();
   if (normalized === "receipt" || normalized === "") {
@@ -40,6 +40,10 @@ export function toCommandClass(command: string): CommandClassValue {
   }
   if (normalized === "compare") {
     return "compare";
+  }
+  // SPEC-0042 R5 — handoff adoption must be measurable, not folded into `other`.
+  if (normalized === "handoff") {
+    return "handoff";
   }
   return "other";
 }

--- a/src/telemetry/index.test.ts
+++ b/src/telemetry/index.test.ts
@@ -41,6 +41,23 @@ describe("recordCliRun builds a valid cli_run event from raw runtime inputs", ()
   });
 });
 
+describe("SPEC-0042 R5 — handoffFormat pass-through", () => {
+  it("records the enum for handoff runs and validates against the strict schema", () => {
+    recordCliRun({ command: "handoff", agentType: undefined, durationMs: 10, ok: true, handoffFormat: "json" });
+    const [event] = peekQueuedEvents();
+    expect((event?.properties as Record<string, unknown>).commandClass).toBe("handoff");
+    expect((event?.properties as Record<string, unknown>).handoffFormat).toBe("json");
+    expect(validateEvent(event as TelemetryEvent)).toBe(true);
+  });
+
+  it("omits the field entirely when not supplied (absent, not null)", () => {
+    recordCliRun({ command: "receipt", agentType: undefined, durationMs: 10, ok: true });
+    const [event] = peekQueuedEvents();
+    expect("handoffFormat" in (event?.properties as Record<string, unknown>)).toBe(false);
+    expect(validateEvent(event as TelemetryEvent)).toBe(true);
+  });
+});
+
 describe("recordCliError builds a valid cli_error event from raw runtime inputs", () => {
   it("enqueues one event that passes schema validation", () => {
     const input: RecordCliErrorInput = {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -20,6 +20,8 @@ export interface RecordCliRunInput {
   agentType: AgentSource | undefined;
   durationMs: number;
   ok: boolean;
+  /** SPEC-0042 R5 — set only for the handoff command; enum, never content. */
+  handoffFormat?: "text" | "json";
 }
 
 /** Records one `cli_run` event (R2). Call once per CLI invocation, right before the process would otherwise exit. */
@@ -34,6 +36,7 @@ export function recordCliRun(input: RecordCliRunInput): void {
       agentType: toAgentTypeTelemetry(input.agentType),
       durationBucket: bucketDuration(input.durationMs),
       ok: input.ok,
+      ...(input.handoffFormat !== undefined ? { handoffFormat: input.handoffFormat } : {}),
     },
   });
 }

--- a/src/telemetry/schemas.test.ts
+++ b/src/telemetry/schemas.test.ts
@@ -59,7 +59,7 @@ describe("R2: valid events pass their schema", () => {
   });
 
   it("R2: commandClass/command enum covers every CLI command class", () => {
-    for (const value of ["receipt", "compare", "other"] as const) {
+    for (const value of ["receipt", "compare", "handoff", "other"] as const) {
       expect(
         cliRunPropertiesSchema.safeParse({
           cliVersion: "0.1.0",
@@ -139,5 +139,28 @@ describe("R3: leakage fixtures — banned content is structurally rejected", () 
 
   it("validateEvent returns false (never throws) for an unrecognized event name", () => {
     expect(validateEvent({ name: "unknown_event" as never, properties: {} as never })).toBe(false);
+  });
+});
+
+describe("SPEC-0042 R5 — handoffFormat allowlist", () => {
+  const base = {
+    cliVersion: "0.1.0",
+    os: "linux" as const,
+    nodeMajor: 20,
+    commandClass: "handoff" as const,
+    agentType: "unknown" as const,
+    durationBucket: "<100ms" as const,
+    ok: true,
+  };
+
+  it("accepts text/json and absence", () => {
+    expect(cliRunPropertiesSchema.safeParse({ ...base, handoffFormat: "text" }).success).toBe(true);
+    expect(cliRunPropertiesSchema.safeParse({ ...base, handoffFormat: "json" }).success).toBe(true);
+    expect(cliRunPropertiesSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("rejects any non-enum value (never content)", () => {
+    expect(cliRunPropertiesSchema.safeParse({ ...base, handoffFormat: "markdown" }).success).toBe(false);
+    expect(cliRunPropertiesSchema.safeParse({ ...base, handoffFormat: "/home/user/secret" }).success).toBe(false);
   });
 });

--- a/src/telemetry/schemas.ts
+++ b/src/telemetry/schemas.ts
@@ -16,7 +16,7 @@ import { z } from "zod";
 export const OS_VALUES = ["darwin", "linux", "win32", "other"] as const;
 export type OsValue = (typeof OS_VALUES)[number];
 
-export const COMMAND_CLASS_VALUES = ["receipt", "compare", "other"] as const;
+export const COMMAND_CLASS_VALUES = ["receipt", "compare", "handoff", "other"] as const;
 export type CommandClassValue = (typeof COMMAND_CLASS_VALUES)[number];
 
 export const AGENT_TYPE_VALUES = ["claude-code", "codex", "cursor", "gemini", "opencode", "unknown"] as const;
@@ -45,6 +45,10 @@ const signatureHashSchema = z.string().regex(/^[0-9a-f]{64}$/, "signatureHash mu
 /** An internal per-adapter constant (e.g. `"1"`), not anything read from a transcript. */
 const adapterVersionSchema = z.string().regex(/^[a-zA-Z0-9_.-]{1,32}$/, "adapterVersion must be a short opaque token");
 
+/** SPEC-0042 R5 — emission mode of the handoff command only; enum, never content. */
+export const HANDOFF_FORMAT_VALUES = ["text", "json"] as const;
+export type HandoffFormatValue = (typeof HANDOFF_FORMAT_VALUES)[number];
+
 export const cliRunPropertiesSchema = z
   .object({
     cliVersion: cliVersionSchema,
@@ -54,6 +58,8 @@ export const cliRunPropertiesSchema = z
     agentType: z.enum(AGENT_TYPE_VALUES),
     durationBucket: z.enum(DURATION_BUCKET_VALUES),
     ok: z.boolean(),
+    /** SPEC-0042 R5 — present only on handoff-command runs. */
+    handoffFormat: z.enum(HANDOFF_FORMAT_VALUES).optional(),
   })
   .strict();
 export type CliRunProperties = z.infer<typeof cliRunPropertiesSchema>;

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { handoffJsonSchema } from "../../src/receipt/exportSchema.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const fixturesDir = path.join(repoRoot, "test", "fixtures");
@@ -424,6 +425,39 @@ describe("built CLI e2e", () => {
     expect(parsed.schemaVersion).toBe(1);
     expect(Object.keys(parsed).sort()).toEqual(["a", "b", "delta", "schemaVersion"]);
     expect(String(parsed.delta)).not.toMatch(/better|worse|winner|superior|inferior/i);
+  });
+
+  it("SPEC-0042: --handoff --json emits the schema-valid resume packet; text form carries header + coverage", async () => {
+    const home = await makeHome();
+    await stageClaudeSession(home, "loop-bash-5x.jsonl", "loop.jsonl");
+
+    const jsonRun = await runCli(["--handoff", "--json"], home);
+    expect(jsonRun.code, jsonRun.stderr).toBe(0);
+    const parsed = JSON.parse(jsonRun.stdout) as Record<string, unknown>;
+    expect(() => handoffJsonSchema.parse(parsed)).not.toThrow();
+    expect(parsed.coverage).toEqual({ turns: 6, toolCalls: 5, compactions: 0, wasteLines: 1 });
+    expect(parsed.schemaVersion).toBe(1);
+    expect(Object.keys(parsed)).toEqual([
+      "schemaVersion",
+      "source",
+      "sessionId",
+      "title",
+      "startedAtMs",
+      "durationMs",
+      "totals",
+      "wasteLines",
+      "suggestions",
+      "threshold",
+      "coverage",
+      "aggregates",
+    ]);
+    expect(jsonRun.stdout).not.toMatch(/"(cwd|gitBranch|isSidechain|parentSessionId|agentId|parentFilePath)"/);
+
+    const textRun = await runCli(["--handoff"], home);
+    expect(textRun.code, textRun.stderr).toBe(0);
+    expect(textRun.stdout).toContain("handoff: ");
+    expect(textRun.stdout).toContain("total $");
+    expect(textRun.stdout).toContain("covers: 6 turns · 5 tool calls · 0 compactions · 1 waste lines");
   });
 
   it("treats malformed budget config as stderr-only advisory and still renders the receipt", async () => {

--- a/test/receipt/handoff-packet.test.ts
+++ b/test/receipt/handoff-packet.test.ts
@@ -1,0 +1,143 @@
+// SPEC-0042 — the resume packet: state header (R1), coverage line (R2), the
+// `--json` shape (R3), privacy bounds (R4), and byte-preserved SPEC-0013
+// contracts (R6). Render-layer tests; CLI dispatch is covered e2e in
+// test/cli-e2e/built-cli.test.ts.
+import { describe, expect, it } from "vitest";
+import type { WasteClassAggregate } from "../../src/aggregate/waste.js";
+import { handoffJsonSchema } from "../../src/receipt/exportSchema.js";
+import { renderHandoff, type HandoffCounts } from "../../src/receipt/handoff.js";
+import { toHandoffJson } from "../../src/receipt/json.js";
+import type { ReceiptModel, WasteLine } from "../../src/receipt/model.js";
+
+const usage = (input: number) => ({ input, output: 0, cacheRead: 0, cacheCreation: 0, total: input });
+
+const stuckLoop: WasteLine = { kind: "stuck-loop", tool: "Bash", runLength: 5, usd: 0.08, tokens: usage(1000), wallClockMs: 225_000 };
+
+function model(overrides: Partial<ReceiptModel> = {}): ReceiptModel {
+  return {
+    agentLabel: "Claude Code",
+    source: "claude-code",
+    sessionId: "/fake/s1.jsonl",
+    title: "Fix the flaky login test",
+    startedAtMs: Date.UTC(2026, 5, 15, 14, 0, 25),
+    durationMs: 275_000,
+    modelMix: [{ model: "claude-opus-4-8", tokens: usage(9000), tokenShare: 1 }],
+    toolRows: [],
+    totalUsd: 0.09,
+    totalTokens: usage(9000),
+    sessionTotalTokens: usage(9000),
+    wasteLines: [stuckLoop],
+    caveats: [],
+    priceDelta: null,
+    methodology: "m",
+    priceRowsUsed: [],
+    unpriceable: false,
+    ...overrides,
+  } as ReceiptModel;
+}
+
+const counts: HandoffCounts = { turns: 6, toolCalls: 5, compactions: 2 };
+
+describe("SPEC-0042 R1 — state header", () => {
+  it("renders header lines in fixed order before the bullets and closes with coverage", () => {
+    const out = renderHandoff(model(), [], counts);
+    expect(out.split("\n")).toEqual([
+      "handoff: Fix the flaky login test",
+      "Claude Code · Jun 15 2026 14:00:25 UTC · 4m 35s",
+      "claude-opus-4-8 100%",
+      "total $0.09 · 6 turns · 5 tool calls",
+      "compactions: 2",
+      "- Bash loop ×5: $0.08, 3m 45s wall-clock",
+      "",
+      "covers: 6 turns · 5 tool calls · 2 compactions · 1 waste lines",
+    ]);
+  });
+
+  it("omits the model-mix line when empty and the compaction line when zero", () => {
+    const out = renderHandoff(model({ modelMix: [] }), [], { ...counts, compactions: 0 });
+    expect(out).not.toContain("%");
+    expect(out).not.toContain("compactions:");
+    expect(out).toContain("covers: 6 turns · 5 tool calls · 0 compactions · 1 waste lines");
+  });
+
+  it("shows tokens, never `$`, when the session is unpriced (I2)", () => {
+    const out = renderHandoff(model({ totalUsd: null, unpriceable: true }), [], counts);
+    expect(out).toContain("total 9,000 tok · 6 turns · 5 tool calls");
+    expect(out).not.toContain("total $");
+  });
+});
+
+describe("SPEC-0042 R6 — SPEC-0013 contracts preserved byte-for-byte", () => {
+  it("suggestions-only output ignores counts entirely", () => {
+    const noWaste = model({ wasteLines: [] });
+    const withCounts = renderHandoff(noWaste, ["rule one"], counts);
+    const without = renderHandoff(noWaste, ["rule one"]);
+    expect(withCounts).toBe(without);
+    expect(withCounts).not.toContain("covers:");
+  });
+
+  it("stays exactly `nothing to hand off` when nothing fired, counts or not", () => {
+    const noWaste = model({ wasteLines: [] });
+    expect(renderHandoff(noWaste, [], counts)).toBe("nothing to hand off");
+  });
+
+  it("waste without counts renders the pre-packet block (no header, no coverage)", () => {
+    const out = renderHandoff(model(), []);
+    expect(out.split("\n")).toEqual([
+      "handoff: Fix the flaky login test",
+      "- Bash loop ×5: $0.08, 3m 45s wall-clock",
+    ]);
+  });
+});
+
+describe("SPEC-0042 R3/R4 — machine-readable packet", () => {
+  const aggregates: WasteClassAggregate[] = [
+    { class: "stuck-loop", cost: 0.08, tokens: usage(1000), distinctSessionCount: 2 },
+  ] as WasteClassAggregate[];
+
+  it("validates against handoffJsonSchema with the pinned key order", () => {
+    const json = toHandoffJson(model(), ["rule one"], 3, counts, aggregates);
+    expect(() => handoffJsonSchema.parse(json)).not.toThrow();
+    expect(Object.keys(json)).toEqual([
+      "schemaVersion",
+      "source",
+      "sessionId",
+      "title",
+      "startedAtMs",
+      "durationMs",
+      "totals",
+      "wasteLines",
+      "suggestions",
+      "threshold",
+      "coverage",
+      "aggregates",
+    ]);
+  });
+
+  it("keeps a below-threshold fired class inspectable in aggregates while absent from suggestions", () => {
+    const json = toHandoffJson(model(), [], 3, counts, aggregates);
+    expect(json.aggregates).toEqual([{ class: "stuck-loop", distinctSessionCount: 2 }]);
+    expect(json.suggestions).toEqual([]);
+  });
+
+  it("emits the full structure with empty arrays on an empty session (no sentinels)", () => {
+    const json = toHandoffJson(model({ wasteLines: [] }), [], 3, { turns: 0, toolCalls: 0, compactions: 0 }, []);
+    expect(() => handoffJsonSchema.parse(json)).not.toThrow();
+    expect(json.wasteLines).toEqual([]);
+    expect(json.aggregates).toEqual([]);
+    expect(json.coverage).toEqual({ turns: 0, toolCalls: 0, compactions: 0, wasteLines: 0 });
+  });
+
+  it("R4: none of the six banned attribution fields appear in text or JSON", () => {
+    const banned = ["cwd", "gitBranch", "isSidechain", "parentSessionId", "agentId", "parentFilePath"];
+    const json = JSON.stringify(toHandoffJson(model(), ["rule"], 3, counts, aggregates));
+    const text = renderHandoff(model(), ["rule"], counts);
+    for (const key of banned) {
+      expect(json).not.toContain(`"${key}"`);
+      expect(text).not.toContain(key);
+    }
+    // adversarial: a smuggled extra key is structurally rejected by .strict()
+    const withExtra = { ...toHandoffJson(model(), [], 3, counts, []), cwd: "/leak" };
+    expect(() => handoffJsonSchema.parse(withExtra)).toThrow();
+  });
+});


### PR DESCRIPTION
## What this adds

`--handoff` becomes a deterministic resume packet: a state header extracted from fields the session already carries, a verifiable `covers:` line, and a machine-readable `--handoff --json` surface (the global flag was previously ignored by this command). Telemetry ships with the feature (`commandClass: handoff` + `handoffFormat` enum).

## Why it matters to users

The handoff block previously told you what was wasted but not what the session *was* — a successor session or teammate still re-derived duration, models, cost, and context churn. Now it's a paste-ready briefing, and hooks/CI can consume it as versioned JSON instead of parsing prose. Extraction, never summarization — the deterministic answer to LLM-generated handoffs' fidelity loss.

## See it

Real maintainer session (dogfood — this satisfies the spec's success criterion):

```
handoff: rewrite-rule-registry-stage1
Claude Code · Jun 14 2026 23:08 UTC · 173h 39m
claude-opus-4-8 100% · <synthetic> 0%
total $4,059.91 · 11,096 turns · 4,362 tool calls
compactions: 8
- TaskOutput loop ×3: $1.19, 30m 12s wall-clock
- ≈ re-priced eligible trivial spans: $4.16 (64 turns → claude-haiku-4-5)

suggested CLAUDE.md rules (recurring across recent sessions — paste manually):
- For short acknowledgments and single-line replies, keep responses minimal — do not restate context.

covers: 11,096 turns · 4,362 tool calls · 8 compactions · 2 waste lines
```

Note the `compactions: 8` line — visible on Codex sessions too thanks to SPEC-0040 (#106).

## What changed

- `src/receipt/handoff.ts` — `HandoffCounts`, state header (omission semantics, no placeholders), coverage line; SPEC-0013 outputs byte-preserved
- `src/receipt/exportSchema.ts` + `src/receipt/json.ts` — strict `handoffJsonSchema` + `toHandoffJson` (fixed key order), registered in the docs field-parity walker
- `src/cli/commands/handoff.ts` — counts from the loaded `Session`, `--json` wiring, help line
- `src/telemetry/*` + `src/cli/index.ts` — `handoff` command class, optional `handoffFormat` enum, recorded centrally in `main()`
- Docs: guide 09, json-schema.md, telemetry.md; new golden `goldens/handoff-claude-code-loop-bash-5x.txt` + regenerated `--help` golden
- Spec amendment recorded in Validation: pinned `startedAt` → `startedAtMs` (consistency with every existing export body)

## What to review, in order

1. `src/receipt/handoff.ts` — packet gating (`counts` + waste) and R6 byte-compat; the suggestions-only path must be untouched.
2. `src/receipt/exportSchema.ts` handoffJsonSchema — the public contract.
3. `src/cli/index.ts` telemetry pass-through — allowlist discipline (enum only, absent when not handoff).
4. `goldens/handoff-claude-code-loop-bash-5x.txt` — deliberate new output.

## Evidence

- `tsc`/`eslint`/`verify-goldens`/`determinism(10x)`/`spec-lint`/`hygiene` all 0, unmasked; 1152/1154 vitest locally (the 2 failures are the known pre-existing 100-iteration timeout tests that fail on clean `origin/main` on this machine and pass in CI); new e2e case schema-parses the packet through the built CLI.
- Spec: SPEC-0042 (approved) — Validation now records S2 (8 findings), spec-PR critic (5), and this build's critic round (4, incl. a field-name BLOCKER resolved by recorded spec amendment) — all applied.

## Notes

`status: building` flip and ledger update ride with the release sweep per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)