### PR TITLE
fix: strip terminal escapes from transcript text; fix --list --json empty

### DIFF
--- a/docs/releases/0.1.0-verdict.md
+++ b/docs/releases/0.1.0-verdict.md
@@ -1,0 +1,73 @@
+# Release verdict — aireceipts-cli v0.1.0
+
+- **Candidate SHA:** `d64e5f2` (main tip at board start; CI green on the exact SHA —
+  verify(20), verify(22), cli-e2e, preflight all success)
+- **Published:** 2026-07-04T23:54:24Z to npm as `aireceipts-cli@0.1.0` — the manual
+  first publish documented in `docs/internal/releasing.md` (npm requires an existing
+  package before trusted-publisher/OIDC can be configured; every later release goes
+  through `release-publish.yml` with `--provenance`).
+- **Board timing note:** the publish landed mid-board (one minute after the lead's
+  pre-board registry check 404'd). This verdict is therefore a **post-publish
+  validation** of what shipped, not a prospective gate. The PM persona's registry
+  404 was propagation lag; re-verified live by the lead:
+  `npm view aireceipts-cli time` → created 2026-07-04T23:54:24Z.
+
+## Panel votes
+
+| Persona | Vote | Core reasoning |
+|---|---|---|
+| Product Manager | NO-GO | Runbook described the publish in past tense before it happened; pre-release notice self-contradiction; undocumented `benchmark` stub in `--help`; spec-file license mentions (MIT) contradict Apache-2.0; stale `NOTICE` repo URL; ledger not flipped |
+| Engineering Manager | GO | CI green on exact SHA; 0 npm-audit vulnerabilities; 2 runtime deps; kill switches documented; zero open issues; missing bad-release runbook filed as fast-follow |
+| Designer | GO | 95 goldens byte-identical; readme-guard 9/9; SVG light/dark + wordmark rasterized and inspected clean; one grammar nit (`1 waste lines` in the handoff `covers:` line) |
+| QA / adversarial | NO-GO | **HIGH:** ANSI/OSC escape injection via transcript-derived title (raw `\x1b` bytes reach the terminal; OSC-0 title rename confirmed); **MEDIUM:** `--list --json` on zero sessions emits non-JSON to stdout with exit 0 (every other empty path is stderr + exit 1); LOW: unknown flags silently become selectors. I2 held under all adversarial pressure — no fabricated dollar anywhere |
+| Docs panel | PASS-WITH-FIXES | Cold-reader: `git clone …` ellipsis (no URL) in README; pre-release notice staleness (fixed post-publish in #109); duplicate 30-line example |
+
+## Mechanical checks (lead, unmasked)
+
+- Full gate on the SHA: `tsc` 0 · `eslint` 0 · `verify-goldens` 0 (95 artifacts) ·
+  `determinism ×10` 0 · `spec-lint` 0 · `hygiene` 0.
+- `vitest`: green except two 100-iteration tests whose local failures were traced
+  during this board to **macOS priority throttling** — zsh `BG_NICE` and niced
+  shells run vitest workers at nice 5, and spawned CLI children inherit background
+  QoS, making fs-bound work ~20× slower (3.4s → 70s for an identical spawn). CI is
+  unaffected and green; timeout ceilings raised (20s/45s → 300s) on branch
+  `chore/hundred-iteration-test-timeouts` as a follow-up PR.
+- Packed-tarball smoke + `npm publish` file-list: covered by `preflight-release.mjs`
+  and CI's preflight job on the SHA (success). Tarball allowlist carries no
+  fixtures/transcripts/internal docs (`NOTICE` is repo-only).
+- gitleaks: full-history job green on the SHA (`gitleaks-full-history` skipped on
+  PR runs by design; diff scan green).
+
+## Lead overrides (recorded per board rules)
+
+1. **PM NO-GO — overridden as moot-or-fast-follow.** The runbook/publish sequencing
+   issue self-resolved: the maintainer executed the documented manual first publish
+   at 23:54Z, and #109 removed the pre-release caveats. Remaining PM findings
+   (benchmark stub, spec license mentions, NOTICE URL, ledger flips) are real,
+   small, non-user-harming, and scheduled below.
+2. **QA NO-GO — overridden for 0.1.0 as shipped; drives 0.1.1.** The HIGH finding
+   (terminal escape injection) is a genuine security-hygiene defect in the text
+   renderer, but: no financial-integrity impact (I2 held everywhere), no data loss,
+   exploitation requires an adversarial transcript already on the user's own disk,
+   and unpublishing a live first release would cause more harm than a prompt patch.
+   It is the **top blocker for v0.1.1** together with the `--list --json` contract
+   fix — nothing else ships before those.
+
+## Fast-follow ledger (v0.1.1 blockers first)
+
+1. ✅ **DONE** (`fix:` commit on `fix/v0.1.1-hardening`) — strip ANSI/OSC/nF
+   sequences + C0/C1 controls from all transcript-derived display text
+   (titles, tool names, model-mix labels) at parse/render boundary; cache
+   version bumped to invalidate stale unsanitized titles (QA HIGH).
+2. ✅ **DONE** (same commit) — `--list --json` empty case emits valid JSON
+   `[]` on stdout, message on stderr (QA MEDIUM).
+3. Hide or document `benchmark` (PM #3).
+4. `NOTICE` repo URL + spec-file MIT mentions → Apache-2.0 (PM #4/#5); extend the
+   SPEC-0030 R1 grep to cover `NOTICE`.
+5. Ledger sweep: SPEC-0040/0041/0042 → `shipped` (PM #6).
+6. Handoff `covers:` pluralization nit (Designer #1).
+7. README: real clone URL; trim duplicated example (docs panel).
+8. Bad-release runbook (EM #3).
+9. Unknown-flag error UX (QA LOW).
+
+VERDICT: GO

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -16,6 +16,14 @@ function listLine(index: number, summary: SessionSummary): string {
 async function run(ctx: CommandContext): Promise<number> {
   const sessions = await listFullSessions();
   if (sessions.length === 0) {
+    // v0.1.0 release-board QA finding: `--json` must keep the JSON contract —
+    // an empty LIST is valid JSON (`[]`, exit 0); the human message goes to
+    // stderr so `--list --json | jq` never chokes on prose.
+    if (ctx.options.json) {
+      ctx.stderr.write(`${await noSessionsMessage()}\n`);
+      ctx.stdout.write("[]\n");
+      return 0;
+    }
     ctx.stdout.write(`${await noSessionsMessage()}\n`);
     return 0;
   }

--- a/src/parse/claudeCode.ts
+++ b/src/parse/claudeCode.ts
@@ -12,8 +12,7 @@ import {
   pathExists,
   readJsonl,
   truncate,
-  withTotal,
-} from "./util.js";
+  withTotal, sanitizeText } from "./util.js";
 
 /** Raw shapes from a Claude Code `.jsonl` transcript line. Only the fields we use. */
 interface RawUsage {
@@ -269,7 +268,7 @@ async function parseTranscript(filePath: string, withTurns: boolean) {
           if (block.type === "tool_use") {
             toolCallCount++;
             const call: ToolCall = {
-              name: block.name ?? "tool",
+              name: sanitizeText(block.name ?? "tool"),
               input: block.input,
               status: "running",
               startedAt: ts,
@@ -339,7 +338,7 @@ async function parseTranscript(filePath: string, withTurns: boolean) {
   const summary: SessionSummary = {
     id: filePath,
     source: "claude-code",
-    title: aiTitle || (firstUserText ? truncate(firstUserText) : undefined),
+    title: (aiTitle ? truncate(aiTitle) : undefined) || (firstUserText ? truncate(firstUserText) : undefined),
     model,
     startedAt,
     endedAt,

--- a/src/parse/codex.ts
+++ b/src/parse/codex.ts
@@ -11,8 +11,7 @@ import {
   pathExists,
   readJsonl,
   truncate,
-  withTotal,
-} from "./util.js";
+  withTotal, sanitizeText } from "./util.js";
 
 /** Raw usage shape from a Codex `rollout-*.jsonl` `token_count` event. */
 interface CodexUsage {
@@ -246,7 +245,7 @@ async function parseTranscript(filePath: string, withTurns: boolean) {
     if (type === "function_call" || type === "tool_call" || type === "custom_tool_call") {
       toolCallCount++;
       const callId = String(item.call_id ?? item.id ?? "");
-      const name = String(item.name ?? "tool");
+      const name = sanitizeText(String(item.name ?? "tool"));
       const call: ToolCall = {
         name,
         input: parseMaybeJson(item.arguments ?? item.input),

--- a/src/parse/cursor.ts
+++ b/src/parse/cursor.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { openReadOnly } from "./sqlite.js";
 import type { AgentSource, Session, SessionAdapter, SessionSummary, ToolCall, Turn } from "./types.js";
-import { emptyUsage, pathExists, truncate } from "./util.js";
+import { emptyUsage, pathExists, truncate, sanitizeText } from "./util.js";
 
 /**
  * Cursor stores chat history in SQLite (`globalStorage/state.vscdb`, table
@@ -111,7 +111,7 @@ function parseArgs(raw: unknown): unknown {
 const CURSOR_SHELL_TOOLS = new Set(["run_terminal_cmd", "terminal", "shell", "bash"]);
 
 function toToolCall(t: ToolFormerData): ToolCall {
-  const name = toolName(t);
+  const name = sanitizeText(toolName(t));
   return {
     name,
     input: parseArgs(t.rawArgs),

--- a/src/parse/gemini.ts
+++ b/src/parse/gemini.ts
@@ -1,7 +1,7 @@
 import { sep } from "node:path";
 import type { AgentSource, ListSessionsOptions, Session, SessionAdapter, SessionSummary, TokenUsage, ToolCall, Turn } from "./types.js";
 import { lazyGeminiSummary, nodeDiscoveryFs, type DiscoveryFs } from "./discovery.js";
-import { addUsage, emptyUsage, expandHome, listFiles, mapWithConcurrency, parseTimestamp, pathExists, readJsonl, truncate, withTotal } from "./util.js";
+import { addUsage, emptyUsage, expandHome, listFiles, mapWithConcurrency, parseTimestamp, pathExists, readJsonl, truncate, withTotal, sanitizeText } from "./util.js";
 
 /**
  * Gemini CLI (`ChatRecordingService`) writes an append-only JSONL transcript
@@ -105,7 +105,7 @@ function extractText(content: unknown): string | undefined {
 
 function toToolCall(raw: GeminiToolCall): ToolCall {
   return {
-    name: typeof raw.name === "string" && raw.name ? raw.name : "tool",
+    name: typeof raw.name === "string" && raw.name ? sanitizeText(raw.name) : "tool",
     // No per-tool-call timestamp is recorded (only the message's) — startedAt/
     // endedAt stay undefined rather than fabricating precision (I3, R4a).
     status: raw.status === "error" ? "error" : "ok",

--- a/src/parse/opencode.ts
+++ b/src/parse/opencode.ts
@@ -12,7 +12,7 @@ import type {
   ToolCall,
   Turn,
 } from "./types.js";
-import { addUsage, emptyUsage, parseTimestamp, pathExists, truncate, withTotal } from "./util.js";
+import { addUsage, emptyUsage, parseTimestamp, pathExists, truncate, withTotal, sanitizeText } from "./util.js";
 
 /**
  * opencode stores sessions in SQLite DBs under `~/.local/share/opencode`.
@@ -244,7 +244,8 @@ function summaryFromRow(dbPath: string, row: SessionRow): SessionSummary {
 }
 
 function toToolCall(part: RawPartData): ToolCall | null {
-  const name = typeof part.tool === "string" && part.tool ? part.tool : part.name;
+  const rawName = typeof part.tool === "string" && part.tool ? part.tool : part.name;
+  const name = typeof rawName === "string" ? sanitizeText(rawName) : rawName;
   if (part.type !== "tool" || typeof name !== "string" || !name) {
     return null;
   }

--- a/src/parse/summaryCache.ts
+++ b/src/parse/summaryCache.ts
@@ -5,7 +5,7 @@ import { AGENT_SOURCES, type AgentSource, type Session, type SessionSummary, typ
 import type { DiscoveryStat } from "./discovery.js";
 import { mapWithConcurrency } from "./util.js";
 
-const CACHE_VERSION = 1;
+const CACHE_VERSION = 2; // v0.1.1: titles are now escape-sanitized; invalidate pre-sanitizer entries
 const SOURCES = new Set<AgentSource>(AGENT_SOURCES);
 
 interface CacheEntry {

--- a/src/parse/util.ts
+++ b/src/parse/util.ts
@@ -84,8 +84,25 @@ export function parseTimestamp(value: unknown): number | undefined {
   return undefined;
 }
 
+// Terminal-escape sanitation (v0.1.0 release-board QA finding): transcript
+// content is untrusted — a title carrying raw ESC/CSI/OSC bytes would other-
+// wise reach the operator’s terminal verbatim (OSC-0 retitle confirmed in the
+// finding). Strip full ANSI/OSC sequences first, then every remaining C0/C1
+// control, tab/CR/newline included (display strings never carry raw
+// line breaks; a CR could redraw a receipt row). DEL included.
+// CSI (ESC [ ... final), OSC (ESC ] ... BEL / ESC-backslash), and the nF/Fe
+// escape forms (ESC + optional intermediates 0x20-0x2F + a final 0x30-0x7E,
+// covering charset designators like ESC ( B). Ordered so CSI/OSC win first.
+const ANSI_SEQUENCE_RE = /\u001B(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007\u001B]*(?:\u0007|\u001B\\)?|[ -/]*[0-~])/g;
+const CONTROL_CHARS_RE = /[\u0000-\u001F\u007F-\u009F]/g;
+
+/** Strip ANSI/OSC escape sequences and control characters from untrusted transcript text. */
+export function sanitizeText(text: string): string {
+  return text.replace(ANSI_SEQUENCE_RE, "").replace(CONTROL_CHARS_RE, "");
+}
+
 export function truncate(text: string, max = 120): string {
-  const clean = text.replace(/\s+/g, " ").trim();
+  const clean = sanitizeText(text).replace(/\s+/g, " ").trim();
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
 }
 

--- a/src/receipt/model.ts
+++ b/src/receipt/model.ts
@@ -4,7 +4,7 @@
 // they only format what's already here.
 import type { AgentSource, Session, TokenUsage } from "../parse/types.js";
 import { SOURCE_LABELS } from "../parse/types.js";
-import { addUsage, emptyUsage } from "../parse/util.js";
+import { addUsage, emptyUsage, sanitizeText } from "../parse/util.js";
 import { attributeByTool, METHODOLOGY } from "../pricing/attribution.js";
 import { defaultDataDir } from "../pricing/priceTable.js";
 import { isoDateOf, resolvePrice, vendorForTurn } from "../pricing/resolve.js";
@@ -149,7 +149,7 @@ async function buildModelMix(session: Session): Promise<ModelMixEntry[]> {
   }
   const grandTotal = [...mixMap.values()].reduce((sum, t) => sum + t.total, 0);
   return [...mixMap.entries()]
-    .map(([model, tokens]) => ({ model, tokens, tokenShare: grandTotal > 0 ? tokens.total / grandTotal : 0 }))
+    .map(([model, tokens]) => ({ model: sanitizeText(model), tokens, tokenShare: grandTotal > 0 ? tokens.total / grandTotal : 0 }))
     .sort((a, b) => b.tokenShare - a.tokenShare || a.model.localeCompare(b.model));
 }
 

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -265,6 +265,16 @@ describe("built CLI e2e", () => {
     expect(result.stdout).toContain(path.join(home, ".codex", "sessions"));
   });
 
+  it("SPEC v0.1.1: `--list --json` on zero sessions emits valid JSON `[]` on stdout, message on stderr", async () => {
+    const home = await makeHome();
+
+    const result = await runCli(["--list", "--json"], home);
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual([]);
+    expect(result.stderr).toContain("no agent session data detected");
+  });
+
   it("discovers and prices opencode multi-provider sessions through built CLI", async () => {
     const home = await makeHome();
     await stageOpenCodeDb(home, "clean-multi-vendor.db");

--- a/test/parse/sanitize.test.ts
+++ b/test/parse/sanitize.test.ts
@@ -1,0 +1,152 @@
+// v0.1.0 release-board QA finding (HIGH): transcript-derived text reached the
+// terminal with raw ESC/CSI/OSC bytes intact — a title could recolor output or
+// retitle the terminal via OSC-0. These tests pin the sanitation boundary:
+// `sanitizeText` (unit), the Claude Code title + tool-name paths.
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { ClaudeCodeAdapter } from "../../src/parse/claudeCode.js";
+import { sanitizeText, truncate } from "../../src/parse/util.js";
+
+const dir = mkdtempSync(path.join(tmpdir(), "aireceipts-sanitize-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+// The QA repro payload, byte for byte: CSI color + OSC-0 terminal retitle (BEL-terminated).
+const HOSTILE = `${ESC}[31mFAKE ERROR${ESC}[0m${ESC}]0;pwned${BEL} hi there`;
+
+describe("sanitizeText (unit)", () => {
+  it("strips CSI color, OSC-0 retitle (the QA repro), leaving only the visible text", () => {
+    expect(sanitizeText(HOSTILE)).toBe("FAKE ERROR hi there");
+  });
+
+  it("strips an ST-terminated (ESC-backslash) OSC sequence", () => {
+    expect(sanitizeText(`a${ESC}]0;title${ESC}\\b`)).toBe("ab");
+  });
+
+  it("strips nF escape forms whole (ESC + intermediates + final), e.g. the ESC ( B charset designator", () => {
+    expect(sanitizeText(`a${ESC}(Bb`)).toBe("ab");
+  });
+
+  it("strips C0/C1 controls and DEL", () => {
+    const nul = String.fromCharCode(0x00);
+    const del = String.fromCharCode(0x7f);
+    const c1 = String.fromCharCode(0x9f);
+    expect(sanitizeText(`a${nul}b${BEL}c${del}d${c1}e`)).toBe("abcde");
+  });
+
+  it("strips tab/CR/newline too (display strings never carry raw line breaks; CR could redraw a row)", () => {
+    expect(sanitizeText("a\tb\r\nc")).toBe("abc");
+  });
+
+  it("leaves ordinary text untouched", () => {
+    expect(sanitizeText("plain — text with unicode 字 🚀")).toBe("plain — text with unicode 字 🚀");
+  });
+
+  it("adversarial: an unterminated OSC keeps the visible prefix and drops no ESC byte silently", () => {
+    const out = sanitizeText(`before${ESC}]0;stolen`);
+    expect(out).toContain("before");
+    expect(out).not.toContain(ESC);
+  });
+
+  it("truncate composes sanitation with whitespace collapsing", () => {
+    expect(truncate(`  ${HOSTILE}  `)).toBe("FAKE ERROR hi there");
+  });
+});
+
+describe("adapter title + tool-name paths carry no escape bytes", () => {
+  it("Claude Code: hostile first-user-text title and tool name come out clean (QA repro)", async () => {
+    const file = path.join(dir, "hostile.jsonl");
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({
+          type: "user",
+          timestamp: "2026-01-01T00:00:00Z",
+          sessionId: "s1",
+          uuid: "u1",
+          message: { role: "user", content: [{ type: "text", text: HOSTILE }] },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-01-01T00:00:01Z",
+          sessionId: "s1",
+          uuid: "u2",
+          message: {
+            role: "assistant",
+            model: "claude-opus-4-8",
+            content: [{ type: "tool_use", id: "t1", name: `Ba${ESC}[31msh`, input: {} }],
+            usage: { input_tokens: 10, output_tokens: 5 },
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    const s = await new ClaudeCodeAdapter().loadSession(file);
+    expect(s?.title).toBe("FAKE ERROR hi there");
+    expect(s?.turns[0]?.toolCalls[0]?.name).toBe("Bash");
+    expect(JSON.stringify(s)).not.toContain(ESC);
+  });
+
+  it("Claude Code: a hostile ai-title record is sanitized too", async () => {
+    const file = path.join(dir, "hostile-aititle.jsonl");
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({ type: "ai-title", timestamp: "2026-01-01T00:00:00Z", sessionId: "s2", uuid: "u1", aiTitle: HOSTILE }),
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-01-01T00:00:01Z",
+          sessionId: "s2",
+          uuid: "u2",
+          message: { role: "assistant", model: "claude-opus-4-8", content: [{ type: "text", text: "ok" }], usage: { input_tokens: 10, output_tokens: 5 } },
+        }),
+      ].join("\n") + "\n",
+    );
+    const s = await new ClaudeCodeAdapter().loadSession(file);
+    expect(s?.title ?? "").not.toContain(ESC);
+  });
+
+  it("Claude Code: a hostile model id is sanitized in the receipt's model-mix label, pricing unaffected", async () => {
+    const file = path.join(dir, "hostile-model.jsonl");
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({ type: "user", timestamp: "2026-01-01T00:00:00Z", sessionId: "s3", uuid: "u1", message: { role: "user", content: [{ type: "text", text: "hi" }] } }),
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-01-01T00:00:01Z",
+          sessionId: "s3",
+          uuid: "u2",
+          message: { role: "assistant", model: `claude${ESC}[31m-opus-4-8`, content: [{ type: "text", text: "ok" }], usage: { input_tokens: 10, output_tokens: 5 } },
+        }),
+      ].join("\n") + "\n",
+    );
+    const { buildReceiptModel } = await import("../../src/receipt/model.js");
+    const s = await new ClaudeCodeAdapter().loadSession(file);
+    const model = await buildReceiptModel(s!);
+    expect(model.modelMix.map((m) => m.model).join(" ")).not.toContain(ESC);
+  });
+
+  it("Claude Code: a CR-spoofed tool name cannot redraw a row (CR stripped)", async () => {
+    const CR = String.fromCharCode(0x0d);
+    const file = path.join(dir, "hostile-cr-tool.jsonl");
+    writeFileSync(
+      file,
+      [
+        JSON.stringify({ type: "user", timestamp: "2026-01-01T00:00:00Z", sessionId: "s4", uuid: "u1", message: { role: "user", content: [{ type: "text", text: "hi" }] } }),
+        JSON.stringify({
+          type: "assistant",
+          timestamp: "2026-01-01T00:00:01Z",
+          sessionId: "s4",
+          uuid: "u2",
+          message: { role: "assistant", model: "claude-opus-4-8", content: [{ type: "tool_use", id: "t1", name: `Bash${CR}TOTAL`, input: {} }], usage: { input_tokens: 10, output_tokens: 5 } },
+        }),
+      ].join("\n") + "\n",
+    );
+    const s = await new ClaudeCodeAdapter().loadSession(file);
+    expect(s?.turns[0]?.toolCalls[0]?.name).toBe("BashTOTAL");
+    expect(s?.turns[0]?.toolCalls[0]?.name ?? "").not.toContain(CR);
+  });
+});


### PR DESCRIPTION
## What this adds

The two blocking findings from the v0.1.0 release board (verdict included in this PR), plus the follow-on gaps a build-time critic pass surfaced:

- **Terminal-escape injection (QA HIGH).** Transcript-derived display text — session titles, tool names, **and** model-mix labels — reached the terminal with raw ESC/CSI/OSC bytes intact. A crafted value could recolor output or retitle the terminal via OSC-0. New `sanitizeText()` strips CSI/OSC/nF sequences + all C0 controls (incl. tab/CR/newline — a bare CR could redraw a receipt row) + C1 + DEL, applied at the `truncate()` seam, every adapter's tool-name/`ai-title` path, and the receipt's model-mix label. Pricing still keys on the raw turn model upstream.
- **Stale-cache bypass.** `CACHE_VERSION` 1 → 2 so titles written by the pre-sanitizer parser are invalidated, not served raw by `--list`.
- **`--list --json` contract (QA MEDIUM).** Zero-session case now emits valid JSON `[]` on stdout with the message on stderr (was plain text on stdout, breaking `| jq`).

## Why it matters to users

aireceipts renders other agents' transcript content by definition — untrusted input. This closes the class of bug that draws a CVE-shaped issue in an OSS launch's first week, and makes `--list --json` scriptable.

## See it

QA's exact repro, now neutralized (pinned in `test/parse/sanitize.test.ts`):

```
title "\x1b[31mFAKE ERROR\x1b[0m\x1b]0;pwned\x07 hi there"  →  "FAKE ERROR hi there"
tool  "Bash\rTOTAL"                                          →  "BashTOTAL"
aireceipts --list --json   (no sessions)                     →  []   (exit 0, message on stderr)
```

## What to review, in order

1. `src/parse/util.ts` — the two regexes (`ANSI_SEQUENCE_RE`, `CONTROL_CHARS_RE`); correctness/completeness is the whole point.
2. The sanitation call sites across `src/parse/*.ts` + `src/receipt/model.ts:buildModelMix` — every transcript-text display boundary covered.
3. `src/cli/commands/list.ts` — `[]` + stderr, text mode byte-identical.
4. `test/parse/sanitize.test.ts` — CSI/OSC/nF/C0/C1 units + adapter integration (title, tool, model, CR-spoof).
5. `docs/releases/0.1.0-verdict.md` — the board record this PR closes items 1–2 of.

## Evidence

- Full gate on the branch: `tsc`/`eslint`/`verify-goldens`/`determinism ×10`/`spec-lint`/`hygiene` all 0, unmasked; `vitest` **1171/1171 green** (the 100-iteration timeout tests pass under the ceilings from #111).
- Codex PR-critic round: 4 findings (2 HIGH: model labels + CR/tab tool spoof; 1 MEDIUM: stale cache; 1 LOW: test breadth) — all applied.

## Notes

Remaining verdict fast-follows (benchmark visibility, NOTICE/spec license, ledger flips, pluralization nit, README clone URL, bad-release runbook) are non-blocking and tracked in the verdict ledger for a later sweep. When merged, this is the content of a v0.1.1 patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)