### PR TITLE
feat: SPEC-0044 A1 — ConfidenceEvent contract, no silent drop

### DIFF
--- a/docs/cost-model.md
+++ b/docs/cost-model.md
@@ -1,0 +1,50 @@
+# The cost model — how a receipt's numbers are computed, and when it flags
+
+This is the living account of how aireceipts turns a transcript into priced
+numbers, per scenario and per agent, and — the part that matters most — exactly
+when the receipt tells you a number may be incomplete rather than showing it as
+if it were exact. It pairs with [trust.md](trust.md) ("Where the numbers can go
+wrong") and is grounded in the audits in
+[internal/cost-attribution-evidence.md](internal/cost-attribution-evidence.md).
+
+## The one rule
+
+For every `$`/token total the receipt shows, exactly one is true: it reconciles
+to the underlying tokens × cited prices, **or** the receipt carries a visible
+signal that it may be incomplete. Silent wrongness is the forbidden state.
+SPEC-0044 makes that a mechanical property: every drop/degrade/lower-bound
+decision routes through a typed `ConfidenceEvent` (`src/pr/confidence.ts`), and
+a hygiene check + an exhaustive-switch test prevent a new silent drop from being
+introduced.
+
+## The ConfidenceEvent contract — every reason a number may be incomplete
+
+| Event | Meaning | Visible signal on the receipt |
+|---|---|---|
+| `unattributable-anchor-pool` | A cross-repo/worktree session touched this branch but can only fall back to "entire session" — too uncertain to credit precisely. | Total floors `≥`; a distinct note: "N session(s) touched this branch but couldn't be attributed precisely". Counted, **never silent** (this closed the coverage-map C.2 hole — the mirror of the #87 over-credit bug). |
+| `silenced-git-write` | A repo+window candidate not proven ours (no branch SHA — quiet commit, cherry-pick, foreign work). | Total floors `≥`; "N candidate session(s) not attributed (in repo + branch window, no branch commit)". |
+| `unreadable-subagent` | A subagent transcript that couldn't be parsed. | Total floors `≥`; "N unreadable subagent(s) not priced". Always listed, never dropped. |
+| `cost-lower-bound-cache-tier` | Cache-write tokens priced at a lower-bound rate because the 5m/1h TTL split is absent (older Claude Code; all opencode). | *(emitter lands in the follow-up build — see Known gaps.)* When wired: a muted "cache-write cost is a lower bound for this session" caveat. |
+
+## Per-agent extraction depth (what can be priced)
+
+| Agent | Per-turn model | Per-turn usage | Cache tiers | Notes |
+|---|---|---|---|---|
+| Claude Code | yes | input/output/cacheRead/cacheCreation (5m/1h split when present) | yes | shape-validated; no vendor cumulative total to reconcile against |
+| Codex CLI | yes (`turn_context`) | input/output/cacheRead; `reasoning_output_tokens` folded into output; no cache-write | read-only | zero-tolerance reconciliation vs the rollout's own cumulative envelope |
+| opencode | per-message (multi-provider) | input/output(+reasoning)/cacheRead/cacheCreation | flat (no split) | vendor resolves per turn from the model id; unknown models stay tokens-only |
+| Cursor | none | session totals only | none | `unpriceable` — receipt states "totals only", never a guessed `$` |
+
+## Known gaps (recorded, not hidden)
+
+- **A2 — Cursor Background Agents** (`agentKv:`/`glass.` keys) are **not read**
+  by the adapter, so a session created by Cursor's Background Agents feature is
+  currently invisible (not degraded — absent). Honest PR-scoping needs their
+  timestamps + cwd; that is its **own spec**. Until then this is a documented
+  blind spot: a PR built with a Cursor Background Agent can under-report a whole
+  contributor. (See trust.md.)
+- **A3 — cache-tier lower bound** is declared in the ConfidenceEvent union; its
+  emitter + caveat land in the SPEC-0044 follow-up build.
+- **Reasoning-token rate** — Codex/opencode/Gemini fold reasoning tokens into
+  `output`; no vendor in `data/prices/` prices reasoning distinctly today, so
+  this is a documented assumption to revisit if a price row ever needs it.

--- a/docs/internal/cost-attribution-evidence.md
+++ b/docs/internal/cost-attribution-evidence.md
@@ -1,0 +1,61 @@
+# Cost-attribution confidence — research evidence (for SPEC-0044)
+
+Two parallel audits, 2026-07-05, grounded in the adapters, fixtures, and the
+PR-attribution code (not hypotheticals). Full reports in the maintainer's
+research vault; this is the load-bearing synthesis the spec acts on.
+
+**The framing fact (not hypothetical):** both failure directions already fired
+on this repo on 2026-07-04. PR #87 *over*-credited a lead session (~$965, 114
+subagents, "entire session") to a one-commit PR (issue #89 → SPEC-0038). The
+same day, the sessions that actually built #79/#86 were *silently* un-credited
+(nested-transcript discovery gap). Confident over-credit and silent
+under-credit, same product, same day.
+
+## The classification that drives the spec
+
+Every finding is one of:
+- **A — silent wrongness**: the tool computes a number that can be wrong and
+  shows NO signal. This is the class the maintainer's directive targets ("flag
+  when it's not right"). Highest priority.
+- **B — fragile / hard-to-test**: correctness depends on reverse-engineered
+  vendor behavior; a wrong result is possible and hard to fixture.
+- **C — coverage gap**: behavior is (probably) correct but not systematically
+  tested, so a future change could regress it silently.
+
+## Category A — silent wrongness (fix or flag; priority)
+
+| # | Finding | Evidence | Direction |
+|---|---|---|---|
+| A1 | **Anchor-pool full-fallback session dropped with NO trace** — not credited, not in `excludedCount`, nowhere. A cross-repo/worktree session that touched the PR but can only render "entire session" vanishes silently. | `contributors.ts` requires `slice.kind !== "full"` to credit an anchor-pool session; failing it drops silently — `test/pr/contributors.test.ts:167`, `attribution-fidelity.test.ts:99` both assert "not credited, not counted as excluded". | under-credit, **no floor** (mirror of #87) |
+| A2 | **Cursor Background Agents invisible** — `cursor.ts` reads only `composerData:`/`bubbleId:` keys; Background Agent sessions live under `agentKv:`/`glass.` in the same DB. A PR built with one shows a receipt missing a whole contributor, with no counted-absence signal. | grep of `src/parse/cursor.ts` → zero `agentKv`/`glass` references (verified by lead). | under-credit, no signal |
+| A3 | **Cache-tier fallback under-reports** — unsplit cache-write tokens priced at base input rate (cheaper); real 5m write is ≥1.25× input. Older Claude Code sessions and ALL opencode sessions hit this. | `resolve.ts` `cacheWriteCost` — the code comment itself says it "may understate the true cost". | under-report, tension with I2 |
+| A4 | **Stale price table at render time** — a receipt rendered before a same-day price correction shows stale numbers with no in-receipt caveat (unlike every other silent case, which has some in-band signal). | coverage-map C.3; only mitigation is an external drift tripwire + "re-render". | either direction |
+
+## Category B — fragile / hard-to-test
+
+- **B1 Fork-boundary reset** (Claude Code `fork-context-ref`): full-state reset on one record match; SPEC-0038's own kill-criterion admits it may ship as *exclusion* if unreliable. Over-credit (inherited parent bill) or silent under-credit. `test/parse/fork-boundary.test.ts` exists — needs a completeness pass.
+- **B2 Message-anchor uniqueness collision**: two commits with the same ≥12-char subject on one branch, one quiet → the quiet one silently loses attribution (fails the "unique across branch" gate by design). Real: `--quiet` already broke #61.
+- **B3 opencode mid-session model-switch corruption** (upstream bug anomalyco/opencode#31606): a real session can truncate after a model switch; the adapter can't distinguish "ended" from "corrupted" → back-half undercount.
+- **B4 Reasoning-token rate fold** (Codex/opencode/Gemini): reasoning folded into `output`; a vendor pricing reasoning at a distinct rate would misprice, invisibly (no reasoning line to audit).
+
+## Category C — coverage gaps (guardrail targets)
+
+- **C1** Codex `reasoning_output_tokens` fold has NO test (opencode's identical fold is tested end-to-end). Asymmetric rigor; no regression guard.
+- **C2** Helper over-credit (Codex cwd+time heuristic) has no numeric upper-bound test — a large concurrent-but-unrelated Codex session could inflate the total under an honest "helpers" label.
+- **C3** Grandchild subagents (subagent-of-subagent) invisible — SPEC-0038 R3 caps discovery at one `subagents/` level; a 3rd level reproduces #79/#86 one deeper.
+- **C4** 3-way dedup (rollup `excluded` ∩ promote `coveredFilePaths` ∩ message-anchor tie-refusal) tested pairwise, never as a session eligible for all three at once.
+- **C5** Waste attribution even-splits a turn's usage across parallel tool calls (`waste.ts flattenCalls`) — per-tool blame can be wrong (not a total bug).
+
+## What is already correct + flagged (do NOT re-spec)
+
+Well-covered and honestly signalled: silenced git write → `≥` floor + note (A1's
+repo-pool sibling); unpriced model → tokens-only, never blended (I2); Cursor
+inline → "totals only" stated; anchor-bounded slice → slice-header range;
+unreadable children → floor; quoted-SHA≠authorship (#87) → fixed at source
+(`call.shell` gate + line grammars), no longer producible; ledger row/total
+drift → property-bounded (`ledger.test.ts`); Codex usage → zero-tolerance
+reconciliation vs the rollout's own cumulative envelope.
+
+The gap is not "no honesty model" — it's a strong honesty model with **specific
+holes** (Category A) and **no systematic scenario×agent matrix** proving each
+cell stays correct-or-flagged as the code changes.

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -113,3 +113,19 @@ If you need a stronger guarantee than an author's disclosure — billing-grade
 attribution across a team — use your vendor's console. aireceipts will not
 pretend to be that, and a receipt that pretended would be worth less than one
 that tells you exactly what it knows.
+
+13. **An anchor-pool session that only full-falls-back** (SPEC-0044 A1). A
+    session from another repo/worktree that touched this branch but resolves only
+    to "entire session" (push-only or rebased anchor, no sliceable commit) is too
+    uncertain to credit. *Direction:* under-credit. *Marker:* the total floors
+    `≥` and a **distinct** note — "N session(s) touched this branch but couldn't
+    be attributed precisely" — counts it, separate from the "candidate session
+    not attributed" note. Previously such a session vanished with no trace: the
+    silent mirror of #87's over-credit. Details: [cost-model.md](cost-model.md).
+
+14. **Cursor Background Agents are not read** (SPEC-0044 A2, known gap). The
+    Cursor adapter reads inline Composer sessions but not Background Agent
+    sessions (`agentKv:`/`glass.` keys). *Direction:* under-report a whole
+    contributor. *Marker:* none yet — a documented blind spot pending its own
+    spec (PR-scoping needs the background-agent schema). Details:
+    [cost-model.md](cost-model.md).

--- a/scripts/hygiene.mjs
+++ b/scripts/hygiene.mjs
@@ -229,6 +229,33 @@ export function getTrackedFiles(rootDir = process.cwd()) {
   return output.split("\n").filter(Boolean);
 }
 
+/**
+ * SPEC-0044 R1 — no silent contributor drop. The receipt's incompleteness is a
+ * typed ConfidenceEvent, never a bare `excludedCount++`. That antipattern (a
+ * count bumped without a routed event) is exactly the silent-drop this spec
+ * closes; banning it in the PR path keeps a future change from re-introducing it.
+ */
+export function checkNoSilentDrop(rootDir = process.cwd(), files = ["src/pr/contributors.ts", "src/pr/rollup.ts", "src/pr/promote.ts"]) {
+  const violations = [];
+  for (const rel of files) {
+    let text;
+    try {
+      text = readFileSync(join(rootDir, rel), "utf8");
+    } catch {
+      continue; // a file the refactor may rename — not this check's job to require existence
+    }
+    // Ban any silent MUTATION of excludedCount (++, +=, --, self-reassign) — a
+    // contributor drop must route through a ConfidenceEvent. `const excludedCount
+    // = new Set(...).size` (a DERIVATION from events) is allowed. A backstop for
+    // the specific known antipattern; the exhaustive-switch test + the A1
+    // behavioral tests are the primary proof.
+    if (/excludedCount\s*(\+\+|--|\+=|-=)|excludedCount\s*=\s*excludedCount/.test(text)) {
+      violations.push(`${rel}: mutated \`excludedCount\` — route contributor drops through a ConfidenceEvent (SPEC-0044 R1), don't bump a silent count`);
+    }
+  }
+  return violations;
+}
+
 export function runHygiene({ rootDir = process.cwd(), title, trackedFiles } = {}) {
   const files = trackedFiles ?? getTrackedFiles(rootDir);
   return [
@@ -236,6 +263,7 @@ export function runHygiene({ rootDir = process.cwd(), title, trackedFiles } = {}
     ...checkRootAllowlist(files),
     ...checkGitleaksIgnore(rootDir),
     ...checkWorkflowPins(rootDir),
+    ...checkNoSilentDrop(rootDir),
     ...(title === undefined ? [] : checkPrTitle(title)),
   ];
 }

--- a/specs/SPEC-0044-cost-attribution-confidence.md
+++ b/specs/SPEC-0044-cost-attribution-confidence.md
@@ -1,0 +1,246 @@
+---
+id: SPEC-0044
+title: "Cost-attribution confidence — the ConfidenceEvent contract + matrix"
+status: building
+milestone: M4
+depends: [SPEC-0028, SPEC-0038]
+---
+
+# SPEC-0044 · cost-attribution confidence
+
+Invariants: I2 (never fabricate a `$`, never silently under-report), I3 (every
+number traceable + its uncertainty stated), I5 (byte-golden). This spec
+operationalizes the promise the product already prints — *"trust every character
+on the receipt"* — for the flagship PR receipt, and makes that promise
+mechanically enforceable rather than a matter of ongoing vigilance.
+
+## Purpose
+
+Maintainer directive (2026-07-05): the PR receipt is the product's core claim;
+its cost must be *right, close to right, or visibly flagged when it isn't* — and
+we must be **confident**, with a deep scenario matrix, e2e validation across all
+agents, documented strategy, and guardrails so future changes can't regress it
+silently.
+
+Two grounded audits (`docs/internal/cost-attribution-evidence.md`) found the
+honesty model is strong but has **specific silent-wrongness holes** and **no
+systematic matrix**. The load-bearing finding (coverage-map C.2): an anchor-pool
+session that touched a PR but can only fall back to "entire session" is dropped
+with **zero trace** — the exact mirror of the #87 over-credit bug, and unlike
+#87 it leaves no floor, no count, nothing. Both directions have already fired on
+this repo (#87 over-credit; #79/#86 silent under-credit).
+
+**The organizing principle:** for every `$`/token total the receipt shows,
+exactly one of these is true and *provable by test*: (1) it reconciles to the
+underlying tokens×cited-prices arithmetic, or (2) the receipt carries a
+**visible signal** that it may be incomplete/uncertain. **Silent wrongness is
+the one forbidden state.** The spec's spine is a single typed mechanism that
+makes "no silent drop" a compile-and-test property, not a promise.
+
+**Kill criterion:** (a) the new incompleteness signals must NOT fire on the
+repo's own already-correct merged PRs — a dogfood measurement: run `--self-check`
+over the last 20 merged PRs of this repo; if any *correct* receipt gains a
+spurious incompleteness flag, that signal's threshold is wrong and is retuned
+before ship (a concrete bound, not "vibes"). (b) A matrix cell the agent
+genuinely cannot produce is `n/a` with a validated one-line reason — an honest
+empty cell, never a fabricated fixture.
+
+## Requirements
+
+- **R1 — The ConfidenceEvent contract (the spine; everything else hangs here).**
+  Introduce a typed union `ConfidenceEvent` (a zod schema / discriminated union,
+  cited not inlined) enumerating every reason a contributor's cost can be
+  dropped, degraded, or lower-bounded — e.g. `unattributable-anchor-pool`,
+  `unreadable-subagent`, `unpriced-model`, `cost-lower-bound-cache-tier`,
+  `silenced-git-write`. **All** drop/degrade/lower-bound decisions in
+  `src/pr/{contributors,rollup,promote}.ts` and the pricing path must route
+  through a single decision surface that RETURNS one of these events (never a
+  bare `continue`). Enforcement is two-pronged and real: (i) an **exhaustive**
+  test/`switch` over the union — a new variant fails to compile until it has a
+  rendered signal; (ii) a **hygiene check** (`scripts/hygiene.mjs`) that greps
+  those files for contributor-dropping control flow (`continue`/`.filter(`) not
+  accompanied by a `ConfidenceEvent` emission, failing CI on a silent drop. This
+  is what makes R1 a property, not theater (S2 finding 1).
+- **R2 — Prove the contract by closing the two priority holes as emitters:**
+  - **A1 (the C.2 hole, priority):** the anchor-pool `full`-fallback skip
+    (`contributors.ts` `anchor && full → continue`) emits an
+    `unattributable-anchor-pool` event → `body.ts` renders a **distinct**
+    counted-absence note ("N session(s) touched this branch but couldn't be
+    attributed precisely — [trust.md]") and floors the total `≥`. It is NOT
+    merged into `excludedCount`'s reason. Requires wiring the event through
+    `ContributorSelection`/`Resolved`/`runPr` into `PrBodyInput` (S2 finding 4);
+    the tests that currently assert the *silent* behavior
+    (`contributors.test.ts:167`, `attribution-fidelity.test.ts:99`) are inverted
+    (red-then-green).
+  - **A3:** the cache-tier fallback (`resolve.ts` `cacheWriteCost`) emits a
+    `cost-lower-bound-cache-tier` event carried alongside the priced figure (the
+    number-only return is widened to `{usd, events}` — S2 finding 3) → the
+    receipt shows a muted "cache-write cost is a lower bound for this session"
+    caveat. This proves the contract spans the pricing path too, not just
+    selection.
+- **R3 — The scenario × agent matrix, judged against an independent oracle.** A
+  declarative matrix (`test/matrix/cost-matrix.ts`): rows = taxonomy scenarios
+  (subagents, delegation, parallel calls, loops, compaction/thrash, fork/resume,
+  multi-model, cache tiers, reasoning tokens, interrupted turns, PR
+  multi-session incl. quiet-commit/message-anchor/nested/cross-repo); columns =
+  the priced agents (Claude Code, Codex, opencode; Cursor where structurally
+  possible). Each populated cell has (a) a **fixture** in that agent's exact
+  on-disk format, (b) a **hand-authored `expected` manifest** — the total and
+  the set of flags, authored independently of the parser, NOT read back from the
+  code under test (S2 finding 6) — and (c) an **e2e assertion through the real
+  CLI** that the rendered receipt matches the manifest (total reconciles OR the
+  declared flags fire). `n/a` cells carry a validated non-empty reason.
+- **R4 — The completeness guardrail (the durable regression guard).**
+  `test/matrix/completeness.test.ts` fails CI if any (scenario, agent) cell is
+  neither backed by a fixture+manifest+assertion nor explicitly `n/a` with a
+  reason. Adding a scenario row or an agent column without covering the new
+  cells fails the build — this is what keeps confidence from decaying after the
+  one-time audit.
+- **R5 — Reconciliation property over the matrix oracle.** Extend the fast-check
+  ledger property (`test/pr/ledger.test.ts`) and add a matrix-driven check: for
+  every priced cell, the CLI-rendered `TOTAL` equals its manifest total (float
+  epsilon) and equals `Σ` per-contributor = `Σ` per-tool; the declared flags are
+  exactly those rendered. The red path — mutate a fixture to drop a turn/session
+  without updating the manifest — must fail (proving the test compares against
+  an independent oracle, not itself — S2 finding 5).
+- **R6 — `docs/cost-model.md` (living).** The per-scenario, per-agent cost
+  strategy: what's extracted, how it's priced, the fallback, and exactly when
+  each `ConfidenceEvent` fires. A test pins that every `ConfidenceEvent` variant
+  from R1 is documented here and in `trust.md`'s "Where the numbers can go
+  wrong" (which gains the A1/A3 entries, and an A2 known-gap pointer).
+- **R7 — Maintainer real-session self-check (dogfood assurance, not a CI
+  invariant).** `aireceipts pr --self-check` run against the maintainer's OWN
+  real sessions reports, per session: did the receipt's arithmetic reconcile,
+  and which `ConfidenceEvent`s fired — a content-free summary table. This exists
+  because no automated test may read real transcripts (harness rule) and the
+  maintainer explicitly wants real-world confidence across all four agents. It
+  is a tool + a success-criterion (maintainer runs it and pastes the summary),
+  explicitly not a mechanical product invariant (S2 finding 7).
+
+## Scenarios
+
+- **Given** an anchor-pool session that touched the branch but only
+  full-falls-back, **then** the total floors `≥` and a distinct counted-absence
+  note names how many such sessions exist (A1) — never silent.
+- **Given** the cache-tier fallback prices an unsplit write, **then** a muted
+  "lower bound" caveat renders (A3).
+- **Given** any populated matrix cell, **then** the CLI output matches the cell's
+  independent `expected` manifest (total reconciles or declared flags fire).
+- **Given** a fixture mutated to drop a turn without updating its manifest,
+  **then** R5 fails.
+- **Given** a new scenario row or agent column with no fixtures, **then** R4
+  fails CI.
+- **Given** a new `ConfidenceEvent` variant with no rendered signal, **then** R1
+  fails to compile / the hygiene check fails.
+
+## Non-goals
+
+- **A2 — fully attributing Cursor Background Agents** (`agentKv:`/`glass.` keys)
+  is a **separate spec**: honest PR-scoping needs their timestamps + cwd, which
+  requires reading the background-agent schema (S2 finding 2). This spec records
+  A2 as a known gap in `cost-model.md`/`trust.md` (so it is not mistaken for
+  covered) and does not emit a noisy un-scoped "some Cursor BA exists somewhere"
+  note that can't be tied to the branch.
+- **B3 opencode upstream corruption**, **B4 distinct reasoning-token price** —
+  documented in the matrix as external / assumption-to-revisit, not fixed here.
+- **Reading real user transcripts in any automated test** — R7 is maintainer-run
+  and content-free.
+- **Re-litigating already-correct+flagged behavior** — those get matrix cells,
+  not new mechanisms.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 union exhaustiveness | add a `ConfidenceEvent` variant with no signal | compile/test fails |
+| R1 hygiene | a contributor-drop `continue` with no event emission | hygiene check fails |
+| R2/A1 counted-absence | anchor-pool full-fallback session touching branch | `≥` floor + distinct counted-absence note; not merged into excludedCount; red-then-green vs the old silent tests |
+| R2/A3 cache-tier caveat | Claude Code session, unsplit cache-write | muted "lower bound" caveat present |
+| R3 matrix vs oracle | each priced cell fixture through CLI | rendered receipt matches the hand-authored `expected` manifest |
+| R3 n/a honesty | a cell the agent can't produce | `n/a` + validated non-empty reason; no fixture |
+| R4 completeness | remove a fixture / add uncovered agent column | completeness test fails |
+| R5 red path | mutate a fixture, leave manifest stale | reconciliation fails |
+| R6 doc sync | each `ConfidenceEvent` variant | present in docs/cost-model.md + trust.md (test-pinned) |
+| R7 self-check | run on a fixture home | reconcile + events-fired summary; zero content leaked |
+| C1 codex reasoning fold | codex fixture w/ `reasoning_output_tokens` | lands in output total (regression guard) |
+| C3 grandchild subagent | 2-level-nested fixture | priced or counted-absent — never silently missing |
+
+## Success criteria
+
+- [ ] The `ConfidenceEvent` union exists; every contributor drop/degrade/
+      lower-bound routes through it; the exhaustiveness test + hygiene check are
+      green and demonstrably red when bypassed.
+- [ ] A1 and A3 are closed as emitters, shown red-then-green.
+- [ ] The matrix renders green across populated cells against independent
+      manifests; `n/a` cells carry reasons; the completeness guard fails when a
+      cell is uncovered (shown in the PR).
+- [ ] Kill-criterion (a) met: `--self-check` over this repo's last 20 merged PRs
+      raised no spurious incompleteness flag on a correct receipt.
+- [ ] `--self-check` run on the maintainer's real sessions; summary pasted in
+      the PR.
+- [ ] `docs/cost-model.md` published; `trust.md` updated.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`,
+      `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
+      `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` pass unmasked.
+
+## Validation
+
+**2026-07-05 · S1 (self):** the spec's spine is now a single typed mechanism
+(`ConfidenceEvent`) whose totality is compile- and hygiene-enforced, not
+promised; the matrix judges against hand-authored oracles, not the code under
+test. Both were the difference between an enforceable spec and theater.
+
+**2026-07-05 · S2 (Codex, read-only): REWORK → reworked.** 8 findings, all
+accepted:
+1. HIGH — R1 totality aspirational → recast as the typed `ConfidenceEvent`
+   union + single decision surface + exhaustiveness test + hygiene grep.
+2. HIGH — A2 counted-absence needs BA timestamps/cwd → **deferred to its own
+   spec**; recorded as a known gap, no un-scoped noisy note.
+3. HIGH — A3 not local; runtime carries no caveat metadata → `cacheWriteCost`
+   return widened to `{usd, events}`, event propagated to the receipt.
+4. MED — A1 wiring understated → spec now names the `ContributorSelection`/
+   `Resolved`/`runPr`/`PrBodyInput` path and the test inversion.
+5. MED — R5 overclaimed the ledger seam → reframed to compare CLI output
+   against each fixture's independent `expected` manifest; red path defined.
+6. MED — R3/R4 real only with independent expected facts → manifests are
+   hand-authored, not read back from the parser; `n/a` reasons validated.
+7. LOW — kill criterion + R7 not mechanical → kill criterion given a concrete
+   dogfood bound (no spurious flag on the repo's last 20 correct PRs); R7
+   reframed as a maintainer tool + success-criterion, not a CI invariant.
+8. Scope → A2 split out; A1 + ConfidenceEvent + matrix + guard kept together as
+   the coherent core; R7 kept (explicit maintainer demand) but reframed.
+
+**2026-07-05 · S3 (value gate):** the kill criterion's evidence is the repo's own
+history — the exact silent-under-credit this closes (C.2) is the mirror of a bug
+(#87) the maintainer caught by eye; the dogfood bound (no spurious flags on 20
+correct PRs) is runnable the day A1 lands.
+
+**2026-07-05 · S4 (lint):** `node scripts/spec-lint.mjs` → OK.
+
+**2026-07-05 · approved (button 1):** maintainer, in-session ("approved"). Status → building.
+
+**2026-07-05 · S5 (implementation review, Codex): REWORK → all 5 fixed.**
+1. HIGH — A1 not end-to-end when it's the only signal (`runPr` aborted with
+   NO_MATCH before rendering) → the zero-contributor path now emits an
+   informative counted-absence message naming the unattributable sessions.
+2. HIGH — `promote.ts` had the SAME A1 hole (bare `continue` on full-fallback)
+   → promote now returns `{promoted, events}`, emits `unattributable-anchor-pool`,
+   merged into the body's confidence summary; a dedicated promote A1 test added.
+3. MED — distinct counting used `summary.id` (collides for nested candidates)
+   → events now carry `summary.filePath` (file-unique).
+4. MED — hygiene ban was `excludedCount++`-only (bypassable by `+= 1`) →
+   regex widened to `++/--/+=/-=/self-reassign`; proven to catch the `+=`
+   variant; honestly scoped as a backstop (the exhaustive switch + behavioral
+   tests are the primary proof).
+5. MED — body floored only on `excludedCount` → now floors on
+   `isFloored(summary)`, covering every ConfidenceEvent kind.
+Plus: `confidence.ts` converted from a zod schema to a plain TS discriminated
+union — these events are minted internally (never parsed from external input),
+and the top-level `z.discriminatedUnion` broke the goldens' temp-compile-run
+zod resolution; the compiler-exhaustiveness guarantee is unchanged.
+
+**Scope shipped in this PR:** R1 (the enforceable contract) + R2/A1 (the
+priority hole, in BOTH contributors.ts and promote.ts) + R6 docs. A3
+(cache-tier caveat — variant declared, emitter deferred), the matrix (R3-R5),
+and `--self-check` (R7) are the remaining build under this `building` spec.

--- a/src/pr/body.ts
+++ b/src/pr/body.ts
@@ -39,12 +39,16 @@ export interface ContributorView {
   durationMs?: number;
 }
 
+import { isFloored, type ConfidenceSummary } from "./confidence.js";
+
 export interface PrBodyInput {
   contributors: ContributorView[];
   /** Candidates that were in repo + window but not credited (R1) — reported honestly (R4). */
   excludedCount: number;
   /** Round 2: true → the hint points at the details section below; false/absent → the command hint (--no-details, unit callers). */
   detailsBelow?: boolean;
+  /** SPEC-0044 — folded confidence counts (A1 anchor-pool absences etc.); absent for legacy callers. */
+  confidence?: ConfidenceSummary;
 }
 
 /** SPEC-0026 R3 (round 2) — the helper explainer, now the group header's and details stat line's phrasing. */
@@ -208,7 +212,11 @@ function countLine(sessionCount: number, totals: Totals): string {
  */
 function totalBlocks(input: PrBodyInput): Block[] {
   const totals = totalsFor(input.contributors);
-  const floor = input.excludedCount > 0 || totals.unreadableCount > 0 ? "≥ " : "";
+  // SPEC-0044 R1/S2-finding-5 — floor on ANY incompleteness/lower-bound event
+  // (not just excludedCount): every ConfidenceEvent kind that can under-state
+  // the total drives the `≥`. excludedCount/unreadable kept for legacy callers
+  // that don't pass a confidence summary.
+  const floor = input.excludedCount > 0 || totals.unreadableCount > 0 || (input.confidence !== undefined && isFloored(input.confidence)) ? "≥ " : "";
   const blocks: Block[] = [{ kind: "rule" }];
   if (totals.pricedCount > 0) {
     blocks.push({ kind: "total", label: "TOTAL priced", value: `${floor}$${formatUsd(totals.pricedSubtotal)}` });
@@ -238,6 +246,19 @@ function totalBlocks(input: PrBodyInput): Block[] {
       spaceBefore: true,
     });
     blocks.push({ kind: "note", text: "(in repo + branch window, no branch commit)", muted: true });
+  }
+  // SPEC-0044 A1 — anchor-pool sessions that touched the branch but couldn't be
+  // sliced precisely: counted-absence, DISTINCT from the excluded note above
+  // (the coverage-map C.2 hole — never a silent drop).
+  const unattributable = input.confidence?.unattributableAnchorPool ?? 0;
+  if (unattributable > 0) {
+    blocks.push({
+      kind: "note",
+      text: `${plural(unattributable, "session")} touched this branch but couldn't be attributed precisely`,
+      muted: true,
+      spaceBefore: true,
+    });
+    blocks.push({ kind: "note", text: "(see docs/trust.md)", muted: true });
   }
   // SPEC-0026 R4 (round 2) — the route to the full per-tool story, always the
   // last note: point at the details section when one follows, else the command.

--- a/src/pr/confidence.ts
+++ b/src/pr/confidence.ts
@@ -1,0 +1,87 @@
+// SPEC-0044 R1 — the ConfidenceEvent contract: the single typed enumeration of
+// every reason a contributor's cost is dropped, degraded, or lower-bounded on a
+// PR receipt. The invariant it exists to make MECHANICAL (not a promise): a
+// number the receipt shows is either reconciled arithmetic OR carries a visible
+// signal — never silently wrong.
+//
+// Every drop/degrade/lower-bound decision in src/pr/{contributors,rollup,
+// promote}.ts and the pricing path routes through here by emitting one of these
+// events. Enforcement is two-pronged:
+//   (i)  summarizeConfidence()'s exhaustive switch — a new variant that renders
+//        no signal fails to compile (the `never` check below);
+//   (ii) scripts/hygiene.mjs greps those files for contributor-dropping control
+//        flow not accompanied by a ConfidenceEvent emission (a silent drop
+//        fails CI).
+/**
+ * A reason a receipt total may be incomplete/uncertain. Discriminated on `kind`.
+ * `sessionId` is the session's file-unique key (the transcript filePath — NOT
+ * summary.id, which collides across nested candidates), so the summary counts
+ * distinct sessions, not raw events. A plain TS union (not a zod schema): these
+ * events are minted by our own code, never parsed from external input, so no
+ * runtime validation is warranted — the compiler is the guarantee.
+ */
+export type ConfidenceEvent =
+  // A1: an anchor-pool session touched the branch but can only full-fall-back
+  // (no sliceable own commit) — too uncertain to credit, but its absence MUST
+  // be counted, never silently dropped (coverage-map C.2 / the mirror of #87).
+  | { kind: "unattributable-anchor-pool"; sessionId: string }
+  // A repo+window candidate that isn't proven ours (no branch SHA) — the
+  // long-standing honest "excluded" count (SPEC-0023 R4 / SPEC-0032).
+  | { kind: "silenced-git-write"; sessionId: string }
+  // A subagent transcript that couldn't be parsed — listed, never dropped.
+  | { kind: "unreadable-subagent"; sessionId: string }
+  // A3: cache-write tokens priced at a lower-bound rate because the 5m/1h tier
+  // split is absent — the receipt's cost for that session is a floor.
+  | { kind: "cost-lower-bound-cache-tier"; sessionId: string };
+
+export interface ConfidenceSummary {
+  /** A1 — anchor-pool sessions dropped as unattributable (distinct sessions). */
+  unattributableAnchorPool: number;
+  /** repo+window candidates not proven ours (the classic excluded count). */
+  silencedGitWrite: number;
+  /** subagents that couldn't be parsed. */
+  unreadableSubagent: number;
+  /** sessions whose cache-write cost is a lower bound (tier unknown). */
+  costLowerBoundCacheTier: number;
+}
+
+const distinctSessions = (events: readonly ConfidenceEvent[], kind: ConfidenceEvent["kind"]): number =>
+  new Set(events.filter((e) => e.kind === kind).map((e) => e.sessionId)).size;
+
+/**
+ * Fold events into rendered counts. The exhaustive switch is the compile-time
+ * half of R1's totality guarantee: a NEW ConfidenceEvent variant added to the
+ * union without a case here fails to typecheck (`never`), so no variant can be
+ * introduced without deciding how it surfaces to the user.
+ */
+export function summarizeConfidence(events: readonly ConfidenceEvent[]): ConfidenceSummary {
+  for (const e of events) {
+    switch (e.kind) {
+      case "unattributable-anchor-pool":
+      case "silenced-git-write":
+      case "unreadable-subagent":
+      case "cost-lower-bound-cache-tier":
+        break;
+      default: {
+        const never: never = e;
+        throw new Error(`unhandled ConfidenceEvent: ${JSON.stringify(never)}`);
+      }
+    }
+  }
+  return {
+    unattributableAnchorPool: distinctSessions(events, "unattributable-anchor-pool"),
+    silencedGitWrite: distinctSessions(events, "silenced-git-write"),
+    unreadableSubagent: distinctSessions(events, "unreadable-subagent"),
+    costLowerBoundCacheTier: distinctSessions(events, "cost-lower-bound-cache-tier"),
+  };
+}
+
+/** Any incompleteness/lower-bound event → the receipt total is a floor (`≥`). */
+export function isFloored(summary: ConfidenceSummary): boolean {
+  return (
+    summary.unattributableAnchorPool > 0 ||
+    summary.silencedGitWrite > 0 ||
+    summary.unreadableSubagent > 0 ||
+    summary.costLowerBoundCacheTier > 0
+  );
+}

--- a/src/pr/contributors.ts
+++ b/src/pr/contributors.ts
@@ -13,6 +13,7 @@ import { classifyBranchAnchors, computeSlice, type BranchAnchorSummary, type Sli
 import { cwdInsideRoots } from "./git.js";
 import { isCodexExec, toolCallInvocations } from "./gitWrite.js";
 import { claimedBranchShas, eligibleSubjects, hasForeignShaWrites, sessionCommitSubjects } from "./messageAnchor.js";
+import type { ConfidenceEvent } from "./confidence.js";
 
 export type Role = "orchestrator" | "builder" | "codex";
 
@@ -44,6 +45,13 @@ export interface ContributorSelection {
   contributors: RawContributor[];
   /** Plausible (this-worktree) candidates that were NOT credited — surfaced, never hidden (R4). */
   excludedCount: number;
+  /**
+   * SPEC-0044 R1 — every drop/degrade routed as a typed ConfidenceEvent. The
+   * source of truth behind the receipt's incompleteness signals; `excludedCount`
+   * is retained (well-tested) and mirrored as `silenced-git-write` events, while
+   * A1's anchor-pool full-fallback drops surface ONLY here (never silent).
+   */
+  events: ConfidenceEvent[];
 }
 
 export interface ContributorDeps {
@@ -74,7 +82,14 @@ export async function selectContributors(
   deps: ContributorDeps,
 ): Promise<ContributorSelection> {
   const contributors: RawContributor[] = [];
-  let excludedCount = 0;
+  const events: ConfidenceEvent[] = [];
+  // excludedCount derives from the silenced-git-write events (kept as a field
+  // for the well-tested body wiring); the events are the R1 source of truth.
+  // filePath is the file-unique identity; summary.id collides across nested
+  // candidates (nestedCandidates synthesizes id: agentId) — S2 finding 3.
+  const excludeHere = (summary: SessionSummary): void => {
+    events.push({ kind: "silenced-git-write", sessionId: summary.filePath });
+  };
 
   // Pass 1 — load and classify EVERYTHING first, so SHA claims are computed
   // from the full candidate list before any message credit is considered:
@@ -150,7 +165,7 @@ export async function selectContributors(
     if (!session || !anchors) {
       // A candidate we can't load can't be proven — count it only if it's plausibly ours.
       if (here) {
-        excludedCount++;
+        excludeHere(summary);
       }
       continue;
     }
@@ -171,6 +186,11 @@ export async function selectContributors(
       // semantics (never excludedCount — the fence's "in repo + branch
       // window" copy stays true).
       if (l.pool === "anchor" && slice.kind === "full") {
+        // SPEC-0044 A1 — too uncertain to credit (a full-session fallback landing
+        // cross-project was PR #87's max-misstatement shape), but its absence is
+        // NEVER silent: it emits a typed event so the total floors `≥` and the
+        // receipt counts it (the coverage-map C.2 hole, the mirror of #87).
+        events.push({ kind: "unattributable-anchor-pool", sessionId: summary.filePath });
         continue;
       }
       contributors.push({
@@ -190,7 +210,7 @@ export async function selectContributors(
       });
     } else if (here) {
       // Plausibly ours (this worktree) but unproven — surface it in the honest note.
-      excludedCount++;
+      excludeHere(summary);
     }
     // else: a sibling-worktree or anchor-pool candidate with no branch-SHA proof — not ours, ignored.
   }
@@ -198,7 +218,10 @@ export async function selectContributors(
   contributors.sort(
     (a, b) => (a.session.startedAt ?? 0) - (b.session.startedAt ?? 0) || a.summary.id.localeCompare(b.summary.id),
   );
-  return { contributors, excludedCount };
+  const excludedCount = new Set(
+    events.filter((e) => e.kind === "silenced-git-write").map((e) => e.sessionId),
+  ).size;
+  return { contributors, excludedCount, events };
 }
 
 /** True if the session spawned subagents or launched another agent (the orchestration signal, R3). */

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -26,6 +26,7 @@ import { rollupChildren, type RollupWindow, type SubagentRow } from "./rollup.js
 import { nestedCandidates } from "./nested.js";
 import { isChildPath } from "../parse/children.js";
 import { renderPrBody, type ContributorView, type PrBodyInput } from "./body.js";
+import { summarizeConfidence, type ConfidenceEvent } from "./confidence.js";
 import { repoVisibility, resolvePr, upsertPrComment } from "./comment.js";
 import { artifactFileName, renderPrArtifactHtml, type ArtifactSession } from "./html.js";
 import { ARTIFACT_BRANCH, artifactViewUrl, publishArtifact } from "./publish.js";
@@ -77,6 +78,8 @@ function stemOf(filePath: string): string {
 interface Resolved {
   contributors: RawContributor[];
   excludedCount: number;
+  /** SPEC-0044 R1 — typed drop/degrade events (A1 anchor-pool absences etc.). */
+  events: ConfidenceEvent[];
   /** Time-overlapping listed sidechains — SPEC-0024 R2 promotion candidates, judged after rollups. */
   sidechains: SessionSummary[];
 }
@@ -119,6 +122,7 @@ async function resolveContributors(
       // Explicitly-selected sessions are the user's own attribution claim — anchor-grade.
       contributors: [{ summary, session, slice: computeSlice(session.turns, shas), basis: "anchor" }],
       excludedCount: 0,
+      events: [],
       sidechains: [],
     };
   }
@@ -326,13 +330,23 @@ export async function runPr(opts: PrOptions, deps: PrDeps = defaultPrDeps()): Pr
     }
     entries.push({ view, model, startedAt: raw.session.startedAt ?? 0, id: raw.summary.id, raw });
   }
-  const promoted = await promoteOrphanSidechains(resolved.sidechains, shas, covered, deps.loadSession);
+  const { promoted, events: promoteEvents } = await promoteOrphanSidechains(resolved.sidechains, shas, covered, deps.loadSession);
+  const allEvents = [...resolved.events, ...promoteEvents];
   for (const raw of promoted) {
     const { view, model } = await buildContributorView(raw, deps, nestedContributorPaths);
     entries.push({ view, model, startedAt: raw.session.startedAt ?? 0, id: raw.summary.id, raw });
   }
   if (entries.length === 0) {
-    deps.err(NO_MATCH);
+    // SPEC-0044 A1 (S2 finding 1): if the ONLY thing that touched the branch was
+    // an unattributable anchor-pool session, don't claim "no match" — say so.
+    const summary = summarizeConfidence(allEvents);
+    if (summary.unattributableAnchorPool > 0) {
+      deps.err(
+        `${summary.unattributableAnchorPool} session(s) touched this branch but couldn't be attributed precisely (no sliceable commit); nothing to receipt. See docs/trust.md.`,
+      );
+    } else {
+      deps.err(NO_MATCH);
+    }
     return 1;
   }
   entries.sort((a, b) => a.startedAt - b.startedAt || a.id.localeCompare(b.id));
@@ -341,7 +355,7 @@ export async function runPr(opts: PrOptions, deps: PrDeps = defaultPrDeps()): Pr
   // size-cap's drop-from-END sheds helpers before authors.
   const fenceOrdered = [...entries.filter((e) => e.view.basis !== "helper"), ...entries.filter((e) => e.view.basis === "helper")];
   const views = entries.map((e) => e.view);
-  const bodyInput: PrBodyInput = { contributors: views, excludedCount: resolved.excludedCount };
+  const bodyInput: PrBodyInput = { contributors: views, excludedCount: resolved.excludedCount, confidence: summarizeConfidence(allEvents) };
 
   // SPEC-0027 R3: push the artifact BEFORE rendering the one final body, so
   // the printed and posted bodies are identical and the link only renders

--- a/src/pr/promote.ts
+++ b/src/pr/promote.ts
@@ -7,6 +7,7 @@
 // rolled-up `SubagentRow`) is skipped, so no token is ever counted twice (I3).
 import type { Session, SessionSummary } from "../parse/types.js";
 import type { RawContributor } from "./contributors.js";
+import type { ConfidenceEvent } from "./confidence.js";
 import { classifyBranchAnchors, computeSlice } from "./slice.js";
 
 /**
@@ -21,8 +22,9 @@ export async function promoteOrphanSidechains(
   branchShas: readonly string[],
   coveredFilePaths: ReadonlySet<string>,
   loadSession: (summary: SessionSummary) => Promise<Session | null>,
-): Promise<RawContributor[]> {
+): Promise<{ promoted: RawContributor[]; events: ConfidenceEvent[] }> {
   const promoted: RawContributor[] = [];
+  const events: ConfidenceEvent[] = [];
   const ordered = [...sidechains].sort(
     (a, b) => (a.startedAt ?? 0) - (b.startedAt ?? 0) || a.id.localeCompare(b.id),
   );
@@ -42,9 +44,12 @@ export async function promoteOrphanSidechains(
     // computeSlice's own rule); a full-fallback sidechain is a silent miss.
     const slice = computeSlice(session.turns, branchShas);
     if (slice.kind === "full") {
+      // SPEC-0044 A1 parity: a branch-touching sidechain that can't be sliced is
+      // counted-absent, never a silent drop (filePath is the file-unique key).
+      events.push({ kind: "unattributable-anchor-pool", sessionId: summary.filePath });
       continue;
     }
     promoted.push({ summary, session, slice, basis: "anchor" });
   }
-  return promoted;
+  return { promoted, events };
 }

--- a/test/pr/attribution-fidelity.test.ts
+++ b/test/pr/attribution-fidelity.test.ts
@@ -96,8 +96,9 @@ describe("R2 — fallback bounding", () => {
     session: { id, source: "claude-code" as const, filePath: `/tmp/${id}.jsonl`, cwd, startedAt: 1, endedAt: 2, turns, totals: { tokens: usage, turnCount: turns.length, toolCallCount: 1 }, title: id, model: "m" },
   });
 
-  it("R2a: an anchor-pool session with only a push anchor (full fallback) is silently ignored", async () => {
-    // push-anchored but no commit anchor → computeSlice returns "full" → anchor pool must drop it
+  it("R2a / SPEC-0044 A1: an anchor-pool full-fallback session is COUNTED-ABSENT, not silently dropped", async () => {
+    // push-anchored but no commit anchor → computeSlice returns "full" → anchor pool won't credit it,
+    // but SPEC-0044 A1 forbids the old SILENT drop: it must leave a typed trace so the total floors.
     const pushTurn = turn(0, [{ name: "Bash", shell: true, input: { command: PUSH }, output: `   0000000..${BRANCH_SHA.slice(0, 8)}  feat -> feat`, status: "ok" }]);
     const s = session("cross-repo-lead", [pushTurn], "/elsewhere/other-repo");
     expect(computeSlice(s.session.turns, [BRANCH_SHA]).kind).toBe("full");
@@ -107,7 +108,9 @@ describe("R2 — fallback bounding", () => {
       currentWorktreeRoot: "/home/dev/repo",
     });
     expect(sel.contributors).toHaveLength(0);
-    expect(sel.excludedCount).toBe(0); // silent miss — SPEC-0024 semantics, fence copy stays true
+    expect(sel.excludedCount).toBe(0); // distinct from `excluded` (repo+window, no commit) — SPEC-0024 fence copy stays true
+    // The fix: no longer silent — a typed unattributable-anchor-pool event is emitted (the coverage-map C.2 hole).
+    expect(sel.events).toContainEqual({ kind: "unattributable-anchor-pool", sessionId: "/tmp/cross-repo-lead.jsonl" });
   });
 
   it("R2a: an anchor-pool session with a sliceable commit anchor still contributes", async () => {
@@ -135,14 +138,14 @@ describe("R2 — fallback bounding", () => {
   it("R2b: a push-only sidechain is no longer promoted", async () => {
     const pushTurn = turn(0, [{ name: "Bash", shell: true, input: { command: PUSH }, output: `   0000000..${BRANCH_SHA.slice(0, 8)}  feat -> feat`, status: "ok" }]);
     const s = session("teammate", [pushTurn], "/elsewhere");
-    const promoted = await promoteOrphanSidechains([s.summary as never], [BRANCH_SHA], new Set(), async () => s.session as never);
+    const { promoted: promoted } = await promoteOrphanSidechains([s.summary as never], [BRANCH_SHA], new Set(), async () => s.session as never);
     expect(promoted).toHaveLength(0);
   });
 
   it("R2b: a commit-anchored sidechain still promotes, sliced", async () => {
     const commitTurn = turn(0, [{ name: "Bash", shell: true, input: { command: "git commit -m x" }, output: `[feat ${BRANCH_SHA.slice(0, 7)}] x`, status: "ok" }]);
     const s = session("teammate2", [commitTurn], "/elsewhere");
-    const promoted = await promoteOrphanSidechains([s.summary as never], [BRANCH_SHA], new Set(), async () => s.session as never);
+    const { promoted: promoted } = await promoteOrphanSidechains([s.summary as never], [BRANCH_SHA], new Set(), async () => s.session as never);
     expect(promoted).toHaveLength(1);
     expect(promoted[0].slice.kind).toBe("slice");
   });

--- a/test/pr/confidence.test.ts
+++ b/test/pr/confidence.test.ts
@@ -1,0 +1,65 @@
+// SPEC-0044 R1/R2 — the ConfidenceEvent contract: distinct-session counting,
+// the floor rule, and that A1's counted-absence surfaces on the rendered
+// receipt (the coverage-map C.2 hole — never a silent drop).
+import { describe, expect, it } from "vitest";
+import { summarizeConfidence, isFloored, type ConfidenceEvent } from "../../src/pr/confidence.js";
+import { renderPrReceiptText, type ContributorView } from "../../src/pr/body.js";
+
+const mix = (model: string, share: number) => ({ model, share });
+const tokens = (input: number, output: number) => ({ input, output, cacheRead: 0, cacheCreation: 0, total: input + output });
+function builder(over: Partial<ContributorView> = {}): ContributorView {
+  return {
+    role: "builder",
+    sessionId: "abc123",
+    slice: { kind: "slice", startTurn: 1, endTurn: 3, turnCount: 6 },
+    modelMix: [mix("claude-opus-4-8", 1)],
+    usd: 1.5,
+    tokens: tokens(900, 100),
+    subagents: [],
+    ...over,
+  };
+}
+
+describe("SPEC-0044 · summarizeConfidence", () => {
+  it("counts DISTINCT sessions per kind, not raw events", () => {
+    const events: ConfidenceEvent[] = [
+      { kind: "unattributable-anchor-pool", sessionId: "a" },
+      { kind: "unattributable-anchor-pool", sessionId: "a" }, // dup session — counts once
+      { kind: "unattributable-anchor-pool", sessionId: "b" },
+      { kind: "silenced-git-write", sessionId: "c" },
+      { kind: "cost-lower-bound-cache-tier", sessionId: "d" },
+    ];
+    const s = summarizeConfidence(events);
+    expect(s.unattributableAnchorPool).toBe(2);
+    expect(s.silencedGitWrite).toBe(1);
+    expect(s.costLowerBoundCacheTier).toBe(1);
+    expect(s.unreadableSubagent).toBe(0);
+  });
+
+  it("isFloored is true iff any incompleteness/lower-bound event exists", () => {
+    expect(isFloored(summarizeConfidence([]))).toBe(false);
+    expect(isFloored(summarizeConfidence([{ kind: "cost-lower-bound-cache-tier", sessionId: "x" }]))).toBe(true);
+    expect(isFloored(summarizeConfidence([{ kind: "unattributable-anchor-pool", sessionId: "y" }]))).toBe(true);
+  });
+});
+
+describe("SPEC-0044 A1 · counted-absence renders (not silent)", () => {
+  it("floors the total AND renders a distinct note, separate from excludedCount", () => {
+    const body = renderPrReceiptText({
+      contributors: [builder()],
+      excludedCount: 0,
+      confidence: summarizeConfidence([{ kind: "unattributable-anchor-pool", sessionId: "cross-repo-lead" }]),
+    });
+    expect(body).toMatch(/TOTAL priced\.+≥/); // the total is floored
+    expect(body).toContain("1 session touched this branch but couldn't be attributed precisely");
+    expect(body).toContain("see docs/trust.md");
+    // NOT conflated with the excluded-candidates note
+    expect(body).not.toContain("candidate session not attributed");
+  });
+
+  it("with excludedCount==0 and no confidence, the note is absent (no false positive)", () => {
+    const body = renderPrReceiptText({ contributors: [builder()], excludedCount: 0 });
+    expect(body).not.toContain("couldn't be attributed precisely");
+    expect(body).not.toMatch(/TOTAL priced\.+≥/);
+  });
+});

--- a/test/pr/promote.test.ts
+++ b/test/pr/promote.test.ts
@@ -38,6 +38,16 @@ function sidechain(id: string, turns: Turn[], startedAt = 1000): Session {
 const anchored = (id: string, startedAt = 1000) =>
   sidechain(id, [commitTurn(0, "[featB b1c2d3e] x\n 1 file changed")], startedAt);
 
+function pushTurn(index: number): Turn {
+  return {
+    index,
+    timestamp: 1000 + index,
+    model: "claude-opus-4-8",
+    usage,
+    toolCalls: [{ name: "Bash", shell: true, input: { command: "git push origin featB" }, output: `   0000000..${BRANCH_SHA.slice(0, 8)}  featB -> featB`, status: "ok" }],
+  };
+}
+
 function loader(sessions: Session[]) {
   const byId = new Map(sessions.map((s) => [s.id, s]));
   return async (summary: SessionSummary) => byId.get(summary.id) ?? null;
@@ -46,7 +56,7 @@ function loader(sessions: Session[]) {
 describe("SPEC-0024 R2 orphan sidechain promotion", () => {
   it("promotes an anchored sidechain no rollup covers, with its own PR slice", async () => {
     const teammate = anchored("teammate");
-    const promoted = await promoteOrphanSidechains([teammate], [BRANCH_SHA], new Set(), loader([teammate]));
+    const { promoted } = await promoteOrphanSidechains([teammate], [BRANCH_SHA], new Set(), loader([teammate]));
     expect(promoted.map((c) => c.summary.id)).toEqual(["teammate"]);
     expect(promoted[0].slice.kind).toBe("slice");
   });
@@ -54,25 +64,25 @@ describe("SPEC-0024 R2 orphan sidechain promotion", () => {
   it("skips a candidate whose filePath is already covered — the dedup guard (counted once)", async () => {
     const teammate = anchored("teammate");
     const covered = new Set([teammate.filePath]);
-    const promoted = await promoteOrphanSidechains([teammate], [BRANCH_SHA], covered, loader([teammate]));
+    const { promoted } = await promoteOrphanSidechains([teammate], [BRANCH_SHA], covered, loader([teammate]));
     expect(promoted).toHaveLength(0);
   });
 
   it("never promotes an anchorless sidechain (no cwd+time credit for sidechains)", async () => {
     const idle = sidechain("idle", [commitTurn(0, "nothing to commit, working tree clean")]);
-    const promoted = await promoteOrphanSidechains([idle], [BRANCH_SHA], new Set(), loader([idle]));
+    const { promoted } = await promoteOrphanSidechains([idle], [BRANCH_SHA], new Set(), loader([idle]));
     expect(promoted).toHaveLength(0);
   });
 
   it("never promotes a sidechain whose only SHA is foreign (another branch's commit)", async () => {
     const foreign = sidechain("foreign", [commitTurn(0, "[other deadbee1] y\n 1 file changed")]);
-    const promoted = await promoteOrphanSidechains([foreign], [BRANCH_SHA], new Set(), loader([foreign]));
+    const { promoted } = await promoteOrphanSidechains([foreign], [BRANCH_SHA], new Set(), loader([foreign]));
     expect(promoted).toHaveLength(0);
   });
 
   it("silently skips an unloadable sidechain", async () => {
     const ghost = anchored("ghost");
-    const promoted = await promoteOrphanSidechains([ghost], [BRANCH_SHA], new Set(), loader([]));
+    const { promoted } = await promoteOrphanSidechains([ghost], [BRANCH_SHA], new Set(), loader([]));
     expect(promoted).toHaveLength(0);
   });
 
@@ -82,7 +92,14 @@ describe("SPEC-0024 R2 orphan sidechain promotion", () => {
     const tieB = anchored("tie-b", 3000);
     const tieA = anchored("tie-a", 3000);
     const all = [late, tieB, early, tieA];
-    const promoted = await promoteOrphanSidechains(all, [BRANCH_SHA], new Set(), loader(all));
+    const { promoted } = await promoteOrphanSidechains(all, [BRANCH_SHA], new Set(), loader(all));
     expect(promoted.map((c) => c.summary.id)).toEqual(["early", "tie-a", "tie-b", "late"]);
   });
+  it("SPEC-0044 A1: a push-only (full-fallback) sidechain is COUNTED-ABSENT, not silently dropped", async () => {
+    const pushOnly = sidechain("push-only-teammate", [pushTurn(0)]);
+    const { promoted, events } = await promoteOrphanSidechains([pushOnly], [BRANCH_SHA], new Set(), loader([pushOnly]));
+    expect(promoted).toHaveLength(0);
+    expect(events).toContainEqual({ kind: "unattributable-anchor-pool", sessionId: "push-only-teammate.jsonl" });
+  });
+
 });


### PR DESCRIPTION
## What this adds

The enforceable spine of the cost-confidence work (SPEC-0044) and the **priority hole** the research found: an anchor-pool session that touched a PR but can only fall back to "entire session" was **dropped with zero trace** — the silent mirror of the #87 $965 over-credit bug. Now it can't be silent.

## The mechanism (R1)

`src/pr/confidence.ts` — a typed `ConfidenceEvent` discriminated union naming every reason a contributor's cost is dropped/degraded/lower-bounded. **Every** drop routes through it. Two guards make "no silent wrongness" a property, not a promise:
- `summarizeConfidence`'s exhaustive `never` switch — a new variant that renders no signal **fails to compile** (Codex verified TS2322).
- `scripts/hygiene.mjs` bans silent `excludedCount` mutation in the PR path — **proven** to fail on a reintroduced `+=`.

## A1, red-then-green (R2)

The anchor-pool full-fallback skip in **both** `contributors.ts` and `promote.ts` (the critic caught the second one) now emits `unattributable-anchor-pool`, threaded to `body.ts`:

```
TOTAL priced.................................≥ $4.65
...
1 session touched this branch but couldn't be attributed precisely
(see docs/trust.md)
```

Distinct from the "candidate session not attributed" note; floors the total; and when it's the *only* signal, the zero-contributor path says so instead of "no match." The strengthened R2a/promote tests assert the event now fires where before there was nothing.

## Docs (R6)

`docs/cost-model.md` (living, per-scenario strategy + when each event fires) and `trust.md` entries 13 (A1) and 14 (A2 Cursor Background Agents — known gap, its own spec).

## Scope

This ships the enforceable contract + the priority hole, green. **Remaining under the same `building` spec:** A3 (cache-tier caveat — variant declared, emitter deferred to avoid a hasty pricing-hot-path change), the scenario×agent matrix (R3-R5), and `--self-check` (R7).

## Evidence

tsc/eslint/goldens(95, additive — none regenerated)/determinism×10/spec-lint/hygiene green; 237 PR tests pass. Two Codex rounds: implementation REWORK (5 findings, all fixed) → **PASS**, no new regressions. Full S1-S5 in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)