### PR TITLE
test: pin author-agnostic receipt-comment selection + no-bot docs note

### DIFF
--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -109,6 +109,10 @@ transcripts remain on the contributor's machine. CI still never generates a rece
 itself: the source transcripts stay local. Rolling out across a whole org:
 [docs/adopt/org-rollout.md](adopt/org-rollout.md).
 
+There is no aireceipts GitHub App or bot: receipts are generated and posted locally by
+design, and a hosted App could never see the transcripts they're built from — the
+decision record is [SPEC-0052](../specs/SPEC-0052-github-app-deferral.md).
+
 ## What the comment contains
 
 - A marker line (`<!-- aireceipts-dogfood -->`) so the upsert and the CI check can find

--- a/specs/SPEC-0052-github-app-deferral.md
+++ b/specs/SPEC-0052-github-app-deferral.md
@@ -31,10 +31,12 @@ marked comment.
 **Optional spec-free hygiene** (S2's "smaller fix" — maintainer's call, no spec
 needed): two regression tests pinning author-agnostic comment selection
 (`user.login` noise through `upsertPrComment` and `check-pr-receipt.mjs`), and one
-FAQ sentence in `docs/pr-receipts.md` ("no bot; local by design"). **Maintainer TODO**
-(external, untestable, deliberately not a requirement): register a placeholder
-`aireceipts` GitHub App (webhook inactive, zero permissions, zero installs) to
-reserve the global App name and the `aireceipts[bot]` login.
+FAQ sentence in `docs/pr-receipts.md` ("no bot; local by design"). *Done 2026-07-05*
+(`test/pr/comment.test.ts`, `test/pr/check-pr-receipt.test.ts`,
+`docs/pr-receipts.md`). **Maintainer TODO — done 2026-07-05**: the placeholder
+`aireceipts` GitHub App is registered (App ID 4224201, github.com/apps/aireceipts;
+webhook inactive, zero permissions, zero installs), reserving the global App name
+and the `aireceipts[bot]` login.
 
 **Do NOT build** (`status: rejected` — `build-spec` gates on `approved`). The
 requirements below are preserved as the record of exactly what was considered.

--- a/test/pr/check-pr-receipt.test.ts
+++ b/test/pr/check-pr-receipt.test.ts
@@ -19,6 +19,18 @@ describe("hasReceiptComment", () => {
     expect(hasReceiptComment("[]")).toBe(false);
     expect(hasReceiptComment("not json")).toBe(false);
   });
+
+  it("keys on the marker only — never on comment author (SPEC-0052 R3)", () => {
+    // A marked comment counts regardless of who authored it, and an unmarked
+    // bot comment never counts — the marker is the whole contract.
+    const markedByHuman = JSON.stringify([
+      { body: "chatter", user: { login: "aireceipts[bot]" } },
+      { body: `${SCRIPT_MARKER}\nreceipt`, user: { login: "alice" } },
+    ]);
+    expect(hasReceiptComment(markedByHuman)).toBe(true);
+    const onlyUnmarkedBot = JSON.stringify([{ body: "not a receipt", user: { login: "aireceipts[bot]" } }]);
+    expect(hasReceiptComment(onlyUnmarkedBot)).toBe(false);
+  });
 });
 
 describe("receiptCheckVerdict", () => {

--- a/test/pr/comment.test.ts
+++ b/test/pr/comment.test.ts
@@ -71,6 +71,23 @@ describe("upsertPrComment", () => {
     expect(calls.filter((c) => c.args.includes("-X"))).toHaveLength(1);
   });
 
+  it("selects the marked comment by body prefix only — never by author (SPEC-0052 R3)", () => {
+    // The GitHub JSON carries a `user` object; selection must ignore it, so a
+    // future bot identity can take over the comment a human's `gh` created
+    // (and a human can update a bot-created one).
+    const existing = JSON.stringify([
+      { id: 111, body: "unrelated", user: { login: "aireceipts[bot]" } },
+      { id: 999, body: `${DOGFOOD_MARKER}\nold receipt`, user: { login: "alice" } },
+    ]);
+    const { run, calls } = mockGh(existing);
+    const result = upsertPrComment(body, run);
+
+    expect(result).toMatchObject({ action: "updated", commentId: 999 });
+    const write = calls.find((c) => c.args.includes("-X"))!;
+    expect(write.args).toContain("PATCH");
+    expect(write.args.join(" ")).toContain("repos/o/r/issues/comments/999");
+  });
+
   it("reports gh missing distinctly", () => {
     const run: CommandRunner = () => ({ stdout: "", stderr: "", code: null, missing: true });
     const result = upsertPrComment(body, run);


### PR DESCRIPTION
## SPEC-0052 hygiene — pin the bot-ready comment contract, close the Tombstone TODOs

The optional spec-free follow-ups recorded in SPEC-0052's Tombstone (merged in #138):

- **Two regression tests** pinning that receipt-comment selection is author-agnostic — the property that lets a future `aireceipts[bot]` take over the same marked comment a human's `gh` created:
  - `test/pr/comment.test.ts` — `upsertPrComment` PATCHes the marked comment when GitHub JSON carries `user.login` authors (marked-by-human wins over unmarked-by-bot).
  - `test/pr/check-pr-receipt.test.ts` — the CI verdict keys on the marker only: marked counts regardless of author; unmarked bot chatter never counts.
- **Docs note** in `docs/pr-receipts.md` (maintainers section): there is no aireceipts GitHub App or bot, by design — links SPEC-0052.
- **Tombstone bookkeeping**: hygiene items and the App-name reservation marked done 2026-07-05 (placeholder App registered: ID 4224201, webhook inactive, zero permissions).

Gates run locally, unmasked: `tsc` 0, `eslint` 0, `vitest` 1355/1355, goldens 0, `spec-lint` 51 OK, `hygiene` OK. Push-hook Codex review: **APPROVE, no findings** (verdict comment below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
