### PR TITLE
fix: upgrade npm before trusted-publishing floor assert

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -44,6 +44,13 @@ jobs:
           node-version: "22.14"
           registry-url: "https://registry.npmjs.org"
 
+      - name: upgrade npm to the trusted-publishing floor
+        # Node 22.14 only *permits* npm >= 11.5.1 — it ships npm 10.x. Trusted
+        # publishing (OIDC) needs 11.5.1+, so install it explicitly before the
+        # floor assert below (which would otherwise fail-closed, as it did on
+        # the first v0.1.1 dispatch).
+        run: npm install -g npm@latest
+
       - name: assert package.json.repository matches this repository
         # Exact match, not substring: parse the URL and require the github.com
         # host with exactly this owner/repo path (Codex review finding 2 — a


### PR DESCRIPTION
## Why

The first v0.1.1 publish dispatch (run 28725912323) **failed safely** at the `npm >= 11.5.1` floor assert — nothing published. Root cause: `setup-node@22.14` ships **npm 10.x**, but OIDC trusted publishing needs **11.5.1+**. SPEC-0033's comment assumed 22.14 satisfied the npm floor; it only satisfies Node's *requirement for* npm 11.5.1.

## Fix

One step after setup-node: `npm install -g npm@latest`, so the floor assert passes and the OIDC publish proceeds. YAML validated.

## After merge
Re-dispatch `release-publish` on main → v0.1.1 publishes with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)