### PR TITLE
chore: release v0.1.1 (first OIDC/trusted-publishing release)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## What this is

Version bump 0.1.0 → 0.1.1 — the **first release through the trusted-publishing OIDC workflow** (v0.1.0 was the manual bootstrap). Trusted publisher is now configured on npmjs.com.

Not a no-op: ships what landed on `main` since the manual publish — codex compaction parsing (SPEC-0040), real-session discovery filter (SPEC-0041), handoff resume packet (SPEC-0042).

## After merge

Dispatch `release-publish` on `main`: it runs the repo/ref/npm-floor asserts → `npm ci` → **`npm run preflight`** (full gate) → `npm publish --provenance --access public` via OIDC. No token; v0.1.1 will carry a provenance attestation (which v0.1.0 lacks).

## Evidence

Version consistent across package.json + lockfile (root and `packages[""]`); Codex review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)