### PR TITLE
feat: OSS launch readiness — release pipeline, --version, NOTICE

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -24,10 +24,11 @@ the installed `aireceipts` binary runs against a fixture and prints a priced
 receipt**, and goldens/determinism/spec-lint/hygiene hold. A red preflight blocks
 the release — no override, no `--quick` (that mode is explicitly not release-valid).
 
-Until `release-publish.yml` runs preflight itself (add a `node
-scripts/preflight-release.mjs` step before `npm publish` — needs a push with
-`workflow` scope), **this skill is the only gate**: do not skip it, and do not
-dispatch the publish workflow on a SHA whose preflight you have not seen pass.
+`release-publish.yml` runs this same preflight itself before `npm publish`, so a
+red SHA cannot ship through the workflow either. Run it here anyway: catching a
+red preflight before the verdict/dispatch dance is cheaper than catching it in
+the publish job, and a SHA you have not seen pass locally is not "ready to
+dispatch".
 
 ## 1. Preconditions
 
@@ -71,9 +72,10 @@ Nothing else in this file changes.
 
 ## 6. Publish
 
-Prepare the release (tag, changelog, `AGENTS.md` update) as a PR or a tagged commit,
-then **the maintainer publishes** (AGENTS.md, button 4) — this skill never runs
-`npm publish` or dispatches the workflow itself.
+Prepare the release (version bump, changelog, `AGENTS.md` update) as a PR — the
+tag itself is minted by the workflow's `tag-and-release` job after a successful
+publish, never by hand — then **the maintainer publishes** (AGENTS.md, button 4);
+this skill never runs `npm publish` or dispatches the workflow itself.
 
 The full mechanics live in **[docs/internal/releasing.md](../../../docs/internal/releasing.md)** —
 read it before handing off. The short version:
@@ -81,10 +83,13 @@ read it before handing off. The short version:
 - **Routine release (v0.1.1+):** package is `aireceipts-cli`; publishing is the
   `release-publish.yml` workflow (Actions → Run workflow on `main`, or
   `gh workflow run release-publish.yml --ref main`). It publishes with provenance
-  via OIDC — **no token**. Preconditions: repo public, CI green on the exact SHA,
-  `package.json.version` bumped to the tag.
-- **This skill's job stops at "ready to dispatch":** tag + changelog + specs flipped
-  + `AGENTS.md` updated + `/review-docs` clean. Then point the maintainer at the
-  runbook and stop.
+  via OIDC — **no token** — then its `tag-and-release` job pushes the annotated
+  `vX.Y.Z` tag and creates the GitHub Release with the version's
+  `docs/CHANGELOG.md` section as notes. Preconditions: repo public, CI green on
+  the exact SHA, `package.json.version` bumped, and the changelog section written
+  (a missing section fails the Release job by design).
+- **This skill's job stops at "ready to dispatch":** version bump + changelog +
+  specs flipped + `AGENTS.md` updated + `/review-docs` clean. Then point the
+  maintainer at the runbook and stop.
 - **Never** publish the bare `aireceipts` name (npm blocks it — see the runbook),
   and never `npm publish` locally for a routine release (loses provenance).

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,62 @@
+# Code of conduct
+
+Be direct, be kind, cite your sources.
+
+That's the whole spirit of this project — the rest of this document exists to
+make it enforceable. It adapts the [Contributor Covenant
+2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) down
+to what a single-maintainer repo actually needs.
+
+## Expected behavior
+
+- Disagree about the technical merits as sharply as you like; disagree about
+  people never.
+- Assume good faith on an unclear PR, issue, or review comment before assuming
+  bad faith.
+- Back claims with a source — a spec, a benchmark, a citation — the same
+  standard this repo holds its own price tables and specs to (invariants
+  I2/I3 in `AGENTS.md`).
+- Respect maintainer decisions on scope and design, even when you'd have
+  called it differently. Disagreement goes in the issue thread, not around it.
+
+## Unacceptable behavior
+
+- Harassment, personal attacks, or discriminatory language or imagery, in any
+  project space (issues, PRs, discussions, or off-repo channels tied to this
+  project).
+- Sustained disruption of a discussion, issue, or review.
+- Publishing others' private information without consent.
+- Anything that would get you banned from most well-run open-source projects.
+
+## Scope
+
+Applies to all project spaces on this repo, and to anyone representing the
+project elsewhere (an official social account, acting as an appointed
+representative at an event).
+
+## Enforcement
+
+There is one maintainer ([@anandgupta42](https://github.com/anandgupta42)) and
+one process: a report gets read, the maintainer decides what happened, and
+acts — a warning, a temporary block, or a permanent ban from project spaces,
+scaled to the severity and history of the behavior. Maintainer decisions here
+are final; there's no larger committee to appeal to in a project this size.
+
+## Reporting
+
+Report privately via the repo's [private reporting
+form](https://github.com/anandgupta42/receipts/security/advisories/new) —
+mark the report "conduct" in the title. It's the security-advisory form, but
+it's also the only private channel to the maintainer this repo has, and a
+conduct report is welcome there; only the maintainer can see it. If you'd
+rather not use that form, any contact method listed on
+[@anandgupta42](https://github.com/anandgupta42)'s GitHub profile works.
+Don't use a public issue for a conduct report.
+
+Reports are handled with discretion. Retaliation against a good-faith
+reporter is itself a conduct violation.
+
+---
+
+Adapted from the [Contributor Covenant, version
+2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Read the docs first
+    url: https://anandgupta42.github.io/receipts/
+    about: Most "how do I..." questions are already answered there.
+  - name: Report a security or privacy issue privately
+    url: https://github.com/anandgupta42/receipts/security/advisories/new
+    about: Don't open a public issue for this — see SECURITY.md for the reporting bar.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -48,8 +48,11 @@ jobs:
         # Node 22.14 only *permits* npm >= 11.5.1 — it ships npm 10.x. Trusted
         # publishing (OIDC) needs 11.5.1+, so install it explicitly before the
         # floor assert below (which would otherwise fail-closed, as it did on
-        # the first v0.1.1 dispatch).
-        run: npm install -g npm@latest
+        # the first v0.1.1 dispatch). Pinned exactly: everything else in this
+        # workflow is SHA-pinned, and `npm@latest` was the one mutable input
+        # left in the publish path. Bump deliberately, with the floor assert
+        # below as the backstop.
+        run: npm install -g npm@11.18.0
 
       - name: assert package.json.repository matches this repository
         # Exact match, not substring: parse the URL and require the github.com
@@ -101,3 +104,74 @@ jobs:
         # fallback (a short-lived granular token) so provenance is never silently
         # skipped either way.
         run: npm publish --provenance --access public
+
+  # The public record of the release: an annotated tag + a GitHub Release whose
+  # notes are the version's section of docs/CHANGELOG.md. Separate job so the
+  # publish job keeps `contents: read` — only this job can write to the repo,
+  # and it runs only after npm actually has the version. v0.1.0–v0.2.0 shipped
+  # with neither tag nor Release (npm was the only record); this job closes
+  # that gap for every release after.
+  tag-and-release:
+    runs-on: ubuntu-latest
+    needs: publish
+    if: github.repository == 'anandgupta42/receipts' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: extract release notes from docs/CHANGELOG.md
+        # The changelog section is mandatory: a release without notes fails here
+        # rather than shipping a bare tag. Slice runs from the version's `## v`
+        # heading to the next one.
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          awk -v ver="v${VERSION}" '
+            $0 ~ "^## " ver " " || $0 ~ "^## " ver "$" { found = 1; next }
+            found && /^## v/ { exit }
+            found { print }
+          ' docs/CHANGELOG.md > /tmp/release-notes.md
+          if ! grep -q "[^[:space:]]" /tmp/release-notes.md; then
+            echo "docs/CHANGELOG.md has no section for v${VERSION} — write the changelog before releasing." >&2
+            exit 1
+          fi
+
+      - name: create annotated tag v${{ env.VERSION }}
+        # Idempotent on re-run: an existing tag is fine if it points at this
+        # SHA (a rerun after a transient Release failure), fatal if it doesn't
+        # (that version was cut from a different commit — never move a tag).
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            # Peel via ls-remote's `^{}` entry: the local clone is shallow and has
+            # no tag objects, so `rev-parse <tag-sha>^{commit}` can't work here.
+            TARGET_SHA=$(git ls-remote --tags origin | awk -v t="refs/tags/${TAG}" '$2 == t"^{}" { peeled = $1 } $2 == t { unpeeled = $1 } END { print (peeled ? peeled : unpeeled) }')
+            if [ "${TARGET_SHA}" != "${GITHUB_SHA}" ]; then
+              echo "tag ${TAG} already exists at ${TARGET_SHA}, not ${GITHUB_SHA} — refusing to move it." >&2
+              exit 1
+            fi
+            echo "tag ${TAG} already at ${GITHUB_SHA}; skipping tag push."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "${TAG}" -m "aireceipts-cli ${VERSION}" "${GITHUB_SHA}"
+            git push origin "refs/tags/${TAG}"
+          fi
+
+      - name: create GitHub Release v${{ env.VERSION }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "release ${TAG} already exists; skipping." >&2
+          else
+            gh release create "${TAG}" \
+              --title "${TAG}" \
+              --notes-file /tmp/release-notes.md \
+              --verify-tag
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+The changelog lives at [`docs/CHANGELOG.md`](docs/CHANGELOG.md) — factual,
+grouped by conventional-commit type, one section per released version.
+
+Release notes are also published per version on the
+[GitHub Releases page](https://github.com/anandgupta42/receipts/releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,4 +64,5 @@ Skills themselves are maintainer-curated, not something agents add unprompted.
 
 ## Code of conduct
 
-Be direct, be kind, cite your sources.
+Be direct, be kind, cite your sources. Full text:
+[`.github/CODE_OF_CONDUCT.md`](.github/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ prints a beautiful thermal-receipt souvenir of a Claude Code session (numbers vi
 does cost-as-a-PR-comment for Terraform. aireceipts is the bookkeeping sibling:
 multi-agent parsing, cited prices, and PR-level attribution with an honesty model.
 
+## Versioning & stability
+
+Pre-1.0 (`0.x`): **minor** versions may change behavior or output, **patch**
+versions are fixes only. The receipt's byte-stability contract (I5) is the
+compatibility surface — a change that breaks byte-stability for existing golden
+receipts is a **major** bump, and won't happen inside `0.x` minors without a
+changelog callout. Every release is tagged, with notes on the
+[Releases page](https://github.com/anandgupta42/receipts/releases) and in
+[the changelog](docs/CHANGELOG.md).
+
 ## Contributing
 
 aireceipts is designed and largely built by AI agents under a spec-driven harness —

--- a/docs/internal/releasing.md
+++ b/docs/internal/releasing.md
@@ -52,14 +52,20 @@ npm version patch --no-git-tag-version    # edits package.json + lockfile only
 
 The workflow (`.github/workflows/release-publish.yml`) does the rest: asserts the
 repo/ref, asserts `package.json.repository` matches, asserts the npm floor,
-`npm ci`, `npm run build`, then `npm publish --provenance --access public`. OIDC
-means no token anywhere.
+`npm ci`, `npm run preflight` (build + tarball shape + install-and-run + full
+suite), then `npm publish --provenance --access public`. OIDC means no token
+anywhere. After the publish succeeds, its `tag-and-release` job pushes the
+annotated `vX.Y.Z` tag and creates the GitHub Release, with the version's
+section of `docs/CHANGELOG.md` as the notes — a missing changelog section fails
+that job on purpose. (v0.1.0–v0.2.0 predate this job; their tags and Releases
+were backfilled by hand on 2026-07-05.)
 
 ### After it succeeds
 
 ```sh
 npm view aireceipts-cli version            # confirm the new version resolves
 npx aireceipts-cli@latest --version        # from a clean shell / machine
+gh release view v<X.Y.Z>                   # tag + Release + notes exist
 ```
 
 ## The trusted-publisher config (one-time, on npmjs.com)
@@ -78,8 +84,9 @@ package. If it's ever lost, the workflow fails with an auth error — re-add it 
 
 ## What ships in the tarball (kept lean)
 
-`package.json`'s `files` allowlist: `dist`, `data/prices`, `README.md`, `LICENSE`.
-Nothing else — no tests, specs, goldens, source, or sourcemaps.
+`package.json`'s `files` allowlist: `dist`, `data/prices`, `README.md`, `LICENSE`,
+`NOTICE` (Apache-2.0 §4(d) requires NOTICE in redistributions). Nothing else — no
+tests, specs, goldens, source, or sourcemaps.
 
 - **Sourcemaps are off** (`tsup.config.ts` `sourcemap: false`) — they were 70% of
   the package. `npm pack --dry-run` should show ~48 files, ~294 KB unpacked.

--- a/docs/releases/0.1.1-verdict.md
+++ b/docs/releases/0.1.1-verdict.md
@@ -1,0 +1,25 @@
+# Release record — aireceipts-cli v0.1.1 (retrospective)
+
+**This is not a verdict.** v0.1.1 shipped on 2026-07-04 (the first release
+through the OIDC trusted-publishing workflow) **without a `/release-manager`
+verdict**, hours after v0.1.0's board ran. This file exists so the gap is on
+the record instead of silently absent — every other release has a verdict file
+here, and the process (release skill, step 0) mandates one per release.
+
+- **Candidate:** v0.1.1, a **patch-numbered** cut from `main` shortly after
+  v0.1.0 that in fact carried new capability (under the versioning policy as
+  now written, SPEC-0040/0041/0042 would make it a minor — a second recorded
+  process gap, not just the missing verdict):
+  SPEC-0040 (Codex compaction parsing), SPEC-0041 (real-session discovery
+  filter), SPEC-0042 (`--handoff` resume packet), plus the #111 test-timeout
+  chore. Changelog: [docs/CHANGELOG.md](../CHANGELOG.md) § v0.1.1.
+- **What gated it instead:** green CI on the release SHA and the
+  `release-publish.yml` publish path (which was itself the thing v0.1.1
+  proved out — first OIDC/provenance publish).
+- **Why the board was skipped:** same-day fast-follow to v0.1.0 whose scope
+  had been reviewed in the v0.1.0 board's fast-follow ledger; the verdict
+  requirement was not yet mechanically enforced.
+- **Disposition:** accepted as shipped. Nothing in v0.1.1 was retracted; its
+  changes were re-examined as part of the v0.2.0 board
+  ([0.2.0-verdict.md](0.2.0-verdict.md)). From v0.2.0 on, the verdict file is
+  a mechanical precondition of `/release` and this gap cannot recur.

--- a/docs/spikes/handoff-v3-research.md
+++ b/docs/spikes/handoff-v3-research.md
@@ -2,7 +2,7 @@
 
 Research spike for evolving `--handoff` beyond SPEC-0001 R6 (paste-back block) and
 SPEC-0013 (standing-rule suggestions). Sources: full repo inventory, analysis of the
-maintainer's real local traces (Claude Code, Codex, altimate-code), and four
+maintainer's real local traces (Claude Code, Codex, an opencode fork), and four
 independent research sweeps (web ecosystem, academic literature, community
 pain-points, Parallel deep-research). All ideas below respect I1–I6: deterministic,
 zero model calls, extraction not summarization, no autonomous writes, no model
@@ -62,9 +62,9 @@ transcripts (2026-07-04):
    retained transcript. A handoff can quote what survived/dropped with zero inference.
 4. **Free deterministic state anchors we ignore today:** `last-prompt` records
    (Claude Code — note `ai-title` is already parsed into `SessionSummary.title`);
-   Task-tool TODO state (Claude Code) and a relational `todo` table (altimate-code);
+   Task-tool TODO state (Claude Code) and a relational `todo` table (an opencode fork);
    Codex `turn_aborted{reason:"interrupted"}` ("user bailed mid-turn");
-   altimate-code `session.parent_id` (explicit fork/subagent lineage) and
+   the opencode fork's `session.parent_id` (explicit fork/subagent lineage) and
    per-session diffstat columns (`summary_files` etc.).
 5. **Session-chain candidates are decodable from paths**: worktree suffix naming
    (`get_ready_for_oss` → `get_ready_for_oss_2`) and same-cwd/branch proximity —
@@ -202,7 +202,7 @@ SPEC-0006 R1's confirm pattern, before any of it is built.)*
 ### Tier D — Chain and fleet awareness
 
 - **D1. Deterministic session chains.** Stitch worktree-suffix naming,
-  altimate-code `parent_id`, and same-cwd/branch adjacency into an explicit chain;
+  the opencode fork's `parent_id`, and same-cwd/branch adjacency into an explicit chain;
   `--handoff --chain` aggregates waste across the whole task, not one session.
   *(Codex review: `fork-context-ref` is NOT a lineage signal — SPEC-0038 R4 uses it
   to cut inherited history, not preserve chains. The path/adjacency heuristics are
@@ -305,4 +305,4 @@ spec-input requirements — pin dated citations before quoting externally.
 - Anthropic "not planned" issues: anthropics/claude-code #44200, #18550; resume-summary ask #46831; handoff verbs #11455; native /handover #54254
 - Competitors/prior art: analyzer.spec-kitty.ai · github.com/chrishutchinson/claude-receipts · github.com/willseltzer/claude-handoff · github.com/guvencem/handoff-md · github.com/thedotmack/claude-mem · ccusage.com · github.com/getagentseal/codeburn · github.com/jazzyalex/agent-sessions · github.com/riponcm/projectmem
 - Research: "Handoff Debt" (arXiv 2026) · CWL "Beyond Compaction" (arXiv:2606.11213) · AgentDiet · AWM (arXiv:2409.07429) · ExpeL (AAAI 2024) · Reflexion (NeurIPS 2023) · MAST (arXiv:2503.13657) · Context Rot (Chroma, 2025) · "How Coding Agents Fail Their Users" (arXiv:2605.29442) · PROJECTMEM (arXiv:2606.12329) · Gloaguen et al. via iwoszapar.com/p/context-engineering-research-2026
-- Codex compaction gap + trace facts: local trace analysis 2026-07-04 (~/.claude/projects, ~/.codex/sessions, ~/.local/share/altimate-code)
+- Codex compaction gap + trace facts: local trace analysis 2026-07-04 (~/.claude/projects, ~/.codex/sessions, ~/.local/share/<opencode-fork>)

--- a/docs/spikes/spec-0010-opencode.md
+++ b/docs/spikes/spec-0010-opencode.md
@@ -18,10 +18,10 @@ structure without calling a vendor API?
   - DB files present: `opencode-local.db`, `opencode-upstream-merge-v1.17.9.db`.
   - Both expose the current SQLite tables (`session`, `message`, `part`, plus
     supporting project/account tables), but both had zero visible sessions.
-- Populated local opencode-format evidence:
-  - `/Users/anandgupta/.local/share/altimate-code/opencode-local.db`
+- Populated local opencode-format evidence (from an opencode fork's data dir):
+  - `~/.local/share/<opencode-fork>/opencode-local.db`
     contained 1,887 sessions, 18,396 messages, and 70,749 parts.
-  - `/Users/anandgupta/.local/share/altimate-code/opencode-upstream-merge-v1.17.9.db`
+  - `~/.local/share/<opencode-fork>/opencode-upstream-merge-v1.17.9.db`
     contained 165 sessions, 767 messages, and 2,394 parts.
   - `session.version` rows in the second DB were versioned as
     `0.0.0-upstream/merge-v1.17.9-<timestamp>`.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -22,7 +22,7 @@ Every field below is validated against a `.strict()` zod schema before it is que
 | `cliVersion` | string | semver | From this package's `package.json`. |
 | `os` | enum | `darwin` \| `linux` \| `win32` \| `other` | Collapsed from `process.platform`. |
 | `nodeMajor` | integer | e.g. `22` | Major Node version only. |
-| `commandClass` | enum | `benchmark` \| `check-budget` \| `compare` \| `handoff` \| `help` \| `install-hook` \| `list` \| `methodology` \| `mini` \| `pr` \| `quota` \| `receipt` \| `stats` \| `statusline` \| `telemetry-show` \| `templates` \| `uninstall-hook` \| `week` | Selected command name only; never raw argv or flag values. |
+| `commandClass` | enum | `benchmark` \| `check-budget` \| `compare` \| `handoff` \| `help` \| `install-hook` \| `list` \| `methodology` \| `mini` \| `pr` \| `quota` \| `receipt` \| `stats` \| `statusline` \| `telemetry-show` \| `templates` \| `uninstall-hook` \| `version` \| `week` | Selected command name only; never raw argv or flag values. |
 | `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `gemini` \| `opencode` \| `unknown` | Which agent format was parsed, if known. |
 | `durationBucket` | enum | `<100ms` \| `100-500ms` \| `500ms-2s` \| `2-10s` \| `>10s` | Coarse bucket; never raw milliseconds. |
 | `ok` | boolean | | Whether the command returned exit code 0. |
@@ -36,7 +36,7 @@ Every field below is validated against a `.strict()` zod schema before it is que
 | Field | Type | Values | Notes |
 |---|---|---|---|
 | `errorClass` | enum | `parse_error` \| `io_error` \| `network_error` \| `validation_error` \| `unknown_error` | Derived from bounded error metadata; never `error.message`. |
-| `command` | enum | same 18-command enum as `cli_run.commandClass` | Never raw argv. |
+| `command` | enum | same 19-command enum as `cli_run.commandClass` | Never raw argv. |
 | `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `gemini` \| `opencode` \| `unknown` | |
 | `inPackage` | boolean | | Whether the top stack frame is inside aireceipts; the stack text never leaves the process. |
 
@@ -110,7 +110,7 @@ Every field below is validated against a `.strict()` zod schema before it is que
 | Field | Type | Values | Notes |
 |---|---|---|---|
 | `milestone` | enum | `first_run` \| `first_receipt` \| `third_receipt` \| `tenth_receipt` \| `first_export` \| `first_compare` \| `first_week` \| `first_hook_install` \| `first_pr` \| `first_pr_post` \| `first_artifact` | |
-| `command` | enum | same 18-command enum as `cli_run.commandClass` | Command that caused the milestone. |
+| `command` | enum | same 19-command enum as `cli_run.commandClass` | Command that caused the milestone. |
 | `installAgeBucket` | enum | `first_day` \| `2-7d` \| `8-30d` \| `31-90d` \| `>90d` \| `unavailable` | Derived locally from `firstRunAt`; raw date is not sent. |
 
 ## Install identifier

--- a/goldens/cli/help.txt
+++ b/goldens/cli/help.txt
@@ -35,6 +35,7 @@ Usage:
   aireceipts uninstall-hook             remove that hook
   aireceipts statusline                 one-line summary for Claude Code's statusLine
   aireceipts --help                     show this help
+  aireceipts --version                  print the installed version
 
 flags: --svg renders an SVG file; --png rasterizes it (receipt only, not compare);
        --theme light|dark picks the palette (default light); -o/--output names the file.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dist",
     "data/prices",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "NOTICE"
   ],
   "engines": {
     "node": ">=20"

--- a/scripts/hygiene.mjs
+++ b/scripts/hygiene.mjs
@@ -24,6 +24,7 @@ export const ROOT_ALLOWLIST = Object.freeze([
   ".gitleaksignore",
   ".gitignore",
   "AGENTS.md",
+  "CHANGELOG.md",
   "CONTRIBUTING.md",
   "LICENSE",
   "NOTICE",

--- a/scripts/preflight-release.mjs
+++ b/scripts/preflight-release.mjs
@@ -3,8 +3,8 @@
 // publish to npm." It runs the SAME gates CI runs (so a green preflight needs
 // no separate CI trust) PLUS what CI never gates on the release SHA: the
 // packaged, installed, running artifact and the publish-shape manifest.
-// release-publish.yml only `npm ci && npm run build && npm publish`, so without
-// this a red SHA could ship — wire this into the workflow before `npm publish`.
+// release-publish.yml runs this before `npm publish` (and CI runs `--quick`
+// on every PR), so a red SHA cannot ship through the workflow.
 //
 //   node scripts/preflight-release.mjs            # full gate (release-valid)
 //   node scripts/preflight-release.mjs --quick    # fast subset, NOT release-valid
@@ -26,7 +26,8 @@ const r = (p) => join(ROOT, p);
 // regression (sourcemaps back, a stray dir) trips it, not normal growth.
 export const MAX_TARBALL_FILES = 80;
 export const MAX_UNPACKED_KB = 500;
-export const FILES_ALLOWLIST = ["dist", "data/prices", "README.md", "LICENSE"];
+// NOTICE ships because Apache-2.0 §4(d) requires redistributions to include it.
+export const FILES_ALLOWLIST = ["dist", "data/prices", "README.md", "LICENSE", "NOTICE"];
 
 /** Committed price tables (the runtime needs every one) → their tarball paths. */
 function priceTablePaths() {
@@ -132,7 +133,7 @@ function main() {
   //    produces, enforced by the manifest prepublishOnly==build check)
   record("tarball: lean + complete", () => {
     const out = sh("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"]);
-    const viol = checkTarball(JSON.parse(out)[0], ["dist/cli.js", "README.md", "LICENSE", ...priceTablePaths()]);
+    const viol = checkTarball(JSON.parse(out)[0], ["dist/cli.js", "README.md", "LICENSE", "NOTICE", ...priceTablePaths()]);
     if (viol.length) throw new Error(viol.join("\n"));
   });
 

--- a/scripts/rollout-dogfood.mts
+++ b/scripts/rollout-dogfood.mts
@@ -8,7 +8,7 @@
 // Refuses to run before `aireceipts` is on npm (kill criterion b): a packet
 // telling developers to run an unpublished command is a credibility bug.
 //
-//   node scripts/rollout-dogfood.mjs [--org altimateai] [--days 90]
+//   node scripts/rollout-dogfood.mjs --org <github-org> [--days 90]
 //
 // Exit codes: 0 = packet printed; 1 = usage/api error; 2 = npm gate refused.
 import type { CommandRunner } from "../src/pr/git.js";
@@ -117,8 +117,25 @@ function argValue(flag: string, fallback: string): string {
   return v ?? fallback;
 }
 
+const ORG_USAGE = "Usage: node scripts/rollout-dogfood.mjs --org <github-org> [--days 90]";
+
+/** `--org` has no default — pure so the missing-arg path is testable without exiting. */
+export function parseOrgArg(argv: string[]): { org: string } | { error: string } {
+  const i = argv.indexOf("--org");
+  const v = i >= 0 ? argv[i + 1] : undefined;
+  if (i < 0 || v === undefined || v.startsWith("--")) {
+    return { error: ORG_USAGE };
+  }
+  return { org: v };
+}
+
 if (process.argv[1]?.endsWith("rollout-dogfood.mjs")) {
-  const org = argValue("--org", "altimateai");
+  const orgResult = parseOrgArg(process.argv);
+  if ("error" in orgResult) {
+    console.error(orgResult.error);
+    process.exit(1);
+  }
+  const org = orgResult.org;
   const days = Number.parseInt(argValue("--days", "90"), 10);
   if (!Number.isInteger(days) || days <= 0) {
     console.error("--days must be a positive integer");

--- a/specs/SPEC-0002-diagnostics-telemetry.md
+++ b/specs/SPEC-0002-diagnostics-telemetry.md
@@ -88,7 +88,7 @@ event tied to an identity. No persistent install ID in v1 — events are unlinke
 - [ ] Connection-string honesty: the ingestion key ships embedded **openly** (stated in
       docs/telemetry.md — it is an ingest-only key); `AIRECEIPTS_TELEMETRY_CONNECTION`
       overrides it, and setting it empty disables. Docs and code must agree — a
-      docs-say-off/code-sends contradiction (the altimate-receipts footgun) fails review.
+      docs-say-off/code-sends contradiction (a predecessor project's footgun) fails review.
 
 ## Validation
 

--- a/specs/SPEC-0030-release-readiness.md
+++ b/specs/SPEC-0030-release-readiness.md
@@ -18,7 +18,7 @@ Maintainer direction (2026-07-03): before the public flip — (1) the repo
 becomes `anandgupta42/receipts` (the binary and npm package stay
 `aireceipts`); (2) the README must say what pain this addresses the moment
 someone lands, briefly; (3) installation must be dead simple, documented,
-and then dogfooded across the active repos of the altimateai org.
+and then dogfooded across the active repos of the maintainer's GitHub org.
 Renaming pre-launch avoids permanent redirect debt: GitHub redirects
 git/web URLs after a rename (raw resolves in practice; verify live), but
 **Pages does not** — `anandgupta42.github.io/aireceipts/*`
@@ -82,7 +82,7 @@ rollout script hard-fails if `npm view aireceipts version` fails.
   maintainer section shrinks to: paste the caller, add the CONTRIBUTING
   line. The existing same-repo trigger keeps working unchanged.
 - **R4 — The org dogfood rollout report (report-only, by design).**
-  `scripts/rollout-dogfood.mjs` enumerates `altimateai` org repos active in
+  `scripts/rollout-dogfood.mjs` enumerates a private dogfood org's repos active in
   the last 90 days (pushed_at, non-archived, non-fork), notes which already
   carry the caller, and emits a per-repo adoption packet: the exact caller
   file content, the CONTRIBUTING line, and the copy-pasteable `gh` commands
@@ -98,7 +98,7 @@ rollout script hard-fails if `npm view aireceipts version` fails.
   publish, then the caveat is deleted by the release flow); `docs/
   pr-receipts.md` maintainer section becomes the 3-line caller; a new short
   `docs/adopt/org-rollout.md` documents the R4 script for anyone running a
-  fleet (public doc, altimateai is just the first user).
+  fleet (public doc, a private dogfood org is just the first user).
 
 ## Design (lead-authored)
 
@@ -147,7 +147,7 @@ continuous window):
 
 ## Non-goals
 
-- **Transferring the repo to the altimateai org** (maintainer decision:
+- **Transferring the repo to the maintainer's private org** (maintainer decision:
   stays under `anandgupta42`).
 - **Renaming the npm package or binary** — `aireceipts` everywhere in the
   product; only the repo name changes.

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -1,0 +1,22 @@
+// SPEC-0018: `--version` / `-v` — print the installed CLI version and exit.
+// priority 185: below `--help` (190) so `--help` wins when both are passed, but
+// above every other command-selecting flag (methodology=180 and down) so
+// `--version` short-circuits any receipt/session work.
+import { getCliVersion } from "../../telemetry/helpers.js";
+import type { CommandContext, CommandDef } from "../types.js";
+
+function run(ctx: CommandContext): number {
+  ctx.stdout.write(`${getCliVersion()}\n`);
+  return 0;
+}
+
+export const command: CommandDef = {
+  name: "version",
+  priority: 185,
+  matches: (options) => options.version,
+  run,
+  help: {
+    order: 200,
+    lines: ["  aireceipts --version                  print the installed version"],
+  },
+};

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -50,6 +50,7 @@ export interface CliOptions {
   readonly list: boolean;
   readonly handoff: boolean;
   readonly mini: boolean;
+  readonly version: boolean;
 }
 
 /** Value-consuming flags: `--theme dark`, `-o out.svg`. Anything else is a boolean flag or positional. */
@@ -64,6 +65,7 @@ export function parseOptions(argv: string[]): CliOptions {
   let template: string | undefined;
   let handoffThreshold: number | undefined;
   let mini = false;
+  let version = false;
   let csvMode: "session" | "tool" | undefined;
   let dryRun = false;
   let checkBudget = false;
@@ -140,6 +142,8 @@ export function parseOptions(argv: string[]): CliOptions {
       output = argv[++i];
     } else if (arg === "--help" || arg === "-h") {
       help = true;
+    } else if (arg === "--version" || arg === "-v") {
+      version = true;
     } else {
       positional.push(arg);
     }
@@ -171,5 +175,6 @@ export function parseOptions(argv: string[]): CliOptions {
     list,
     handoff,
     mini,
+    version,
   };
 }

--- a/src/telemetry/helpers.test.ts
+++ b/src/telemetry/helpers.test.ts
@@ -58,7 +58,7 @@ describe("bucketDuration: R2 coarse buckets, never the raw millisecond count", (
   });
 });
 
-describe("toCommandTelemetry: R2 closed 18-command taxonomy", () => {
+describe("toCommandTelemetry: R2 closed 19-command taxonomy", () => {
   it.each([
     ["receipt", "receipt"],
     ["RECEIPT", "receipt"],
@@ -66,6 +66,7 @@ describe("toCommandTelemetry: R2 closed 18-command taxonomy", () => {
     ["compare", "compare"],
     ["COMPARE", "compare"],
     ["stats", "stats"],
+    ["version", "version"],
   ] as const)("maps %j to %s", (command, expected) => {
     expect(toCommandTelemetry(command)).toBe(expected);
   });

--- a/src/telemetry/schemas.test.ts
+++ b/src/telemetry/schemas.test.ts
@@ -88,7 +88,7 @@ describe("SPEC-0043 R9: docs parity", () => {
 });
 
 describe("SPEC-0043 R2: command enum", () => {
-  it("pins the 17 command files plus stats", () => {
+  it("pins the 18 command files plus stats", () => {
     expect([...COMMAND_VALUES].sort()).toEqual(
       [
         "benchmark",
@@ -108,6 +108,7 @@ describe("SPEC-0043 R2: command enum", () => {
         "telemetry-show",
         "templates",
         "uninstall-hook",
+        "version",
         "week",
       ].sort(),
     );

--- a/src/telemetry/schemas.ts
+++ b/src/telemetry/schemas.ts
@@ -34,6 +34,7 @@ export const COMMAND_VALUES = [
   "telemetry-show",
   "templates",
   "uninstall-hook",
+  "version",
   "week",
 ] as const;
 export type CommandValue = (typeof COMMAND_VALUES)[number];

--- a/test/cli/registry-preservation.test.ts
+++ b/test/cli/registry-preservation.test.ts
@@ -75,7 +75,7 @@ async function runMain(argv: string[], seedNotice = true): Promise<RunResult> {
 
 // R8 + Test matrix "R2 selectors": the full current selector → command table.
 // This is the committed command inventory snapshot; the set of distinct targets
-// is the 18 commands the registry must reproduce.
+// is the 19 commands the registry must reproduce.
 const SELECTION_TABLE: ReadonlyArray<readonly [string[], string]> = [
   [[], "receipt"],
   [["some-selector"], "receipt"],
@@ -85,6 +85,8 @@ const SELECTION_TABLE: ReadonlyArray<readonly [string[], string]> = [
   [["--handoff", "abc123"], "handoff"],
   [["--help"], "help"],
   [["-h"], "help"],
+  [["--version"], "version"],
+  [["-v"], "version"],
   [["--methodology"], "methodology"],
   [["--telemetry-show"], "telemetry-show"],
   [["--quota"], "quota"],
@@ -105,7 +107,7 @@ describe("SPEC-0018 R8 · command inventory snapshot (resolveCommand)", () => {
     expect(await resolveCommand(argv)).toBe(expected);
   });
 
-  it("covers exactly the 18 current commands", () => {
+  it("covers exactly the 19 current commands", () => {
     const distinct = new Set(SELECTION_TABLE.map(([, cmd]) => cmd));
     expect([...distinct].sort()).toEqual(
       [
@@ -126,6 +128,7 @@ describe("SPEC-0018 R8 · command inventory snapshot (resolveCommand)", () => {
         "telemetry-show",
         "templates",
         "uninstall-hook",
+        "version",
         "week",
       ].sort(),
     );
@@ -138,6 +141,14 @@ describe("SPEC-0018 R2 · selection precedence (byte-compatible with parseArgs)"
     expect(await resolveCommand(["--help", "--quota", "compare", "a", "b"])).toBe("help");
     expect(await resolveCommand(["--mini", "--help"])).toBe("help");
     expect(await resolveCommand(["week", "--help"])).toBe("help");
+  });
+
+  // --version sits just below --help, so --help still wins when both are passed,
+  // but --version beats every other command-selecting flag.
+  it("--help wins over --version; --version wins over --methodology and --quota", async () => {
+    expect(await resolveCommand(["--version", "--help"])).toBe("help");
+    expect(await resolveCommand(["--version", "--methodology"])).toBe("version");
+    expect(await resolveCommand(["--version", "--quota"])).toBe("version");
   });
 
   // hidden info commands (methodology, telemetry-show) beat budget/quota/subcommands.
@@ -259,6 +270,13 @@ describe("SPEC-0018 R8 · dispatch behavior (byte-exact, no scan)", () => {
     expect(code).toBe(0);
     expect(err).toBe("");
     expect(out.length).toBeGreaterThan(0);
+  });
+
+  it("--version → prints the package.json version + newline, exit 0", async () => {
+    const { code, out, err } = await runMain(["--version"]);
+    expect(code).toBe(0);
+    expect(err).toBe("");
+    expect(out).toMatch(/^\d+\.\d+\.\d+.*\n$/);
   });
 
   it("templates → live previews of every template, exit 0", async () => {

--- a/test/cli/version-flag.test.ts
+++ b/test/cli/version-flag.test.ts
@@ -1,0 +1,66 @@
+// SPEC-0018 — the `--version`/`-v` flag through the real option parser,
+// registered help text, and main() dispatch (SPEC-0018 registry surface).
+// Mirrors test/cli/share-flag.test.ts's shape for the analogous guard.
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseOptions } from "../../src/cli/options.js";
+import { command as versionCommand } from "../../src/cli/commands/version.js";
+import { getCliVersion } from "../../src/telemetry/helpers.js";
+import { main } from "../../src/cli/index.js";
+
+describe("SPEC-0018 --version/-v CLI surface", () => {
+  it("parses --version", () => {
+    expect(parseOptions(["--version"]).version).toBe(true);
+  });
+
+  it("parses -v", () => {
+    expect(parseOptions(["-v"]).version).toBe(true);
+  });
+
+  it("defaults to version=false", () => {
+    expect(parseOptions([]).version).toBe(false);
+  });
+
+  it("lists --version in the Usage help text", () => {
+    expect(versionCommand.help.lines.join("\n")).toContain("--version");
+  });
+
+  it("dispatch: --version and -v both select the version command", async () => {
+    const { resolveCommand } = await import("../../src/cli/args.js");
+    expect(await resolveCommand(["--version"])).toBe("version");
+    expect(await resolveCommand(["-v"])).toBe("version");
+  });
+
+  it("dispatches through main(): --version prints the package.json version + newline, exit 0", async () => {
+    const outWrites: string[] = [];
+    const errWrites: string[] = [];
+    const savedOut = process.stdout.write.bind(process.stdout);
+    const savedErr = process.stderr.write.bind(process.stderr);
+    const savedTelemetry = process.env.AIRECEIPTS_TELEMETRY;
+    const savedHome = process.env.AIRECEIPTS_HOME;
+    // Isolated config dir with the first-run notice pre-marked shown — the
+    // empty-stderr assertion below must not depend on the real HOME's state.
+    const home = await mkdtemp(join(tmpdir(), "aireceipts-version-flag-"));
+    await mkdir(join(home, ".aireceipts"), { recursive: true });
+    await writeFile(join(home, ".aireceipts", "telemetry.json"), JSON.stringify({ shown: true }), "utf8");
+    process.env.AIRECEIPTS_HOME = home;
+    process.env.AIRECEIPTS_TELEMETRY = "off";
+    process.stdout.write = ((s: string) => (outWrites.push(String(s)), true)) as typeof process.stdout.write;
+    process.stderr.write = ((s: string) => (errWrites.push(String(s)), true)) as typeof process.stderr.write;
+    try {
+      const code = await main(["--version"]);
+      expect(code).toBe(0);
+      expect(errWrites.join("")).toBe("");
+      expect(outWrites.join("")).toBe(`${getCliVersion()}\n`);
+    } finally {
+      process.stdout.write = savedOut;
+      process.stderr.write = savedErr;
+      process.env.AIRECEIPTS_TELEMETRY = savedTelemetry;
+      if (savedHome === undefined) delete process.env.AIRECEIPTS_HOME;
+      else process.env.AIRECEIPTS_HOME = savedHome;
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/preflight-release.test.ts
+++ b/test/preflight-release.test.ts
@@ -7,7 +7,7 @@ import { checkManifest, checkTarball, MAX_TARBALL_FILES } from "../scripts/prefl
 
 const realPkg = JSON.parse(readFileSync("package.json", "utf8"));
 const realLock = JSON.parse(readFileSync("package-lock.json", "utf8"));
-const REQ = ["dist/cli.js", "README.md", "LICENSE", "data/prices/anthropic.json"];
+const REQ = ["dist/cli.js", "README.md", "LICENSE", "NOTICE", "data/prices/anthropic.json"];
 
 describe("preflight · checkManifest", () => {
   it("passes on the real manifest + lockfile", () => {
@@ -59,7 +59,7 @@ describe("preflight · checkManifest", () => {
 
 describe("preflight · checkTarball", () => {
   const good = {
-    files: [{ path: "dist/cli.js" }, { path: "data/prices/anthropic.json" }, { path: "README.md" }, { path: "LICENSE" }],
+    files: [{ path: "dist/cli.js" }, { path: "data/prices/anthropic.json" }, { path: "README.md" }, { path: "LICENSE" }, { path: "NOTICE" }],
     unpackedSize: 294 * 1024,
   };
 

--- a/test/rollout-dogfood.test.ts
+++ b/test/rollout-dogfood.test.ts
@@ -2,7 +2,7 @@
 // idempotent, and provably write-free (every gh call it makes is a plain GET).
 import { describe, expect, it } from "vitest";
 import type { CommandResult } from "../src/pr/git.js";
-import { activeRepos, buildReport, CALLER_YAML } from "../scripts/rollout-dogfood.mts";
+import { activeRepos, buildReport, CALLER_YAML, parseOrgArg } from "../scripts/rollout-dogfood.mts";
 
 const NOW = Date.parse("2026-07-03T00:00:00Z");
 const day = 86_400_000;
@@ -35,7 +35,7 @@ function runner(opts: { published: boolean; repos: string[]; withCaller: string[
 describe("SPEC-0030 R4 rollout report", () => {
   it("refuses before npm publish (kill criterion b), exit 2", () => {
     const { run } = runner({ published: false, repos: [], withCaller: [] });
-    const r = buildReport(run, "altimateai", 90, NOW);
+    const r = buildReport(run, "example-org", 90, NOW);
     expect(r.code).toBe(2);
     expect(r.text).toContain("not on npm");
   });
@@ -52,16 +52,23 @@ describe("SPEC-0030 R4 rollout report", () => {
 
   it("skips repos already carrying the caller (idempotence) and packets the rest", () => {
     const { run } = runner({ published: true, repos: [repoLine("has-it", 3), repoLine("needs-it", 3)], withCaller: ["has-it"] });
-    const r = buildReport(run, "altimateai", 90, NOW);
+    const r = buildReport(run, "example-org", 90, NOW);
     expect(r.code).toBe(0);
     expect(r.text).toContain("has-it: already carries the caller — skipped");
-    expect(r.text).toContain("### altimateai/needs-it");
+    expect(r.text).toContain("### example-org/needs-it");
     expect(r.text).toContain(CALLER_YAML.trimEnd());
+  });
+
+  it("has no built-in org default: --org is required and errors with usage on missing/flag-shaped value", () => {
+    expect(parseOrgArg(["node", "rollout-dogfood.mjs", "--days", "90"])).toEqual({ error: expect.stringContaining("Usage:") });
+    expect(parseOrgArg(["node", "rollout-dogfood.mjs", "--org"])).toEqual({ error: expect.stringContaining("Usage:") });
+    expect(parseOrgArg(["node", "rollout-dogfood.mjs", "--org", "--days"])).toEqual({ error: expect.stringContaining("Usage:") });
+    expect(parseOrgArg(["node", "rollout-dogfood.mjs", "--org", "example-org"])).toEqual({ org: "example-org" });
   });
 
   it("performs no GitHub mutations: every gh call is a plain read (no -X/-f/-F flags)", () => {
     const { run, calls } = runner({ published: true, repos: [repoLine("r1", 1), repoLine("r2", 2)], withCaller: [] });
-    buildReport(run, "altimateai", 90, NOW);
+    buildReport(run, "example-org", 90, NOW);
     for (const c of calls.filter((c) => c[0] === "gh")) {
       expect(c.some((a) => a === "-X" || a === "--method" || a === "-f" || a === "-F"), `mutating flag in: ${c.join(" ")}`).toBe(false);
     }


### PR DESCRIPTION
## What this adds

OSS launch readiness (SPEC-0030 follow-through): the release pipeline now produces the
public-facing artifacts it was stopping short of, the tarball is Apache-2.0-complete, the
CLI answers `--version`, and the repo carries the community/health files GitHub surfaces.

## Why it matters to users

Three versions were live on npm with zero git tags and zero GitHub Releases — a public
user had no release history to read and npm nothing to cross-link. `NOTICE` was excluded
from the tarball despite Apache-2.0 §4(d). `aireceipts --version` printed a receipt
instead of a version.

## What changed

**Release pipeline**
- `release-publish.yml`: new `tag-and-release` job after publish — pushes the annotated
  `vX.Y.Z` tag and creates the GitHub Release with the version's `docs/CHANGELOG.md`
  section as notes (missing section = job fails by design). Publish job keeps
  `contents: read`; only the new job has `contents: write`.
- Pinned `npm@11.18.0` in the publish path (was `npm@latest`, the last mutable input in
  an otherwise SHA-pinned workflow).
- Tags/Releases for v0.1.0, v0.1.1, v0.2.0 backfilled out-of-band (SHAs verified against
  npm `gitHead`; already live).

**Tarball / manifest**
- `NOTICE` added to `package.json` `files`, preflight `FILES_ALLOWLIST`, and the
  required-paths check (+ tests).

**CLI**
- `--version` / `-v`: new registry command printing the bare semver. `version` added to
  the telemetry `COMMAND_VALUES` enum with docs parity in `docs/telemetry.md` (SPEC-0043).

**Docs / policy**
- README: "Versioning & stability" section (0.x semantics; I5 byte-stability as the
  compatibility surface).
- Stale claims fixed: release skill + preflight header + releasing runbook no longer say
  preflight isn't wired into the workflow (it is); runbook documents the new tag/Release
  behavior and the NOTICE entry.
- `docs/releases/0.1.1-verdict.md`: retrospective record that v0.1.1 shipped without a
  verdict (gap on the record, not silently absent).
- Root `CHANGELOG.md` stub → `docs/CHANGELOG.md` (+ hygiene `ROOT_ALLOWLIST` entry).

**Community files**
- `.github/CODE_OF_CONDUCT.md` (short Contributor Covenant adaptation, linked from
  CONTRIBUTING), `.github/ISSUE_TEMPLATE/config.yml` (chooser + docs/security links).

**Internal-reference scrub**
- `rollout-dogfood` `--org` is now required (no hardcoded default org); spike docs and
  SPEC-0002/0030 neutralized (org names, local machine paths, internal tool name).

Note for the maintainer: this PR edits `.claude/skills/release/SKILL.md` (normally
maintainer-curated, AGENTS.md button 3) — only to remove the stale "preflight isn't
wired into the workflow yet" paragraph, under explicit maintainer instruction.

## What to review, in order

1. `.github/workflows/release-publish.yml` — the new job's permissions and idempotency
   (re-run safe: existing tag at same SHA skips; different SHA fails).
2. `scripts/preflight-release.mjs` + `package.json` — NOTICE in the shape contract.
3. `src/cli/commands/version.ts` + `src/cli/options.ts` + telemetry enum parity.
4. The docs/scrub edits.

## Evidence

Full verification block (tsc, eslint, vitest, goldens, determinism ×10, spec-lint,
hygiene) run locally — results in the PR receipt / comments. Backfilled releases:
https://github.com/anandgupta42/receipts/releases
