### PR TITLE
docs: aireceipts-cli is published — drop pre-release caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ accounts, no servers, nothing leaves your machine.
 npx aireceipts-cli          # receipt for your newest session
 ```
 
-> **Status**: source-first pre-release. Until the npm package is published:
-> `git clone … && npm install && npm run build && node dist/cli.js`
+Or install it: `npm i -g aireceipts-cli`, then the command is `aireceipts`.
 
 What you get back — the hero image above, as the bytes your terminal prints:
 

--- a/docs/guide/02-install.md
+++ b/docs/guide/02-install.md
@@ -21,18 +21,8 @@ npm install -g aireceipts-cli
 aireceipts            # now available directly
 ```
 
-> **Pre-release note.** Until the npm package is published, install from source:
->
-> ```sh
-> git clone https://github.com/<owner>/receipts
-> cd receipts
-> npm install
-> npm run build
-> node dist/cli.js        # this is your `aireceipts`
-> ```
->
-> The commands in these docs are written as `aireceipts …`; with a source
-> checkout, read that as `node dist/cli.js …`.
+> **Prefer not to install?** `npx aireceipts-cli` runs the latest release without
+> a global install — the command inside is the same `aireceipts`.
 
 ## Upgrade
 

--- a/site/docs/02-install.html
+++ b/site/docs/02-install.html
@@ -344,7 +344,7 @@ footer{
 <pre class="doc-code"><code class="language-sh">npm install -g aireceipts-cli
 aireceipts            # now available directly</code></pre>
 
-<blockquote><strong>Pre-release note.</strong> Until the npm package is published, install from source:  <code></code><code>sh git clone https://github.com/&lt;owner&gt;/receipts cd receipts npm install npm run build node dist/cli.js        # this is your </code>aireceipts<code> </code><code></code>  The commands in these docs are written as <code>aireceipts …</code>; with a source checkout, read that as <code>node dist/cli.js …</code>.</blockquote>
+<blockquote><strong>Prefer not to install?</strong> <code>npx aireceipts-cli</code> runs the latest release without a global install — the command inside is the same <code>aireceipts</code>.</blockquote>
 
 <h2 id="upgrade">Upgrade</h2>
 


### PR DESCRIPTION
## What this adds

`aireceipts-cli@0.1.0` is **live on npm** (published 2026-07-04; `npx -y aireceipts-cli` verified downloading + running the published binary). The 'source-first pre-release / until the npm package is published' notes are now false, so they're removed:

- **README Install**: the pre-release status blockquote is gone; adds `npm i -g aireceipts-cli` alongside the `npx` line.
- **docs/guide/02-install.md**: the install-from-source git-clone block becomes a short 'prefer not to install? `npx aireceipts-cli`' note.
- **site/docs/02-install.html** synced to match (targeted, no unrelated regen drift).

README guard 9/9, hygiene OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)