### PR TITLE
chore: v0.1.0-verdict fast-follows — license, NOTICE, handoff plural

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,4 +2,4 @@ aireceipts
 Copyright 2026 Anand Gupta
 
 This product includes software developed as part of the aireceipts project
-(https://github.com/anandgupta42/aireceipts).
+(https://github.com/anandgupta42/receipts).

--- a/goldens/handoff-claude-code-loop-bash-5x.txt
+++ b/goldens/handoff-claude-code-loop-bash-5x.txt
@@ -4,4 +4,4 @@ claude-opus-4-8 100%
 total $0.09 · 6 turns · 5 tool calls
 - Bash loop ×5: $0.08, 3m 45s wall-clock
 
-covers: 6 turns · 5 tool calls · 0 compactions · 1 waste lines
+covers: 6 turns · 5 tool calls · 0 compactions · 1 waste line

--- a/specs/SPEC-0000-product.md
+++ b/specs/SPEC-0000-product.md
@@ -68,7 +68,7 @@ doubt, this file wins.
 
 ## OSS / indie / zero-telemetry stance
 
-aireceipts is built in the open by one person, as OSS, MIT-licensed. It is not a company
+aireceipts is built in the open by one person, as OSS, Apache-2.0-licensed. It is not a company
 product and is not gated behind a signup. Beyond the disclosed, one-switch-escapable I4
 telemetry contract (diagnostics plus pseudonymous feature-adoption events), it never
 phones home: no third-party analytics, no crash uploads, no update pings. If a future opt-in feature

--- a/specs/SPEC-0001-m1-receipt-engine.md
+++ b/specs/SPEC-0001-m1-receipt-engine.md
@@ -22,8 +22,8 @@ everything later builds on the primitives this milestone lands.
 ## Requirements
 
 - **R1 — Adapters.** Discover and parse local transcripts into one normalized `Session`
-  model. Extract from the maintainer’s earlier private tooling (same author; re-license
-  MIT): `src/trace/types.ts`, `load.ts`, `registry.ts`, `claudeCode.ts` + `anthropic.ts`,
+  model. Extract from the maintainer’s earlier private tooling (same author; re-licensed
+  Apache-2.0): `src/trace/types.ts`, `load.ts`, `registry.ts`, `claudeCode.ts` + `anthropic.ts`,
   `codex.ts` — stripped of receipt/attestation/store code. **Cursor is a degraded-mode
   adapter in M1**: its source (`cursor.ts`) exposes no model id and total-only tokens, so
   it supports `--list` and a tokens-only receipt, never priced per-tool attribution

--- a/specs/SPEC-0004-launch-surface.md
+++ b/specs/SPEC-0004-launch-surface.md
@@ -26,7 +26,7 @@ runs `npx aireceipts` within 60 seconds.
   matrix incl. Cursor's degraded mode, stated honestly), what it will never claim
   (the honesty ladder in one sentence), the telemetry sentence linking
   docs/telemetry.md, quickstart for `compare` and `--handoff`, samosa placeholder,
-  MIT. ≤120 lines.
+  Apache-2.0. ≤120 lines.
 - **R2 — docs/telemetry.md.** Field-by-field schema exactly mirroring SPEC-0002's zod
   schemas (SPEC-0002's parity test binds this file), kill switches, the open
   embedded-key note, first-run notice text reproduced.
@@ -40,7 +40,7 @@ runs `npx aireceipts` within 60 seconds.
   README quickstart commands verbatim against a fixture — the honest prepublish stand-in
   for `npx aireceipts` (S2 finding). Public-npx verification stays a release-day check.
 - **R6 — Docs lint.** A script asserts: README ≤120 lines with required sections
-  (hero/quickstart/supported/telemetry/license), telemetry link present, MIT + samosa
+  (hero/quickstart/supported/telemetry/license), telemetry link present, Apache-2.0 + samosa
   placeholders present, assets referenced by README exist and byte-match regeneration,
   and the voice grep (zero `founder|Altimate|internal` in README/docs/CONTRIBUTING).
 

--- a/src/receipt/handoff.ts
+++ b/src/receipt/handoff.ts
@@ -112,9 +112,14 @@ function stateHeaderLines(model: ReceiptModel, counts: HandoffCounts): string[] 
   return lines;
 }
 
+/** Pluralize a count with its noun (`1 waste line`, `2 waste lines`) — matches the receipt's row-label singular/plural discipline. */
+function countNoun(n: number, singular: string): string {
+  return `${formatInt(n)} ${singular}${n === 1 ? "" : "s"}`;
+}
+
 /** SPEC-0042 R2 — the packet states what it covers, checkably (fixed format, counts only). */
 function coverageLine(model: ReceiptModel, counts: HandoffCounts): string {
-  return `covers: ${formatInt(counts.turns)} turns · ${formatInt(counts.toolCalls)} tool calls · ${formatInt(counts.compactions)} compactions · ${formatInt(model.wasteLines.length)} waste lines`;
+  return `covers: ${countNoun(counts.turns, "turn")} · ${countNoun(counts.toolCalls, "tool call")} · ${countNoun(counts.compactions, "compaction")} · ${countNoun(model.wasteLines.length, "waste line")}`;
 }
 
 /**

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -507,7 +507,7 @@ describe("built CLI e2e", () => {
     expect(textRun.code, textRun.stderr).toBe(0);
     expect(textRun.stdout).toContain("handoff: ");
     expect(textRun.stdout).toContain("total $");
-    expect(textRun.stdout).toContain("covers: 6 turns · 5 tool calls · 0 compactions · 1 waste lines");
+    expect(textRun.stdout).toContain("covers: 6 turns · 5 tool calls · 0 compactions · 1 waste line");
   });
 
   it("treats malformed budget config as stderr-only advisory and still renders the receipt", async () => {

--- a/test/receipt/handoff-packet.test.ts
+++ b/test/receipt/handoff-packet.test.ts
@@ -49,7 +49,7 @@ describe("SPEC-0042 R1 — state header", () => {
       "compactions: 2",
       "- Bash loop ×5: $0.08, 3m 45s wall-clock",
       "",
-      "covers: 6 turns · 5 tool calls · 2 compactions · 1 waste lines",
+      "covers: 6 turns · 5 tool calls · 2 compactions · 1 waste line",
     ]);
   });
 
@@ -57,7 +57,7 @@ describe("SPEC-0042 R1 — state header", () => {
     const out = renderHandoff(model({ modelMix: [] }), [], { ...counts, compactions: 0 });
     expect(out).not.toContain("%");
     expect(out).not.toContain("compactions:");
-    expect(out).toContain("covers: 6 turns · 5 tool calls · 0 compactions · 1 waste lines");
+    expect(out).toContain("covers: 6 turns · 5 tool calls · 0 compactions · 1 waste line");
   });
 
   it("shows tokens, never `$`, when the session is unpriced (I2)", () => {


### PR DESCRIPTION
## What this adds

The three non-blocking cosmetic items from the v0.1.0 release board (all its blocking findings shipped in v0.1.2/v0.2.0):

- **License drift.** Specs claimed "MIT" where the project is Apache-2.0 — SPEC-0000 ("as OSS, MIT-licensed"), SPEC-0004 (README license-section refs), SPEC-0001 ("re-license MIT" for the imported private tooling) → Apache-2.0. (SPEC-0016's "MIT gitleaks CLI" refs are correctly left — that describes the tool's own upstream license.)
- **NOTICE** pointed at `github.com/anandgupta42/aireceipts` (wrong) → `.../receipts`, matching `package.json`.
- **Handoff `covers:` pluralization.** "1 waste lines" → "1 waste line" via a `countNoun` helper across turns / tool calls / compactions / waste lines, mirroring the receipt rows' singular/plural logic.

## Not changed (deliberate)

`benchmark` stays in `--help` — it's honestly labeled "v1: client contract only, sends disabled," which matches SPEC-0015 and the code. Adding a deliberately-inert stub to the README command table would mislead more than the current state; it earns README docs when SPEC-0015 enables sending.

## What to review

1. The spec license edits — genuine project-license claims flipped, third-party (gitleaks) MIT refs left.
2. `src/receipt/handoff.ts` `countNoun` + the one changed golden (`goldens/handoff-claude-code-loop-bash-5x.txt`) + updated render/e2e assertions.

## Evidence

- `tsc`/`eslint`/`verify-goldens`/`spec-lint`/`hygiene` all 0; handoff render + packet tests green (23).
- Only one golden changed (the handoff coverage line); all others byte-identical.
- Codex critic: **NO FINDINGS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)