### PR TITLE
chore: size 100-iteration test ceilings for macOS QoS throttling

### DIFF
--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -339,6 +339,10 @@ describe("built CLI e2e", () => {
     expect(textResult.stdout).not.toContain("$");
   });
 
+  // Children spawned from vitest fork workers inherit macOS background QoS and
+  // run I/O-throttled ~20x on loaded dev Macs (measured: an identical spawn is
+  // 3.4s outside vitest, ~70s inside). CI (Linux) is unaffected. Ceiling sized
+  // for the throttled worst case; the test asserts correctness, not speed.
   it("loads 100 simulated opencode sessions through built CLI and samples receipt selectors", async () => {
     const home = await makeHome();
     await stageOpenCodeDb(home, "simulated-100.db");
@@ -388,7 +392,7 @@ describe("built CLI e2e", () => {
       expect(Object.keys(tools).sort()).toEqual(toolNames.sort());
       expect(receipt.toolRows.reduce((sum, row) => sum + row.callCount, 0)).toBe(Math.max(1, sim.tools.length));
     }
-  }, 45_000);
+  }, 600_000);
 
   it("keeps output flag precedence stable: SVG beats CSV/JSON, and CSV beats JSON", async () => {
     const home = await makeHome();

--- a/test/parse/opencode.test.ts
+++ b/test/parse/opencode.test.ts
@@ -553,6 +553,10 @@ describe.skipIf(!hasNodeSqlite)("OpenCodeAdapter", () => {
     });
   });
 
+  // 100 SQLite round-trips run I/O-throttled under vitest fork workers on macOS
+  // (background QoS inheritance; also slow when the adapter takes the sqlite3
+  // CLI path and shells out per query). Ceiling sized for the throttled worst
+  // case — release preflight runs this locally, not just on CI's fast path.
   it("validates 100 generated opencode schema/model/tool combinations", async () => {
     const dir = tempDir();
     dirs.push(dir);
@@ -591,7 +595,7 @@ describe.skipIf(!hasNodeSqlite)("OpenCodeAdapter", () => {
       }
       expect(receipt.toolRows.reduce((sum, row) => sum + row.callCount, 0)).toBe(Math.max(1, sim.tools.length));
     }
-  });
+  }, 300_000);
 
   it("degrades invalid SQLite files to no sessions and null loads", async () => {
     const dir = tempDir();


### PR DESCRIPTION
## What this adds

Raises the two 100-iteration tests' timeout ceilings (opencode combinations 20s → 300s; built-CLI 100-session e2e 45s → 600s), with the mechanism documented at each site.

## Why it matters to users

Not user-facing — it unblocks `preflight-release.mjs` (which runs the full suite locally) on maintainer hardware, so local release gates stop failing for environmental reasons.

## See it

Root-caused during the v0.1.0 release board: an identical `dist/cli.js --list --json` spawn measures **3.4s outside vitest vs ~70s inside a vitest fork worker** on macOS (nice-independent) — children inherit background QoS and get I/O-throttled ~20×. CI (Linux) is unaffected and has always been green on these tests.

## What changed

- `test/parse/opencode.test.ts` — 300s ceiling + comment
- `test/cli-e2e/built-cli.test.ts` — 600s ceiling + comment

## What to review, in order

1. The comments — do they say exactly what was measured, no more.
2. That assertions are untouched (correctness gate unchanged; only the hang-watchdog latency moves).

## Evidence

`tsc`/`eslint` 0; the opencode test passes locally at 300s; measurement methodology in the PR description. Codex critic: 1 LOW (comment precision) — applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)