### PR TITLE
docs: fix stale plural in handoff guide example

### DIFF
--- a/docs/guide/09-handoff.md
+++ b/docs/guide/09-handoff.md
@@ -14,7 +14,7 @@ claude-opus-4-8 100%
 total $0.09 · 6 turns · 5 tool calls
 - Bash loop ×5: $0.08, 3m 45s wall-clock
 
-covers: 6 turns · 5 tool calls · 0 compactions · 1 waste lines
+covers: 6 turns · 5 tool calls · 0 compactions · 1 waste line
 ```
 
 The block opens with the session's state — agent, when, how long, which models,


### PR DESCRIPTION
## What

One-line fix: the handoff guide's example output showed `1 waste lines`; the #129 pluralization fix made the CLI emit `1 waste line` (singular). Syncs the guide example to actual output.

## Why

Found while confirming `--handoff` is documented — it is (guide, README table, `--help`, `--json` schema all cover it). This was the only stale spot, and it was my own #129 change that created the drift.

## Evidence

`docs/guide/09-handoff.md:17` now matches the renderer + tests; hygiene/spec-lint green; Codex: NO FINDINGS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)