### PR TITLE
fix: spec-lint catches duplicate spec ids across filenames

### DIFF
--- a/scripts/spec-lint.mjs
+++ b/scripts/spec-lint.mjs
@@ -18,10 +18,15 @@ const files = (process.argv.slice(2).length
 ).filter((f) => !f.includes("SPEC-0000"));
 
 const errors = [];
+const idOwners = new Map(); // SPEC id -> [files declaring it]
 for (const file of files) {
   const s = readFileSync(file, "utf8");
   const fm = s.match(/^---\n([\s\S]*?)\n---/);
   if (!fm) { errors.push(`${file}: missing YAML frontmatter`); continue; }
+  // Normalize one layer of matched surrounding quotes so `id: SPEC-1` and
+  // `id: "SPEC-1"` are the same key, not two distinct ones.
+  const id = fm[1].match(/^id:\s*(\S+)/m)?.[1]?.replace(/^(['"])(.*)\1$/, "$2");
+  if (id) idOwners.set(id, [...(idOwners.get(id) ?? []), file]);
   const status = fm[1].match(/^status:\s*(\S+)/m)?.[1];
   if (!status || !STATUS.has(status)) errors.push(`${file}: status must be one of ${[...STATUS].join("|")} (got: ${status})`);
   for (const k of ["id:", "title:", "milestone:"]) {
@@ -41,6 +46,17 @@ for (const file of files) {
   // Inline type definitions belong in code (AGENTS.md anti-duplication rule).
   if (/^\s*(export\s+)?(interface|type)\s+\w+/m.test(s)) {
     errors.push(`${file}: inline TS type definition found — cite file:line or a zod schema instead`);
+  }
+}
+
+// One id, one file. Side-session drafts have repeatedly reused a live SPEC
+// number (0043, 0046) because the number was free when the branch forked but
+// taken by the time it merged; the collision merged silently because this lint
+// only checked structure. A rejected/tombstoned spec keeps its id, so a clash
+// with an active spec is a real violation the author must renumber.
+for (const [id, owners] of idOwners) {
+  if (owners.length > 1) {
+    errors.push(`duplicate spec id ${id} declared by: ${owners.join(", ")} — renumber all but one`);
   }
 }
 

--- a/test/spec-lint.test.ts
+++ b/test/spec-lint.test.ts
@@ -1,0 +1,89 @@
+// spec-lint's duplicate-id guard. Two spec files declaring the same `id:`
+// must fail the lint — the side-session collision (0043, 0046) that merged
+// silently green because the lint only checked structure.
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+function fixture(id: string): string {
+  return `---
+id: ${id}
+title: "lint fixture"
+status: draft
+milestone: M9
+depends: []
+---
+
+# ${id}: lint fixture
+
+## Purpose
+Fixture for the duplicate-id guard.
+
+## Requirements
+None.
+
+## Non-goals
+None.
+
+## Test matrix
+| Case | Input | Expected |
+|---|---|---|
+| a | b | c |
+
+## Success criteria
+- [ ] n/a
+`;
+}
+
+function runLint(...files: string[]): { status: number; stderr: string } {
+  const r = spawnSync("node", ["scripts/spec-lint.mjs", ...files], { encoding: "utf8" });
+  return { status: r.status ?? 1, stderr: r.stderr + r.stdout };
+}
+
+describe("spec-lint duplicate-id guard", () => {
+  let dir: string;
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "aireceipts-spec-lint-"));
+  });
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("fails when two specs declare the same id, and names both files", () => {
+    const a = join(dir, "SPEC-9001-alpha.md");
+    const b = join(dir, "SPEC-9001-beta.md");
+    writeFileSync(a, fixture("SPEC-9001"));
+    writeFileSync(b, fixture("SPEC-9001"));
+    const { status, stderr } = runLint(a, b);
+    expect(status).not.toBe(0);
+    expect(stderr).toContain("duplicate spec id SPEC-9001");
+    expect(stderr).toContain("SPEC-9001-alpha.md");
+    expect(stderr).toContain("SPEC-9001-beta.md");
+  });
+
+  it("treats a quoted id as equal to its unquoted twin", () => {
+    const a = join(dir, "SPEC-9004-alpha.md");
+    const b = join(dir, "SPEC-9004-beta.md");
+    writeFileSync(a, fixture("SPEC-9004"));
+    writeFileSync(b, fixture('"SPEC-9004"'));
+    const { status, stderr } = runLint(a, b);
+    expect(status).not.toBe(0);
+    expect(stderr).toContain("duplicate spec id SPEC-9004");
+  });
+
+  it("passes when ids are distinct", () => {
+    const a = join(dir, "SPEC-9002-alpha.md");
+    const b = join(dir, "SPEC-9003-beta.md");
+    writeFileSync(a, fixture("SPEC-9002"));
+    writeFileSync(b, fixture("SPEC-9003"));
+    const { status } = runLint(a, b);
+    expect(status).toBe(0);
+  });
+
+  it("the committed spec tree has no duplicate ids", () => {
+    const { status } = runLint();
+    expect(status).toBe(0);
+  });
+});


### PR DESCRIPTION
## What this adds

`spec-lint` now fails when two spec files declare the same `id:`. It checked structure only, so a duplicate id merged silently green.

## Why it matters

This is the recurring side-session collision: a branch forks when a SPEC number is free and merges after another session has taken it. It happened with SPEC-0043 and again this week with SPEC-0046 (a rejected `pr-backfill` spec on main collided with an in-flight positioning spec). Both merged clean despite two files sharing an id, because nothing checked. A rejected/tombstoned spec keeps its id, so a clash with an active spec is a real violation — exactly the case that slipped through.

## What changed

- `scripts/spec-lint.mjs` — builds an `id → files` map across the linted set and fails on any id with more than one owner, naming them. One layer of matched surrounding quotes is normalized so `SPEC-1` and `"SPEC-1"` are the same key.
- `test/spec-lint.test.ts` — red path (same id → fail, both files named), quoted-twin path, green path (distinct ids → pass), and a guard that the committed tree is clean.

## What to review, in order

1. `scripts/spec-lint.mjs` — the id-map + duplicate check operates over the same `files` set the rest of the lint uses, so CI's no-arg run (`node scripts/spec-lint.mjs`) covers the whole tree; explicit-arg runs are scoped to that subset (matching existing per-file behavior).
2. `test/spec-lint.test.ts` — the red path would fail if the guard were removed; the quoted-twin case guards the false-negative Codex caught.

## Evidence

- Gates: `tsc` 0 · `eslint` 0 · `hygiene` 0 · `spec-lint` 0 (48) · targeted `vitest` 4/4; full suite green pre-amend and re-run by CI here.
- No new spec: this hardens an existing CI gate to enforce an already-implied invariant (one id, one file); the SPEC-0048 numbering note pre-flagged it as worth adding.
- Independent review: Codex REWORK (quoted-id false-negative) → fixed → LGTM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
