### PR TITLE
feat: flag discovery-layer unreadable sessions, repo-scoped (SPEC-0045)

### DIFF
--- a/docs/trust.md
+++ b/docs/trust.md
@@ -159,3 +159,15 @@ that tells you exactly what it knows.
     credited, its total is a lower bound: the receipt says "N unreadable
     transcript record(s) skipped — total may be incomplete" and the PR total
     floors `≥`. A clean transcript never trips it.
+17. **A session that failed to parse before it was even a candidate**
+    (SPEC-0045). B4 (#15) catches a candidate whose full transcript won't load;
+    this catches the same failure one layer earlier — at *discovery*, where a
+    file that can't be parsed would otherwise be dropped before the PR flow sees
+    it. If its lazy metadata places it in **this repo**, it is flagged exactly
+    like #15 (floors `≥`, counted as an unreadable session). **The honest
+    limit:** a transcript so corrupt that even its lazy metadata (the working
+    directory) is lost cannot be tied to any particular repo, so it is excluded
+    without a per-receipt note — flagging it would fire on any corrupt file
+    anywhere under your agent's data directory, PR-relevant or not. A degraded
+    file is likewise excluded from every non-PR view (`week`, `compare`,
+    `--list`, budget), which never render an incomplete total for it.

--- a/specs/SPEC-0045-discovery-load-failure.md
+++ b/specs/SPEC-0045-discovery-load-failure.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0045
 title: "Discovery-layer load failures — the session that never became a candidate"
-status: draft
+status: building
 milestone: M4
 depends: [SPEC-0044]
 ---
@@ -57,12 +57,12 @@ event.
 - **R1 — Retain degraded summaries with a typed reason.** When
   `completeSummariesWithCache` fails to complete a lazy summary *because the
   transcript's own parse failed* (not a transient stat/size/cache miss — those
-  are retried, never marked degraded), mark it `degraded: "parse"` (a field on
+  are retried, never marked degraded), mark it `degraded: "unreadable"` (a field on
   `SessionSummary`, cited in `parse/types.ts`, not inlined) and RETAIN it. The
   distinction matters: only a deterministic parse failure guarantees the PR-side
   `loadSession` will also return null (S2 finding 4).
 - **R2 — PR-layer routing: degraded + repo-scoped → `unreadable-session`.** In
-  `selectContributors`, a candidate whose summary is `degraded: "parse"` AND
+  `selectContributors`, a candidate whose summary is `degraded: "unreadable"` AND
   whose `cwd` resolves into the current repo/worktree emits `unreadable-session`
   (SPEC-0044 B4's variant) and floors `≥` — routed explicitly, NOT into the
   `here`→`silenced-git-write` path (S2 finding 1). A degraded candidate with NO
@@ -74,7 +74,7 @@ event.
   summaries: `week` (`aggregate/week.ts`), `compare`, token budget
   (`budget/compute.ts`), `--list` + its `--json` (`cli/commands/list.ts`,
   `receipt/json.ts`). The default receipt uses `newestSession()` (lazy, a
-  different path — S2 finding 5): if the newest is `degraded: "parse"`, skip to
+  different path — S2 finding 5): if the newest is `degraded: "unreadable"`, skip to
   the next readable session rather than render a zero receipt. A test pins each
   surface (S2 finding 6).
 - **R4 — Sub-case 2 + unscopeable sub-case-1 are documented, not surfaced.** A
@@ -117,7 +117,7 @@ event.
 
 | Case | Input | Expected |
 |---|---|---|
-| R1 degraded flag | lazy-ok + parse-fails file | summary retained, `degraded: "parse"`; a transient stat/cache miss is NOT marked degraded |
+| R1 degraded flag | lazy-ok + parse-fails file | summary retained, `degraded: "unreadable"`; a transient stat/cache miss is NOT marked degraded |
 | R2 scoped emit (here) | degraded file, `cwd` in current worktree | `unreadable-session` fires (NOT `silenced-git-write`), total floors `≥` |
 | R2 scoped emit (anchor-pool) | degraded file, `cwd` in repo, cross-worktree | `unreadable-session` fires |
 | R2 anti-wallpaper | degraded file, no `cwd`, in branch window | NO event, NO floor |
@@ -156,7 +156,7 @@ accepted:
    anti-wallpaper guard: fire only when `cwd` is repo-scoped; else → R4.
 3. HIGH — R3 non-PR caller list incomplete → added budget, `--list`/`--json`.
 4. MEDIUM — `loadSession`-null not guaranteed → R1 marks degraded ONLY on a
-   deterministic parse failure (`degraded: "parse"`), not transient stat/cache.
+   deterministic parse failure (`degraded: "unreadable"`), not transient stat/cache.
 5. MEDIUM — default receipt uses `newestSession` (lazy) → R3 handles that path
    explicitly (fall through to next readable).
 6. Missing test rows → added (here/anchor-pool/no-cwd/outside-repo/budget/list/
@@ -171,3 +171,25 @@ day R1/R2 land.
 **2026-07-05 · S4 (lint):** `node scripts/spec-lint.mjs` → OK.
 
 Status remains draft pending maintainer approval (button 1).
+
+**2026-07-05 · approved (button 1):** maintainer, in-session ("lets do" + Option
+A repo-cwd-scoped). Status → building.
+
+**2026-07-05 · implementation review (Codex): REWORK → all addressed.**
+1. HIGH — `load()→null` also covers missing/raced/IO files, so `degraded:"parse"`
+   mislabels → renamed the reason to cause-agnostic `degraded:"unreadable"` (the
+   user-facing signal — "couldn't read a session" — is honest for all of them);
+   only a load-null after a *successful* stat sets it (a transient stat throw
+   stays a dropped null, never degraded).
+2. HIGH — the no-selector default receipt used lazy `newestSession` and errored
+   on a corrupt newest → `resolveSelector` now iterates lazy summaries and
+   returns the newest that LOADS (carrying the pre-loaded session so `receipt.ts`
+   doesn't re-parse — same load count in the common case), skipping an
+   unreadable newest.
+3. MEDIUM — anti-wallpaper admission was under-tested → added a runPr test: a
+   degraded no-cwd session that only overlaps the window does NOT fire
+   `unreadable-session` (kills the `if (s.degraded) continue` mutant).
+4. LOW — confirmed the R2 contributor test kills the routing mutant (degraded →
+   `unreadable-session` vs → `excludeHere`).
+5. LOW — no golden risk (additive field; default `listFullSessions` filters
+   degraded).

--- a/specs/SPEC-0045-discovery-load-failure.md
+++ b/specs/SPEC-0045-discovery-load-failure.md
@@ -1,0 +1,173 @@
+---
+id: SPEC-0045
+title: "Discovery-layer load failures — the session that never became a candidate"
+status: draft
+milestone: M4
+depends: [SPEC-0044]
+---
+
+# SPEC-0045 · discovery-layer load failures
+
+Invariants: I2 (never silently under-report), I3 (traceable + uncertainty
+stated). The deferred follow-up from SPEC-0044 B4's review: B4 closed the
+*selection*-layer silent drop (a candidate whose `loadSession` returns null now
+emits `unreadable-session`), but a session that fails at the *discovery* layer —
+before it ever becomes a candidate — is still dropped with no signal.
+
+## Purpose
+
+`src/pr/index.ts` filters `listFullSessions()` summaries into candidates, then
+`loadSession`s each; B4 flags a `loadSession` null. Two discovery-layer drops
+happen *upstream*, so the session never reaches the candidate filter:
+
+- **Sub-case 1 — full-completion failure, metadata survives.** A lazy summary is
+  built (`filePath`, `source`, `startedAt` from first record, `endedAt` from
+  mtime, and — for Claude/Codex/Gemini — a first-record `cwd`), but
+  `completeSummariesWithCache` fails to complete it and drops it
+  (`summaryCache.ts:207` `results.filter((s) => s !== null)`).
+- **Sub-case 2 — lazy-summary failure, no metadata.** The adapter's own
+  `listSessions` catch (`claudeCode.ts:416/432`) drops a file that can't produce
+  even a lazy summary — no `cwd`/timestamps, so PR-relevance is unknowable.
+
+**S2 killed the naive "reuse B4 for free" premise; the corrected design:** a
+degraded summary does NOT automatically hit B4's emission. `selectContributors`
+routes a load-null `here` (current-worktree) candidate to `silenced-git-write`,
+not `unreadable-session` (`contributors.ts:165` vs `:173`), and the anchor pool
+admits a no-cwd file on time-overlap alone — which would *wallpaper*. So R1 adds
+explicit PR-layer routing keyed on a degraded **reason**, and scopes strictly to
+repo-cwd relevance. Sub-case 2 (no metadata → unscopeable) is documented, not
+surfaced (the A3 crying-wolf lesson).
+
+**Organizing principle (unchanged from SPEC-0044):** a session that touched a PR
+is credited, or its absence is *visibly* flagged — extended up to discovery,
+honestly: scoped where cwd lets us scope, documented where we structurally
+cannot.
+
+**Kill criterion:** (a) the `unreadable-session` signal fires ONLY for a
+degraded file whose `cwd` places it in THIS repo/worktree — never on
+time-overlap alone (no wallpaper; verified by a degraded no-cwd + in-window
+fixture that must NOT fire). (b) No non-PR surface (`week`, `compare`, token
+budget, `--list`/`--json`, the default receipt) renders a degraded summary's
+incomplete/zero total. If (a) can't be met because the degraded summary lacks a
+reliable `cwd`, that file is unscopeable and falls to R3 (docs), not a fired
+event.
+
+## Requirements
+
+- **R1 — Retain degraded summaries with a typed reason.** When
+  `completeSummariesWithCache` fails to complete a lazy summary *because the
+  transcript's own parse failed* (not a transient stat/size/cache miss — those
+  are retried, never marked degraded), mark it `degraded: "parse"` (a field on
+  `SessionSummary`, cited in `parse/types.ts`, not inlined) and RETAIN it. The
+  distinction matters: only a deterministic parse failure guarantees the PR-side
+  `loadSession` will also return null (S2 finding 4).
+- **R2 — PR-layer routing: degraded + repo-scoped → `unreadable-session`.** In
+  `selectContributors`, a candidate whose summary is `degraded: "parse"` AND
+  whose `cwd` resolves into the current repo/worktree emits `unreadable-session`
+  (SPEC-0044 B4's variant) and floors `≥` — routed explicitly, NOT into the
+  `here`→`silenced-git-write` path (S2 finding 1). A degraded candidate with NO
+  `cwd`, or a `cwd` outside this repo, is NOT admitted on time-overlap alone and
+  does NOT fire (S2 finding 2 — the anti-wallpaper guard); it is unscopeable →
+  R4.
+- **R3 — Non-PR surfaces exclude degraded summaries (ALL of them).** Every
+  non-PR consumer that reads a summary's totals filters out `degraded`
+  summaries: `week` (`aggregate/week.ts`), `compare`, token budget
+  (`budget/compute.ts`), `--list` + its `--json` (`cli/commands/list.ts`,
+  `receipt/json.ts`). The default receipt uses `newestSession()` (lazy, a
+  different path — S2 finding 5): if the newest is `degraded: "parse"`, skip to
+  the next readable session rather than render a zero receipt. A test pins each
+  surface (S2 finding 6).
+- **R4 — Sub-case 2 + unscopeable sub-case-1 are documented, not surfaced.** A
+  file that fails lazy-summary building, or a degraded file with no usable
+  `cwd`, cannot be scoped to a PR; `docs/trust.md` gains a "discovery-layer
+  limitation" entry stating these are excluded and why. No per-receipt caveat
+  (unscoped → wallpaper). (R3-telemetry from the prior draft is CUT per S2
+  finding 7 — it added plumbing for no user-visible scoped signal.)
+- **R5 — Discovery stays isolated + deterministic.** Retaining degraded
+  summaries never reorders complete summaries, never aborts the list on one bad
+  file (existing per-adapter isolation holds), and is deterministic (same
+  corrupt fixture → same degraded entry, verified ×10).
+
+## Scenarios
+
+- **Given** a transcript whose `cwd` is in THIS repo and whose lazy summary
+  builds but parse fails, **when** the PR receipt renders, **then**
+  `unreadable-session` fires and the total floors `≥` (R2).
+- **Given** a degraded file with no `cwd` (or a `cwd` in another repo) that
+  merely overlaps the branch window, **then** NO event fires — not wallpaper
+  (R2 anti-wallpaper).
+- **Given** a degraded summary exists, **when** `week`/`compare`/budget/`--list`
+  run, **then** it is excluded; no incomplete/zero total renders (R3).
+- **Given** the newest session is degraded, **when** the default receipt runs,
+  **then** it falls through to the next readable session (R3).
+- **Given** a file that fails lazy-summary building, **then** nothing renders and
+  `trust.md` documents the exclusion (R4).
+
+## Non-goals
+
+- **Recovering an unreadable transcript's cost** — no parseable tokens; make the
+  ABSENCE visible, never fabricate a `$`.
+- **Scoping sub-case 2 or a no-cwd degraded file** — structurally impossible; R4
+  documents it.
+- **A per-receipt global unreadable-file count** — rejected as wallpaper.
+- **Discovery-to-telemetry plumbing for sub-case 2** — cut (S2 finding 7).
+- **Changing B4's existing selection emission** — R2 adds a sibling route.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 degraded flag | lazy-ok + parse-fails file | summary retained, `degraded: "parse"`; a transient stat/cache miss is NOT marked degraded |
+| R2 scoped emit (here) | degraded file, `cwd` in current worktree | `unreadable-session` fires (NOT `silenced-git-write`), total floors `≥` |
+| R2 scoped emit (anchor-pool) | degraded file, `cwd` in repo, cross-worktree | `unreadable-session` fires |
+| R2 anti-wallpaper | degraded file, no `cwd`, in branch window | NO event, NO floor |
+| R2 outside repo | degraded file, `cwd` in another repo | NO event |
+| R3 week/compare | a degraded summary present | excluded; no incomplete total |
+| R3 budget + `--list`/`--json` | a degraded summary present | excluded from totals/rows/JSON |
+| R3 default receipt | newest session is degraded | falls through to next readable |
+| R4 sub-case 2 | file fails lazy-summary build | nothing rendered; documented |
+| R5 determinism | same corrupt fixture ×10 | identical degraded entry, stable order |
+
+## Success criteria
+
+- [ ] A repo-scoped degraded session flags `unreadable-session`; a no-cwd /
+      out-of-repo degraded file does NOT (red-then-green, both directions).
+- [ ] `week`/`compare`/budget/`--list`/`--json`/default-receipt never render a
+      degraded summary's total (a test per surface).
+- [ ] Sub-case 2 + unscopeable degraded are docs-only; no receipt caveat.
+- [ ] `docs/trust.md` gains the discovery-layer limitation entry.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`,
+      `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
+      `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` pass unmasked; the
+      `src/pr/**` + `src/pricing/**` mutation gate (SPEC-0044 M3) holds.
+
+## Validation
+
+**2026-07-05 · S1 (self):** grounded the two sub-cases in `summaryCache.ts:207`
+and the adapter catches; the initial "reuse B4 for free" framing was the risk.
+
+**2026-07-05 · S2 (Codex, read-only): REWORK → reworked.** 7 findings, all
+accepted:
+1. CRITICAL — degraded `here` candidate routes to `silenced-git-write`, not
+   `unreadable-session` → R2 now adds explicit PR-layer routing keyed on the
+   degraded reason, bypassing the `here` path.
+2. HIGH — no-cwd degraded fires on time-overlap alone (wallpaper) → R2
+   anti-wallpaper guard: fire only when `cwd` is repo-scoped; else → R4.
+3. HIGH — R3 non-PR caller list incomplete → added budget, `--list`/`--json`.
+4. MEDIUM — `loadSession`-null not guaranteed → R1 marks degraded ONLY on a
+   deterministic parse failure (`degraded: "parse"`), not transient stat/cache.
+5. MEDIUM — default receipt uses `newestSession` (lazy) → R3 handles that path
+   explicitly (fall through to next readable).
+6. Missing test rows → added (here/anchor-pool/no-cwd/outside-repo/budget/list/
+   default/transient-vs-parse).
+7. Cut R3-telemetry (weakest) → sub-case 2 is docs-only (R4).
+
+**2026-07-05 · S3 (value gate):** the evidence is B4's own review — this exact
+gap was found one layer down while fixing B4, on this repo. The red-then-green
+(a repo-scoped degraded fixture fires; a no-cwd one does not) is runnable the
+day R1/R2 land.
+
+**2026-07-05 · S4 (lint):** `node scripts/spec-lint.mjs` → OK.
+
+Status remains draft pending maintainer approval (button 1).

--- a/src/cli/commands/receipt.ts
+++ b/src/cli/commands/receipt.ts
@@ -36,7 +36,9 @@ async function run(ctx: CommandContext): Promise<number> {
     ctx.stderr.write(`${resolved.error}\n`);
     return 1;
   }
-  const session = await loadSession(resolved.summary);
+  // SPEC-0045 R3 — the no-selector default already loaded a readable session
+  // (skipping any unreadable newest); reuse it, no second parse.
+  const session = resolved.session ?? (await loadSession(resolved.summary));
   if (!session) {
     ctx.stderr.write(`failed to load session "${resolved.summary.id}"\n`);
     return 1;

--- a/src/cli/common/session.ts
+++ b/src/cli/common/session.ts
@@ -2,8 +2,8 @@
 // benchmark commands, under common ownership. Moved verbatim from the pre-refactor
 // CLI dispatcher — selector logic still delegates to the parse layer's
 // `listFullSessions`/`selectSummary`/`newestSession`; nothing is reimplemented.
-import { anyDetected, listFullSessions, newestSession, rootsHint, selectSummary } from "../../index.js";
-import type { SessionSummary } from "../../parse/types.js";
+import { anyDetected, listFullSessions, listSessions, loadSession, rootsHint, selectSummary } from "../../index.js";
+import type { Session, SessionSummary } from "../../parse/types.js";
 import { TEMPLATE_NAMES, isTemplateName } from "../../receipt/blocks.js";
 import type { TemplateName } from "../../receipt/blocks.js";
 
@@ -16,13 +16,21 @@ export async function noSessionsMessage(): Promise<string> {
 
 export async function resolveSelector(
   selector: string | undefined,
-): Promise<{ summary: SessionSummary } | { error: string }> {
+): Promise<{ summary: SessionSummary; session?: Session } | { error: string }> {
   if (selector === undefined || selector.trim() === "") {
-    const summary = await newestSession();
-    if (!summary) {
-      return { error: await noSessionsMessage() };
+    // SPEC-0045 R3 — the default receipt shows the NEWEST readable session. A
+    // corrupt/unreadable newest is skipped (fall through to the next) rather
+    // than erroring; the session is loaded here and returned so the caller
+    // renders it without a second load (same load count as before in the common
+    // case, where the newest reads fine on the first try).
+    const lazy = await listSessions();
+    for (const summary of lazy) {
+      const session = await loadSession(summary);
+      if (session) {
+        return { summary, session };
+      }
     }
-    return { summary };
+    return { error: await noSessionsMessage() };
   }
   const sessions = await listFullSessions();
   if (sessions.length === 0) {

--- a/src/parse/load.ts
+++ b/src/parse/load.ts
@@ -14,8 +14,17 @@ export async function listSessions(agent?: AgentSource): Promise<SessionSummary[
   return sortMostRecentFirst(lists.flat());
 }
 
-/** Full summaries across every adapter, most-recent-first, with an incremental file-summary cache for JSONL transcripts. */
-export async function listFullSessions(agent?: AgentSource): Promise<SessionSummary[]> {
+/**
+ * Full summaries across every adapter, most-recent-first, with an incremental
+ * file-summary cache for JSONL transcripts.
+ *
+ * SPEC-0045 R3 — a `degraded: "unreadable"` summary (retained by R1 so the PR layer
+ * can flag an unreadable session) has no reliable totals, so it is EXCLUDED by
+ * default: every non-PR consumer (`week`, `compare`, token budget, `--list`)
+ * calls this without opting in and never sees a degraded summary's zero total.
+ * Only the PR flow passes `includeDegraded: true`.
+ */
+export async function listFullSessions(agent?: AgentSource, opts?: { includeDegraded?: boolean }): Promise<SessionSummary[]> {
   const pool = agent ? adapters().filter((a) => a.id === agent) : adapters();
   const cache = await SummaryCache.load();
   const lists = await Promise.all(
@@ -36,7 +45,9 @@ export async function listFullSessions(agent?: AgentSource): Promise<SessionSumm
     }),
   );
   await cache.save();
-  return sortMostRecentFirst(lists.flat());
+  const all = lists.flat();
+  const filtered = opts?.includeDegraded ? all : all.filter((s) => s.degraded === undefined);
+  return sortMostRecentFirst(filtered);
 }
 
 /** The mtime-newest lazy summary, used before full-parsing exactly one default receipt session. */

--- a/src/parse/summaryCache.ts
+++ b/src/parse/summaryCache.ts
@@ -192,7 +192,13 @@ export async function completeSummariesWithCache(
       }
       const full = await opts.load(summary);
       if (!full) {
-        return null;
+        // SPEC-0045 R1 — the lazy summary built but the full transcript can't be
+        // read (loadSession returned null — a corrupt transcript, or a file that
+        // vanished/errored after stat; all honestly "unreadable"). Retain it marked
+        // degraded so the PR layer can flag a repo-scoped unreadable session
+        // (R2) instead of it vanishing at discovery. NOT cached — a fixed file
+        // should re-parse cleanly next run.
+        return { ...summary, degraded: "unreadable" as const };
       }
       const fullSummary = stripTurns(full);
       cache.set(summary.filePath, stat, fullSummary);

--- a/src/parse/types.ts
+++ b/src/parse/types.ts
@@ -114,6 +114,15 @@ export interface SessionSummary {
    * the receipt renders a tokens-only note instead (I2). */
   unpriceable?: boolean;
   /**
+   * SPEC-0045 R1 — the lazy summary built (this carries `filePath`/timestamps/
+   * `cwd`) but the FULL transcript failed to parse (`loadSession` returns null).
+   * Retained through discovery rather than silently dropped so the PR layer can
+   * flag a repo-scoped unreadable session (R2). Only a *deterministic* parse
+   * failure sets this — never a transient stat/cache miss. A degraded summary
+   * has no reliable totals; every non-PR surface excludes it (R3).
+   */
+  degraded?: "unreadable";
+  /**
    * SPEC-0019 R1a — attribution-only. The raw session's working directory and
    * git branch (first seen in the transcript). Used solely to match a session
    * to the current repo/worktree for `aireceipts pr`. Absent in the raw

--- a/src/pr/contributors.ts
+++ b/src/pr/contributors.ts
@@ -163,6 +163,15 @@ export async function selectContributors(
   for (const l of loaded) {
     const { summary, here, session, anchors } = l;
     if (!session || !anchors) {
+      // SPEC-0045 R2 — a repo-scoped transcript we couldn't PARSE (degraded at
+      // discovery). Only repo-scoped degraded files reach here (index.ts keeps
+      // no-cwd degraded out of the pools), so "couldn't read" ≠ "unproven repo
+      // candidate": flag it via the typed event even when `here`, never fold it
+      // into the silent silenced-git-write excluded count.
+      if (summary.degraded === "unreadable") {
+        events.push({ kind: "unreadable-session", sessionId: summary.filePath });
+        continue;
+      }
       // A candidate we can't load can't be proven. In the current worktree it's
       // the classic excluded count; OUTSIDE it (anchor pool / sibling worktree)
       // it used to vanish silently — SPEC-0044 B4: "couldn't read" ≠ "not ours",

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -75,7 +75,10 @@ export interface PrRunResult {
 
 export function defaultPrDeps(overrides: Partial<PrDeps> = {}): PrDeps {
   return {
-    listSessions: async () => (await import("../parse/load.js")).listFullSessions(),
+    // SPEC-0045 R3 — only the PR flow opts into degraded summaries (so it can
+    // flag a repo-scoped unreadable session, R2); every other surface excludes
+    // them by default.
+    listSessions: async () => (await import("../parse/load.js")).listFullSessions(undefined, { includeDegraded: true }),
     loadSession: async (summary) => (await import("../parse/load.js")).loadSession(summary),
     runGit: defaultRunner,
     runGh: defaultRunner,
@@ -179,6 +182,14 @@ async function resolveContributors(
     if (isBranchCandidate(s, roots, commitMs)) {
       candidates.push({ summary: s, pool: "repo" });
     } else if (overlapsBranchWindow(s, commitMs)) {
+      // SPEC-0045 R2 anti-wallpaper — a degraded (unparseable) file that only
+      // overlaps the branch window, with no repo cwd match, is NOT proven ours;
+      // admitting it to the anchor pool would fire `unreadable-session` on time
+      // overlap alone (wallpaper). Unscopeable → excluded, documented (R4). A
+      // degraded file WITH a repo cwd took the isBranchCandidate branch above.
+      if (s.degraded) {
+        continue;
+      }
       // SPEC-0024 R1/R2 — time-overlapping but outside the repo pool: flagged
       // sidechains queue for promotion; everything else (cross-repo leads,
       // no-cwd sessions) joins the anchor pool, credited on SHA proof only.
@@ -192,7 +203,9 @@ async function resolveContributors(
   for (const n of nested) {
     if (isBranchCandidate(n.summary, roots, commitMs)) {
       candidates.push({ summary: n.summary, pool: "repo" });
-    } else if (overlapsBranchWindow(n.summary, commitMs)) {
+    } else if (overlapsBranchWindow(n.summary, commitMs) && !n.summary.degraded) {
+      // SPEC-0045 R2 anti-wallpaper — same rule as the top-level pool: a degraded
+      // nested candidate only joins the pools when repo-scoped (branch above).
       candidates.push({ summary: n.summary, pool: "anchor" });
     }
   }

--- a/test/parse/discovery-cache.test.ts
+++ b/test/parse/discovery-cache.test.ts
@@ -9,6 +9,44 @@ import type { SessionSummary } from "../../src/parse/types.js";
 
 const tmpRoots: string[] = [];
 
+const ZERO_USAGE = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 };
+
+describe("SPEC-0045 R1 — degraded retention", () => {
+  const lazy: SessionSummary = {
+    id: "/x/broken.jsonl",
+    source: "claude-code",
+    filePath: "/x/broken.jsonl",
+    cwd: "/repo/app",
+    startedAt: 1000,
+    endedAt: 2000,
+    totals: { tokens: ZERO_USAGE, turnCount: 0, toolCallCount: 0 },
+  };
+
+  it("retains a lazy summary whose FULL parse fails, marked degraded (not dropped)", async () => {
+    const cachePath = path.join(await tempRoot("dc-r1-"), "cache.json");
+    // load() returns null — the deterministic parse failure that degrades it.
+    const result = await completeSummariesWithCache([lazy], {
+      cachePath,
+      stat: async () => ({ size: 100, mtimeMs: 42 }),
+      load: async () => null,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].degraded).toBe("unreadable");
+    expect(result[0].filePath).toBe("/x/broken.jsonl");
+    expect(result[0].cwd).toBe("/repo/app"); // metadata survives → PR layer can scope it
+  });
+
+  it("does NOT mark an empty (size 0) file degraded — that's transient, dropped", async () => {
+    const cachePath = path.join(await tempRoot("dc-r1e-"), "cache.json");
+    const result = await completeSummariesWithCache([lazy], {
+      cachePath,
+      stat: async () => ({ size: 0, mtimeMs: 42 }),
+      load: async () => null,
+    });
+    expect(result).toHaveLength(0);
+  });
+});
+
 afterEach(async () => {
   await Promise.all(tmpRoots.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 });

--- a/test/pr/contributors.test.ts
+++ b/test/pr/contributors.test.ts
@@ -220,6 +220,22 @@ describe("SPEC-0024 R1 anchor pool (SHA anchor is the only key)", () => {
     // the total floors `≥` (SPEC-0044 B4 — the honesty red-team gap).
     expect(summarizeConfidence(sel.events).unreadableSession).toBe(1);
   });
+
+  it("SPEC-0045 R2 — a degraded (parse-failed) repo candidate flags unreadable-session even when `here`, not the silent excluded count", async () => {
+    // A repo-scoped transcript whose lazy summary built (cwd = CURRENT_ROOT) but
+    // whose full parse fails — `degraded: "unreadable"`, retained through discovery
+    // (R1). Because cwd is the current worktree it is `here`; the pre-0045 path
+    // folded a load-null `here` candidate into the SILENT silenced-git-write
+    // excluded count (S2 CRITICAL). SPEC-0045 routes a degraded candidate to
+    // `unreadable-session` instead. `loaderFor([])` returns null — the same
+    // parse failure that degraded it.
+    const degraded: PoolCandidate = { summary: { ...summaryOf(makeSession("dgr-here", [])), degraded: "unreadable" }, pool: "repo" };
+    const sel = await selectContributors([degraded], [BRANCH_SHA], loaderFor([]));
+    expect(sel.contributors).toHaveLength(0);
+    expect(summarizeConfidence(sel.events).unreadableSession).toBe(1);
+    // NOT the silent excluded count — that's the whole point of the fix.
+    expect(sel.excludedCount).toBe(0);
+  });
 });
 
 describe("R3 role derivation (descriptive, not ranking)", () => {

--- a/test/pr/run.test.ts
+++ b/test/pr/run.test.ts
@@ -8,6 +8,7 @@ import { loadById } from "../../src/parse/load.js";
 import type { CommandResult, CommandRunner } from "../../src/pr/git.js";
 import { DOGFOOD_MARKER } from "../../src/pr/body.js";
 import { runPr, type PrDeps } from "../../src/pr/index.js";
+import type { SessionSummary } from "../../src/parse/types.js";
 
 const FIX = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "pr");
 const ANCHORS = path.join(FIX, "claude-anchors.jsonl");
@@ -80,6 +81,29 @@ describe("R3 render-first ordering", () => {
     expect(ghCalled).toBe(false);
     expect(out[0].startsWith(DOGFOOD_MARKER)).toBe(true);
     expect(out[0]).toContain("session slice: turns 2–4 of 6");
+  });
+
+  it("SPEC-0045 R2 anti-wallpaper — a degraded no-cwd session that only overlaps the window does NOT flag unreadable-session", async () => {
+    // A transcript that failed to parse (degraded) with NO cwd, whose timestamps
+    // merely overlap the branch window. Without repo-cwd proof it isn't ours, so
+    // index.ts keeps it OUT of the anchor pool (the `if (s.degraded) continue`
+    // guard) — it must NOT fire `unreadable-session`, or every corrupt file
+    // anywhere would floor unrelated PRs.
+    const real = (await loadById("claude-code", ANCHORS))!;
+    const degradedNoCwd: SessionSummary = {
+      id: "/elsewhere/ghost.jsonl",
+      source: "claude-code",
+      filePath: "/elsewhere/ghost.jsonl",
+      startedAt: Date.parse("2026-06-28T10:02:20.000Z"),
+      endedAt: Date.parse("2026-06-28T10:02:40.000Z"),
+      totals: { tokens: { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 }, turnCount: 0, toolCallCount: 0 },
+      degraded: "unreadable", // no cwd → not repo-scoped
+    };
+    const { deps, out } = await makeDeps({ listSessions: async () => [real, degradedNoCwd] });
+    const code = await runPr({ post: false }, deps);
+    expect(code).toBe(0);
+    // The real session still renders; the no-cwd degraded file is silent.
+    expect(out[0]).not.toContain("couldn't be read");
   });
 
   it("explicit --session can select a subagent by stem, render, and post", async () => {


### PR DESCRIPTION
## What this fixes

The deferred follow-up from SPEC-0044 B4's review. B4 flags a candidate whose transcript fails to load at the *selection* layer; this closes the sibling gap where a session fails at **discovery** (`listFullSessions`) and never becomes a candidate at all — dropped with no signal. Supersedes the draft-spec PR #127.

## See it

```
degraded (unparseable) transcript, cwd = THIS repo:
  ⚠ a session touched this branch but couldn't be read   ← flagged, total floors ≥

degraded transcript, no cwd / another repo, only time-overlap:
  (silent — not proven ours; anti-wallpaper)

week / compare / --list / budget:  degraded rows excluded (no zero totals)
default receipt, newest is corrupt:  skips to the next readable session
```

## What changed

- **R1** — `completeSummariesWithCache` retains a lazy summary (carries cwd/timestamps) marked `degraded: "unreadable"` on a full-parse null, instead of dropping it.
- **R2** — repo-cwd-scoped: a degraded candidate in this repo emits `unreadable-session` (not the silent `silenced-git-write` count — the S2 CRITICAL finding); `index.ts` keeps no-cwd/out-of-repo degraded files out of the anchor pool (anti-wallpaper).
- **R3** — `listFullSessions` excludes degraded by default (PR opts in); the default receipt skips an unreadable newest, pre-loading the next so there's no second parse.
- **R4** — unscopeable cases documented in `trust.md`, no wallpaper caveat.

## What to review, in order

1. `src/pr/index.ts` — the `if (s.degraded) continue` anti-wallpaper guard: can a no-cwd degraded file still reach the emission? (Codex traced every path: no.)
2. `src/pr/contributors.ts` — degraded → `unreadable-session`, even when `here`, not the silent count.
3. `src/parse/summaryCache.ts` — degraded only on a load-null after a successful stat (not a transient throw).
4. `test/pr/run.test.ts` anti-wallpaper + `contributors.test.ts` R2 — the mutant-killers.

## Evidence

tsc / eslint / goldens (byte-identical, additive field) / spec-lint / hygiene green. Codex impl review: **REWORK → all 5 findings addressed** (cause-agnostic `unreadable` rename; default-receipt fall-through; anti-wallpaper test; dispositions in the spec Validation). Full suite + `src/pr/**` mutation gate on CI. One pre-existing environmental flake (`hook-commands` closed-stdin consent) is unrelated to this diff and passes in CI. `--json`/`--csv` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)