### PR TITLE
fix: telemetry-show sends nothing + docs/code parity sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@
 **Why this exists.** AI coding agents spend real money invisibly — you see the diff,
 never the bill. aireceipts reads the transcripts your agent already writes to disk and
 turns them into receipts: what a session cost, tool by tool; what a PR cost, across
-every agent that built it; where tokens were wasted. Local and deterministic — no
-accounts, no servers, nothing leaves your machine.
+every supported agent session it can attribute; where tokens were wasted. Local and
+deterministic — no accounts, no servers; your transcripts and code never leave your
+machine (anonymous, content-free diagnostics are on by default and opt-out — see
+[docs/telemetry.md](docs/telemetry.md)).
 
 ## Install
 

--- a/docs/guide/01-getting-started.md
+++ b/docs/guide/01-getting-started.md
@@ -1,7 +1,9 @@
 # Get started in 60 seconds
 
 aireceipts reads the transcripts your AI coding agent already writes to disk and
-prints a priced receipt of what a session cost. No account, no API key, no upload.
+prints a priced receipt of what a session cost. No account, no API key; your
+transcripts and code are never uploaded (anonymous diagnostics are opt-out — see
+[docs/telemetry.md](../telemetry.md)).
 
 This page takes you from nothing to a receipt, a weekly total, and an automatic
 receipt after every session — in about a minute.

--- a/docs/guide/06-week.md
+++ b/docs/guide/06-week.md
@@ -4,7 +4,7 @@ Goal: total every session from the last seven days, across every agent, with an
 honest comparison to the week before.
 
 ```sh
-aireceipts week
+aireceipts week --since 2026-06-18
 ```
 
 ```
@@ -55,8 +55,9 @@ which also makes the output reproducible:
 aireceipts week --since 2026-06-18
 ```
 
-That's the invocation behind the digest above — the `· since override` in the
-header marks it.
+That's the invocation shown at the top — the `· since override` in the header
+marks it. A bare `aireceipts week` (no `--since`) instead prints a trailing-7-days
+header ending at the current moment.
 
 ## Split by project
 

--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -39,8 +39,7 @@ JSON export.
 |---|---|---|
 | `schemaVersion` | number (literal `1`) | This schema's major version. Bumped only on a breaking change. |
 | `agentLabel` | string | Human label for the agent, e.g. "Claude Code". |
-| `source` | enum | One of `claude-code`, `codex`, `cursor`, `gemini`. |
-| `source` | enum | One of `claude-code`, `codex`, `cursor`, `opencode`. |
+| `source` | enum | One of `claude-code`, `codex`, `cursor`, `gemini`, `opencode`. |
 | `sessionId` | string | Adapter-local id (an absolute file path for file-based adapters). |
 | `title` | string \| null | Session title, or null when the adapter reports none. |
 | `startedAtMs` | number \| null | Session start, epoch milliseconds, or null. |
@@ -216,9 +215,12 @@ cacheCreationTokens, totalTokens, callCount`
 
 ## Weekly digest (SPEC-0008 integration point)
 
-`week --json` (SPEC-0008's weekly digest) is not yet implemented on this branch. When it
-lands, it MUST wrap its payload with the same `schemaVersion` constant
-(`SCHEMA_VERSION` from `src/receipt/exportSchema.ts`) rather than inventing a second,
-undocumented shape (R5, single-source-of-truth). Add a `weekJsonSchema` alongside the
-existing schemas, document its fields inside the `json-fields` markers above, and the
-parity test will hold it to the same contract automatically.
+`week --json` (SPEC-0008's weekly digest) **is** implemented (`weekToJson` in
+`src/receipt/week.ts`) and emits a `{window, priorWindow, sinceOverride, byProject, current, prior, delta,
+topWaste}` digest (waste lines are under `topWaste`). It does **not** yet carry a `schemaVersion` wrapper or a `weekJsonSchema` in
+`exportSchema.ts`, so it is not covered by the field-parity test — a known gap tracked
+for a follow-up: it MUST gain the same `schemaVersion` constant (from
+`src/receipt/exportSchema.ts`) and a `weekJsonSchema` documented inside the
+`json-fields` markers above, rather than a second undocumented shape (R5,
+single-source-of-truth). Until then, treat `week --json` as an unversioned convenience
+surface, not part of the versioned contract.

--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -14,10 +14,6 @@ From your checkout (or worktree) with the PR branch checked out:
 npx aireceipts-cli pr --post
 ```
 
-> **Pre-release note:** until the npm package is published, run the same command
-> from a source checkout: `node dist/cli.js pr --post` (see the README's install
-> status). The one-command story becomes literal at v0.1.0.
-
 That is the finalizer for humans, Codex, Claude Code, OpenCode, Cursor, and any other
 coding assistant. It discovers supported local agent sessions, matches them to the
 current repo/worktree and PR branch, renders the exact comment body, then upserts one
@@ -85,8 +81,8 @@ anonymous raw fetches 404 there, so the viewer shows its error with a direct
 GitHub link (readable as source by anyone with access) until the repo is
 public. Publishing writes nothing to your working tree, index, or current
 branch, and each PR's file is overwritten in place — other PRs' artifacts are
-never touched. The viewer page itself carries no analytics or beacons and
-never will (I4's spirit): nobody, including the aireceipts project, learns
+never touched. The viewer page itself carries no analytics or beacons (I4's
+spirit): nobody, including the aireceipts project, learns
 who viewed which receipt.
 
 ## For maintainers (repo integration, 2 minutes)

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -22,7 +22,7 @@ There are exactly three event types. Nothing else is ever recorded.
 | `os` | enum | `darwin` \| `linux` \| `win32` \| `other` | `process.platform`, collapsed to a closed set — never the raw platform string. |
 | `nodeMajor` | integer | e.g. `22` | Major Node version only. |
 | `commandClass` | enum | `receipt` \| `compare` \| `handoff` \| `other` | Which subcommand ran — never the raw argv or any flag values. |
-| `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `opencode` \| `unknown` | Which agent format was parsed, if known. |
+| `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `gemini` \| `opencode` \| `unknown` | Which agent format was parsed, if known. |
 | `durationBucket` | enum | `<100ms` \| `100-500ms` \| `500ms-2s` \| `2-10s` \| `>10s` | Coarse bucket — never the raw millisecond count. |
 | `ok` | boolean | | Whether the run succeeded. |
 | `handoffFormat` | enum (optional) | `text` \| `json` | SPEC-0042: emission mode, present only on handoff-command runs — never content. |
@@ -33,14 +33,14 @@ There are exactly three event types. Nothing else is ever recorded.
 |---|---|---|---|
 | `errorClass` | enum | `parse_error` \| `io_error` \| `network_error` \| `validation_error` \| `unknown_error` | A small fixed taxonomy derived from the error's constructor name or a well-known Node error code — **never `error.message`**, which can contain a file path or other identifying text. |
 | `command` | enum | `receipt` \| `compare` \| `handoff` \| `other` | Same closed taxonomy as `cli_run.commandClass`. |
-| `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `opencode` \| `unknown` | |
+| `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `gemini` \| `opencode` \| `unknown` | |
 | `inPackage` | boolean | | Whether the error's top stack frame originated inside `aireceipts`'s own installed code (helps us tell "our bug" from "your environment") — the stack trace text itself is inspected internally and never leaves the process. |
 
 ### `parse_failure` — one per transcript-parsing failure
 
 | Field | Type | Values | Notes |
 |---|---|---|---|
-| `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `opencode` | |
+| `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `gemini` \| `opencode` \| `unknown` | |
 | `adapterVersion` | string | short opaque token, e.g. `"1"` | An internal per-adapter constant, not anything read from a transcript. |
 | `signatureHash` | string | 64-character sha256 hex digest | A hash of a content-free description of *where* parsing broke (e.g. `"claude-code:turn.usage.missing"`). The raw description is hashed before it ever reaches a payload — you cannot recover it from the hash, and it never contains transcript content. |
 
@@ -65,10 +65,10 @@ Permanently, structurally banned — there is no field for any of these anywhere
 Either of the following disables telemetry completely. When disabled, `flushTelemetry()` returns immediately without making any network call — this is verified by tests that stub the network layer and assert it is never invoked.
 
 ```bash
-AIRECEIPTS_TELEMETRY=off aireceipts receipt ...
+AIRECEIPTS_TELEMETRY=off aireceipts ...
 # or: AIRECEIPTS_TELEMETRY=0 / AIRECEIPTS_TELEMETRY=false (case-insensitive)
 
-DO_NOT_TRACK=1 aireceipts receipt ...
+DO_NOT_TRACK=1 aireceipts ...
 ```
 
 To disable permanently, export one of these in your shell profile.

--- a/specs/SPEC-0018-cli-command-registry.md
+++ b/specs/SPEC-0018-cli-command-registry.md
@@ -62,9 +62,12 @@ each add one command merge conflict-free and have zero overlapping production fi
 - **R6 — Telemetry lifecycle remains one wrapper.** Parsing, command selection, command
   execution, telemetry recording, first-run notice, and bounded flush remain owned by
   `main()`. Lifecycle tests cover parse failure, command throw, command nonzero exit,
-  command success, and `telemetry-show`: exactly one run/error event as appropriate,
-  first-run notice skipped only for `telemetry-show`, and `flushTelemetry()` always
-  awaited.
+  command success, and `telemetry-show`: exactly one run/error event as appropriate for
+  real commands, and `flushTelemetry()` awaited for them. **`telemetry-show` is the sole
+  exception on all three axes** — no first-run notice, no `cli_run`/`cli_error` record,
+  and no flush — because it is the preview-what-would-be-sent command and must itself
+  send nothing (SPEC-0002 R5 governs; the scenario below has always said so, and a
+  fetch-spy test with telemetry *enabled* proves it).
 - **R7 — Shared helpers are allowed under common ownership.** Commands may import
   shared CLI helpers from explicit common modules such as `src/cli/common/*` or existing
   domain modules. The rule is not "commands never import helpers"; the rule is that a

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,27 +18,38 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
   const options = parseOptions(argv);
   const commands = await loadCommands();
   const command = selectCommand(commands, options);
-  if (command.name !== "telemetry-show") {
+  // `telemetry-show` is the inspect-what-would-be-sent command: it must itself
+  // send nothing and record nothing, or the privacy-preview surface becomes a
+  // privacy leak (v0.1.0 docs-board BLOCKER). It's exempt from the first-run
+  // notice, the `cli_run` record, AND the flush below.
+  const isTelemetryShow = command.name === "telemetry-show";
+  if (!isTelemetryShow) {
     await ensureFirstRunNotice((text) => process.stderr.write(text + "\n"), undefined);
   }
   const ctx = createContext(options, commands);
   const started = Date.now();
   try {
     const code = await command.run(ctx);
-    recordCliRun({
-      command: command.name,
-      agentType: undefined,
-      durationMs: Date.now() - started,
-      ok: code === 0,
-      // SPEC-0042 R5 — emission mode for the handoff command only (enum, never content).
-      ...(command.name === "handoff" ? { handoffFormat: options.json ? ("json" as const) : ("text" as const) } : {}),
-    });
+    if (!isTelemetryShow) {
+      recordCliRun({
+        command: command.name,
+        agentType: undefined,
+        durationMs: Date.now() - started,
+        ok: code === 0,
+        // SPEC-0042 R5 — emission mode for the handoff command only (enum, never content).
+        ...(command.name === "handoff" ? { handoffFormat: options.json ? ("json" as const) : ("text" as const) } : {}),
+      });
+    }
     return code;
   } catch (err) {
-    recordCliError({ command: command.name, agentType: undefined, err });
+    if (!isTelemetryShow) {
+      recordCliError({ command: command.name, agentType: undefined, err });
+    }
     process.stderr.write(String(err instanceof Error ? err.message : err) + "\n");
     return 1;
   } finally {
-    await flushTelemetry();
+    if (!isTelemetryShow) {
+      await flushTelemetry();
+    }
   }
 }

--- a/test/cli/registry-lifecycle.test.ts
+++ b/test/cli/registry-lifecycle.test.ts
@@ -94,15 +94,15 @@ describe("SPEC-0018 R6 · main() telemetry lifecycle", () => {
     expect(telemetry.flushTelemetry).toHaveBeenCalledTimes(1);
   });
 
-  it("telemetry-show → run event recorded, flush awaited, first-run notice SKIPPED", async () => {
+  it("telemetry-show → records NOTHING, flushes NOTHING, notice skipped (SPEC-0002 R5: the preview command must itself send nothing)", async () => {
     const code = await main(["--telemetry-show"]);
     expect(code).toBe(0);
-    expect(telemetry.recordCliRun).toHaveBeenCalledTimes(1);
-    expect(telemetry.recordCliRun).toHaveBeenCalledWith(
-      expect.objectContaining({ command: "telemetry-show", ok: true }),
-    );
-    expect(telemetry.flushTelemetry).toHaveBeenCalledTimes(1);
-    // R6: the notice is skipped only for telemetry-show.
+    // v0.1.0 docs-board BLOCKER: previewing telemetry must not itself emit
+    // telemetry. SPEC-0002 R5 ("payload printed, nothing sent") governs over
+    // SPEC-0018 R6's vaguer "as the lifecycle requires".
+    expect(telemetry.recordCliRun).not.toHaveBeenCalled();
+    expect(telemetry.recordCliError).not.toHaveBeenCalled();
+    expect(telemetry.flushTelemetry).not.toHaveBeenCalled();
     expect(telemetry.ensureFirstRunNotice).not.toHaveBeenCalled();
   });
 });

--- a/test/cli/telemetry-show-no-send.test.ts
+++ b/test/cli/telemetry-show-no-send.test.ts
@@ -1,0 +1,76 @@
+// v0.1.0 docs-board BLOCKER: `--telemetry-show` (the command that PREVIEWS what
+// telemetry would be sent) must itself send nothing and record nothing — even
+// with telemetry fully ENABLED. The existing lifecycle tests ran with
+// AIRECEIPTS_TELEMETRY=off, so they never exercised the send path; this test
+// enables telemetry with a valid connection string and spies `fetch`.
+// SPEC-0002 R5 ("payload printed, nothing sent") is the governing contract.
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { main } from "../../src/cli/index.js";
+
+const VALID_CONNECTION =
+  "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://example.invalid/";
+
+describe("SPEC-0002 R5 · --telemetry-show sends nothing even with telemetry enabled", () => {
+  let home: string;
+  const saved: Record<string, string | undefined> = {};
+  let origOut: typeof process.stdout.write;
+  let origErr: typeof process.stderr.write;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "aireceipts-telshow-"));
+    mkdirSync(join(home, ".aireceipts"), { recursive: true });
+    // Mark the first-run notice already shown so nothing else writes/prompts.
+    writeFileSync(join(home, ".aireceipts", "telemetry.json"), JSON.stringify({ shown: true }));
+    for (const k of ["HOME", "USERPROFILE", "AIRECEIPTS_TELEMETRY", "DO_NOT_TRACK", "AIRECEIPTS_TELEMETRY_CONNECTION"]) {
+      saved[k] = process.env[k];
+    }
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    // Telemetry ON: kill switches cleared, a valid (but unreachable) endpoint set.
+    delete process.env.AIRECEIPTS_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
+    process.env.AIRECEIPTS_TELEMETRY_CONNECTION = VALID_CONNECTION;
+    origOut = process.stdout.write.bind(process.stdout);
+    origErr = process.stderr.write.bind(process.stderr);
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+    process.stderr.write = (() => true) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("--telemetry-show fires zero fetch calls (telemetry enabled, valid endpoint)", async () => {
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const code = await main(["--telemetry-show"]);
+
+    expect(code).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("a normal command WITH telemetry enabled would attempt a send — proving the guard is real, not just an unreachable endpoint", async () => {
+    // Sanity: this asserts our on-config actually enables sending, so the
+    // telemetry-show zero-call result above is meaningful. `templates` is a
+    // trivial always-succeeds command. fetch is stubbed so nothing leaves.
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 200 }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const code = await main(["templates"]);
+
+    expect(code).toBe(0);
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What this adds

Closes the v0.1.0 release-board **docs panel** (which returned FAIL: 2 blockers + 5 majors). One real code fix, the rest doc/code parity.

## Why it matters to users

- **Privacy (code BLOCKER).** `--telemetry-show` — the command whose whole job is to *preview* what telemetry would be sent — was itself recording a `cli_run` event and flushing it to the network. Previewing telemetry leaked telemetry. Now it records nothing and flushes nothing (it was already exempt from the first-run notice). SPEC-0002 R5 ("payload printed, nothing sent") is the governing contract; SPEC-0018 R6's prose is clarified to match its own scenario.
- **Trust.** Several docs overclaimed ("nothing leaves your machine" despite opt-out diagnostics; "across every agent"; a stale pre-release note falsified by the live npm publish; telemetry enum drift; a `week --json` "not implemented" claim that's false). All corrected against actual code.

## See it

The gap survived because every existing telemetry test ran with `AIRECEIPTS_TELEMETRY=off`. The new test runs with telemetry **enabled** and a valid endpoint, spies `fetch`:

```
--telemetry-show   → 0 fetch calls   (was: 1 cli_run POST to /v2/track)
templates (sanity) → ≥1 fetch call   (proves the on-config really sends)
```

## What to review, in order

1. `src/cli/index.ts` — the `isTelemetryShow` exemption across notice/record/error/flush; must not suppress telemetry for any *other* command.
2. `test/cli/telemetry-show-no-send.test.ts` — telemetry-on fetch-spy proof + the sanity counter-case.
3. `specs/SPEC-0018-cli-command-registry.md` R6 prose — now consistent with its long-standing scenario ("no telemetry is sent").
4. The doc diffs — each verified against code (agentType enums incl. `gemini`; `source` five-value row; `week --json` real key list, flagged unversioned).

## Evidence

- Full gate on the branch: `tsc`/`eslint`/`verify-goldens`/`spec-lint`/`hygiene` all 0; `vitest` green (1160). readme-guard + json-schema-parity pass.
- Codex PR-critic: 1 LOW (I'd mislisted the `week --json` root keys) — applied.

## Notes

Fast-follow to the v0.1.0 verdict, alongside #112 (escape-injection hardening). Both target a **v0.1.2** patch — note v0.1.1 shipped for the OIDC/trusted-publishing milestone before either landed, so the escape-injection HIGH and this telemetry-show BLOCKER are currently live and should drive the next patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)