### PR TITLE
docs: GTM copy for --handoff, retroactivity, roadmap, and an advanced guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ same tokens on claude-haiku-4-5...$0.04 (78% less)
   could run — each priced, each conservative (a false positive fails our CI).
 - **An honest cheaper-model line**: "same tokens on X" is arithmetic on your real token
   counts, never a claim that X would have done the job.
+- **Works on your existing sessions**: aireceipts reads the transcripts your agents
+  already wrote — install today, get receipts for last month, no new session needed.
+- **A handoff that graduates, carefully**: `--handoff` turns the waste a session
+  actually hit into a paste-ready instruction for the next run; a suggested standing
+  rule only fires once a waste class recurs across 3+ sessions, so a one-off fluke
+  never becomes a rule.
 - **Exports**: SVG/PNG images, JSON with a versioned schema, CSV.
 
 ## The honesty rules
@@ -170,7 +176,7 @@ pricing, troubleshooting ([hosted docs](https://anandgupta42.github.io/receipts/
 [FAQ](docs/faq.md) · [What a receipt proves](docs/trust.md) ·
 [PR receipts](docs/pr-receipts.md) · [Integrations](docs/guide/15-integrations.md) ·
 [JSON schema](docs/json-schema.md) · [statusline](docs/statusline.md) ·
-[telemetry](docs/telemetry.md)
+[telemetry](docs/telemetry.md) · [Roadmap](docs/ROADMAP.md)
 
 **Related work.** [claude-receipts](https://github.com/chrishutchinson/claude-receipts)
 prints a beautiful thermal-receipt souvenir of a Claude Code session (numbers via

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Honest and short, on purpose: order and reasons, never dates. For what's
 actually shipped in the current release, see the current-state inventory in
-[AGENTS.md](../AGENTS.md).
+[AGENTS.md](https://github.com/anandgupta42/receipts/blob/main/AGENTS.md).
 
 ## Now
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,47 @@
+# Roadmap
+
+Honest and short, on purpose: order and reasons, never dates. For what's
+actually shipped in the current release, see the current-state inventory in
+[AGENTS.md](../AGENTS.md).
+
+## Now
+
+Cost-attribution confidence (SPEC-0044): the shipped slices — the
+`ConfidenceEvent` contract, the no-silent-drop guarantee, the per-model cost
+matrix, the cache-write caveat, and the subagent double-count fix — are
+already in the current release. The spec itself stays open until its
+`--self-check` kill-criterion and cost-model docs land.
+
+## Next
+
+- **Integration with coding agents.** The handoff and standing rules are
+  built to be read by a machine, not just pasted by a human. Claude Code
+  hooks ship today (`aireceipts install-hook`); the deeper direction is
+  agent-native integrations that consume `--handoff --json` directly — a
+  hook or harness that reads the packet and acts on it without a human
+  pasting anything.
+- **Broader adapter coverage.** More coding agents parsed to the same
+  per-turn depth Claude Code, Codex, Gemini CLI, and opencode already get.
+- **The opt-in cost-per-turn benchmark (SPEC-0015).** The client contract —
+  payload build, the allowlisted schema, `--dry-run`, the `[y/N]` consent
+  flow — is shipped; sends stay disabled until a separate server spec owns
+  cohort definitions, abuse policy, and the explicit network exception that
+  would allow one (I1/I4).
+
+## Later
+
+- **A hosted GitHub App stays parked, not planned** (SPEC-0052). An App
+  can't generate a receipt — the transcripts it would need live on the
+  developer's machine, not on GitHub — and none of its three recorded
+  revisit triggers (an org rejecting the per-repo workflow as the
+  enforcement mechanism, a committed hosted org-aggregation product, or
+  fork-PR contributors measurably losing receipts) has fired. It reopens
+  only if one does.
+
+## Principles
+
+Local-first: your transcripts and code never leave your machine. Deterministic:
+the same transcript in always renders the same receipt out, byte for byte.
+No fabricated dollars, ever — every price traces to a dated, cited source.
+Facts, not rankings: a receipt reports what a session cost; it never grades
+or ranks one model or agent against another.

--- a/docs/guide/09-handoff.md
+++ b/docs/guide/09-handoff.md
@@ -78,6 +78,14 @@ note. The default threshold is `3`:
 aireceipts --handoff --handoff-threshold 3
 ```
 
+That recurrence count is the false-positive control: it requires the same
+waste class to repeat across `N` *distinct recent sessions*, not just several
+times inside one session, before it's ever suggested as a standing rule — a
+one-off fluke, however dramatic, never becomes a `CLAUDE.md` line. And when
+nothing recurs, the handoff stays silent about rules the same way it stays
+silent about waste: no waste fired means `nothing to hand off`, never
+invented advice.
+
 ## Next
 
 - **[Compare two sessions](05-compare.md)** — confirm the fix actually cost less.

--- a/docs/guide/16-improve-your-next-session.md
+++ b/docs/guide/16-improve-your-next-session.md
@@ -1,0 +1,72 @@
+# Improve your next session
+
+Goal: turn today's receipt into a cheaper session tomorrow — a six-step loop,
+in order, using commands you already have.
+
+## 1. Read the waste lines
+
+Every receipt lists what it caught, each priced on its own line. A `$0.08`
+stuck loop and a `$12` one deserve different amounts of attention — read the
+receipt (see [Read a receipt](04-read-a-receipt.md)) before you do anything
+else.
+
+## 2. Hand it off
+
+```sh
+aireceipts --handoff
+```
+
+Paste the block into your next prompt, or into `CLAUDE.md` if you want it to
+stick across sessions. See [Fix it next time](09-handoff.md) for a full
+worked example, and the `--json` form for hooks or another agent's harness.
+
+## 3. Let recurring waste graduate into a rule
+
+A single session's waste is a note. Waste that recurs across sessions is a
+pattern worth a standing rule — but only once it's actually recurred:
+`--handoff-threshold` (default `3`) requires a waste class to show up in `3`
+or more of your recent sessions before the handoff suggests a `CLAUDE.md`
+line for it. That gate is deliberate — a one-off fluke never becomes a
+standing rule — and near-misses below the threshold still show up in the
+`--json` form's `aggregates`, so you can watch one build toward it.
+
+## 4. Set a budget
+
+A budget won't stop an agent mid-run, but it will tell you the moment you're
+near or over one, and give a script an exit code to key off:
+
+```sh
+aireceipts --check-budget || echo "over budget this week"
+```
+
+Full setup: [Set and watch a budget](08-budget.md).
+
+## 5. Verify the fix actually cost less
+
+Once you've applied a handoff — or just changed how you prompt — compare the
+session before the fix to the one after:
+
+```sh
+aireceipts compare <before> <after>
+```
+
+Each argument is a selector (index, session id, or title substring); the
+closing line states the ratio between the two, in dollars. Guide:
+[Compare two sessions](05-compare.md).
+
+## 6. Watch the week trend down
+
+```sh
+aireceipts week
+```
+
+prints a trailing-7-day digest, including `Top waste` — the number to watch
+shrink as fixes stick, and the one this whole loop is aimed at. See
+[Aggregate the week](06-week.md).
+
+## Next
+
+- **[Fix it next time](09-handoff.md)** — the handoff block in full, with the
+  false-positive gate explained.
+- **[Set and watch a budget](08-budget.md)** — the advisory cap this loop
+  feeds.

--- a/docs/guide/16-improve-your-next-session.md
+++ b/docs/guide/16-improve-your-next-session.md
@@ -6,9 +6,9 @@ in order, using commands you already have.
 ## 1. Read the waste lines
 
 Every receipt lists what it caught, each priced on its own line. A `$0.08`
-stuck loop and a `$12` one deserve different amounts of attention — read the
-receipt (see [Read a receipt](04-read-a-receipt.md)) before you do anything
-else.
+stuck loop and one costing ten times more deserve different amounts of
+attention — read the receipt (see [Read a receipt](04-read-a-receipt.md))
+before you do anything else.
 
 ## 2. Hand it off
 

--- a/docs/internal/launch-kit.md
+++ b/docs/internal/launch-kit.md
@@ -19,22 +19,25 @@ Recommendation: **1**. The repo is the demo; the title should point at it.
 
 > aireceipts is a local CLI that reads the transcripts your coding agent
 > already writes (Claude Code, Codex, Cursor, opencode) and prints a cost
-> receipt: per-tool spend, cache economics, waste lines, and a PR-level
-> receipt of every agent session behind a pull request.
+> receipt: per-tool spend, waste lines, and a PR-level receipt of every
+> agent session behind a pull request — and it works retroactively, on
+> sessions already on disk.
 >
-> The honesty rules are the product: no fabricated dollars (unpriced models
-> render tokens-only), every price cited to a dated vendor page checked in
-> CI, byte-deterministic output golden-tested 10× per commit, and a doc on
-> what a receipt can and can't prove (docs/trust.md).
+> Every receipt ends with a handoff: the session's measured waste becomes
+> a paste-ready instruction for the next run. A suggestion graduates to a
+> standing rule only after recurring across 3+ sessions — a one-off
+> fluke never becomes a rule — and an empty handoff prints "nothing to
+> hand off," never invented advice.
 >
-> The repo is agent-built under a spec harness and dogfoods itself: every
-> PR carries the receipt of the sessions that built it — including the day
-> the attribution engine caught itself crediting a $965 session to the
-> wrong PR, and the spec + fix that followed.
+> No fabricated dollars: every price is cited to a dated vendor page
+> checked in CI; byte-deterministic, golden-tested 10x per commit
+> (docs/trust.md).
 >
-> `npx aireceipts-cli` — no accounts, no servers; your transcripts and code
-> never leave your machine (only anonymous, content-free diagnostics, off with
-> one env var — see the first comment).
+> `npx aireceipts-cli` — no accounts, no servers; transcripts never leave
+> your machine (anonymous, content-free diagnostics, off with one env
+> var — see the first comment).
+
+Word count (post body only): 148.
 
 ## Prepared first comment (post immediately under your submission)
 
@@ -52,6 +55,21 @@ The telemetry disclosure is deliberate and goes first, not buried: a
 "nothing leaves your machine" tool that phones home at all will be asked
 about it on HN, and volunteering it reads as honesty while being asked
 reads as a dodge.
+
+## Prepared handoff answer (paste if asked "how do you avoid false positives?")
+
+> The handoff prints exactly what fired on that session — each waste line
+> with what it cost — extracted from the transcript, never summarized, so
+> nothing can be paraphrased away. If nothing fired, it says so: `nothing
+> to hand off`, instead of inventing advice to fill the space.
+>
+> Standing-rule suggestions (a `CLAUDE.md` line to add) are gated
+> separately and more strictly: a waste class has to recur across 3 or
+> more distinct recent sessions — not just repeat inside one session —
+> before it's ever suggested as a rule. `--handoff-threshold` controls
+> that number; the default is 3. That recurrence gate is the actual
+> false-positive control: a one-off fluke never becomes a standing rule.
+> Worked example: docs/guide/09-handoff.md.
 
 ## The claude-receipts reply
 

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -45,8 +45,29 @@ const NAV_SECTIONS = Object.freeze([
     ],
   },
   {
+    section: "Agents",
+    items: [
+      "agents/README.md",
+      "agents/claude-code.md",
+      "agents/codex.md",
+      "agents/cursor.md",
+      "agents/gemini.md",
+      "agents/opencode.md",
+    ],
+  },
+  {
     section: "Why",
-    items: ["guide/13-pricing.md", "guide/14-session-attribution.md", "trust.md", "cost-model.md"],
+    items: [
+      "guide/13-pricing.md",
+      "guide/14-session-attribution.md",
+      "trust.md",
+      "cost-model.md",
+      "ROADMAP.md",
+    ],
+  },
+  {
+    section: "Advanced",
+    items: ["guide/16-improve-your-next-session.md"],
   },
 ]);
 

--- a/site/docs/01-getting-started.html
+++ b/site/docs/01-getting-started.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">
@@ -419,6 +433,18 @@ vs. prior 7 days (Jun 11 2026 → Jun 18 2026)
      aireceipts · local · npx aireceipts-cli      </code></pre>
 
 <p>Every session on your machine, across every supported agent, totalled for the last seven days — still local, still no upload.</p>
+
+<h2 id="already-have-sessions-aireceipts-works-retroactively">Already have sessions? aireceipts works retroactively</h2>
+
+<p>Installed today after weeks of agent use? Your history is already on disk, and aireceipts reads it as-is — no re-running anything. Sweep every existing session in one command:</p>
+
+<pre class="doc-code"><code class="language-sh">npx aireceipts-cli backfill</code></pre>
+
+<p>That prints a summary of what it found (and writes nothing). To generate the receipts, add <code>--out</code>:</p>
+
+<pre class="doc-code"><code class="language-sh">npx aireceipts-cli backfill --out ./receipts</code></pre>
+
+<p>You get one receipt file per session — byte-identical to running <code>aireceipts &lt;selector&gt;</code> on each — plus an <code>index.txt</code> manifest. <code>--since &lt;date&gt;</code> and <code>--limit N</code> narrow the sweep; <code>--json</code> emits the summary machine-readably. Re-running against the same directory is safe (it refuses to write into a directory it didn't create).</p>
 
 <h2 id="4-make-it-automatic">4. Make it automatic</h2>
 

--- a/site/docs/02-install.html
+++ b/site/docs/02-install.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/03-install-hook.html
+++ b/site/docs/03-install-hook.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/04-read-a-receipt.html
+++ b/site/docs/04-read-a-receipt.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/05-compare.html
+++ b/site/docs/05-compare.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/06-week.html
+++ b/site/docs/06-week.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/07-statusline.html
+++ b/site/docs/07-statusline.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/08-budget.html
+++ b/site/docs/08-budget.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/09-handoff.html
+++ b/site/docs/09-handoff.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">
@@ -341,11 +355,18 @@ footer{
 Claude Code · Jun 15 2026 14:00:25 UTC · 4m 35s
 claude-opus-4-8 100%
 total $0.09 · 6 turns · 5 tool calls
-- Bash loop ×5: $0.08, 3m 45s wall-clock
+--------------------------------------------------
+COULD HAVE SAVED...........................≤ $0.08
+  81% of $0.09 · arithmetic, not a prediction
+
+⚠ Bash loop ×5......................$0.08 (3m 45s)
+  → change or stop after two identical failures
 
 covers: 6 turns · 5 tool calls · 0 compactions · 1 waste line</code></pre>
 
-<p>The block opens with the session's state — agent, when, how long, which models, what it cost, how many turns and tool calls (plus a compaction count when any fired) — then lists the waste lines with what each one cost, and closes with a <code>covers:</code> line stating exactly what the packet accounts for. Everything is extracted from the transcript, never summarized, so nothing can be paraphrased away. Paste it into your next prompt (or your <code>CLAUDE.md</code>) so the agent knows what to avoid — here, a Bash command it re-ran five times over nearly four minutes.</p>
+<p>The block opens with the session's state — agent, when, how long, which models, what it cost, how many turns and tool calls (plus a compaction count when any fired). Then comes the savings slip: a <code>COULD HAVE SAVED</code> ceiling summing the fired waste lines (the <code>≤</code> and the hedge line are the honesty contract — this is arithmetic over what the detectors found, never a prediction that a different run would have gone better), each waste line as evidence with the same <code>⚠</code>/<code>≈</code> glyphs the receipt prints, and under each class a one-line <code>→</code> rule your agent can follow next time. The rules are fixed strings keyed to the waste class — extracted evidence plus a static instruction, never generated prose. It closes with a <code>covers:</code> line stating exactly what the packet accounts for. Paste the whole block into your next prompt so the agent knows what to avoid — here, a Bash command it re-ran five times over nearly four minutes.</p>
+
+<p>The same slip rides the PR comment: <code>aireceipts pr</code> adds a collapsed <code>handoff — could have saved ≤ $X</code> section after the full receipts whenever a counted session fired a waste line (and adds nothing at all on a clean PR).</p>
 
 <h2 id="machine-readable-form">Machine-readable form</h2>
 
@@ -368,6 +389,8 @@ covers: 6 turns · 5 tool calls · 0 compactions · 1 waste line</code></pre>
 <p>Some waste shows up run after run. Pass <code>--handoff-threshold N</code> and, for any waste class that recurs across <code>N</code> or more of your recent sessions, the handoff also suggests a <code>CLAUDE.md</code> rule to prevent it — a durable fix instead of a one-off note. The default threshold is <code>3</code>:</p>
 
 <pre class="doc-code"><code class="language-sh">aireceipts --handoff --handoff-threshold 3</code></pre>
+
+<p>That recurrence count is the false-positive control: it requires the same waste class to repeat across <code>N</code> <em>distinct recent sessions</em>, not just several times inside one session, before it's ever suggested as a standing rule — a one-off fluke, however dramatic, never becomes a <code>CLAUDE.md</code> line. And when nothing recurs, the handoff stays silent about rules the same way it stays silent about waste: no waste fired means <code>nothing to hand off</code>, never invented advice.</p>
 
 <h2 id="next">Next</h2>
 

--- a/site/docs/11-share-and-export.html
+++ b/site/docs/11-share-and-export.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/12-troubleshooting.html
+++ b/site/docs/12-troubleshooting.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/13-pricing.html
+++ b/site/docs/13-pricing.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/14-session-attribution.html
+++ b/site/docs/14-session-attribution.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/15-integrations.html
+++ b/site/docs/15-integrations.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/16-improve-your-next-session.html
+++ b/site/docs/16-improve-your-next-session.html
@@ -351,7 +351,7 @@ footer{
 
 <h2 id="1-read-the-waste-lines">1. Read the waste lines</h2>
 
-<p>Every receipt lists what it caught, each priced on its own line. A <code>$0.08</code> stuck loop and a <code>$12</code> one deserve different amounts of attention — read the receipt (see <a href="04-read-a-receipt.html">Read a receipt</a>) before you do anything else.</p>
+<p>Every receipt lists what it caught, each priced on its own line. A <code>$0.08</code> stuck loop and one costing ten times more deserve different amounts of attention — read the receipt (see <a href="04-read-a-receipt.html">Read a receipt</a>) before you do anything else.</p>
 
 <h2 id="2-hand-it-off">2. Hand it off</h2>
 

--- a/site/docs/16-improve-your-next-session.html
+++ b/site/docs/16-improve-your-next-session.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Use a template — aireceipts docs</title>
+<title>Improve your next session — aireceipts docs</title>
 <meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
 <meta name="theme-color" content="#e9edf0">
 <style>
@@ -286,8 +286,8 @@ footer{
     <div class="rule2" aria-hidden="true"></div>
     <div class="doc-hero">
       <p class="doc-label">Docs ledger</p>
-      <h1>Use a template</h1>
-      <p class="sub">Rendered from <code>docs/guide/10-templates.md</code>.</p>
+      <h1>Improve your next session</h1>
+      <p class="sub">Rendered from <code>docs/guide/16-improve-your-next-session.md</code>.</p>
     </div>
   </header>
   <main class="doc-grid">
@@ -345,99 +345,51 @@ footer{
       </ul>
     </aside>
     <article class="doc-content">
-<h1 id="use-a-template">Use a template</h1>
+<h1 id="improve-your-next-session">Improve your next session</h1>
 
-<p>Goal: render the same receipt in a different visual style — for a screenshot, a share, or just taste.</p>
+<p>Goal: turn today's receipt into a cheaper session tomorrow — a six-step loop, in order, using commands you already have.</p>
 
-<p>A template changes only how the receipt is <em>drawn</em>. The numbers, the honesty rules, and the totals are identical across all of them.</p>
+<h2 id="1-read-the-waste-lines">1. Read the waste lines</h2>
 
-<h2 id="see-the-styles">See the styles</h2>
+<p>Every receipt lists what it caught, each priced on its own line. A <code>$0.08</code> stuck loop and a <code>$12</code> one deserve different amounts of attention — read the receipt (see <a href="04-read-a-receipt.html">Read a receipt</a>) before you do anything else.</p>
 
-<pre class="doc-code"><code class="language-sh">aireceipts templates</code></pre>
+<h2 id="2-hand-it-off">2. Hand it off</h2>
 
-<p>prints a short live preview of each built-in template:</p>
+<pre class="doc-code"><code class="language-sh">aireceipts --handoff</code></pre>
 
-<pre class="doc-code"><code>── classic  (default) ──
-Bash..............................$0.05  (3 calls)
-Edit..............................$0.05  (2 calls)
-(thinking/reply)..................$0.03  (2 turns)
-Write.............................$0.03  (2 calls)
-Read...............................$0.02  (1 call)
---------------------------------------------------
+<p>Paste the block into your next prompt, or into <code>CLAUDE.md</code> if you want it to stick across sessions. See <a href="09-handoff.html">Fix it next time</a> for a full worked example, and the <code>--json</code> form for hooks or another agent's harness.</p>
 
-── grocery ──
-TXN #A2998369
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
+<h2 id="3-let-recurring-waste-graduate-into-a-rule">3. Let recurring waste graduate into a rule</h2>
 
-── datavis ──
-[##########] = priciest line; others in proportion
+<p>A single session's waste is a note. Waste that recurs across sessions is a pattern worth a standing rule — but only once it's actually recurred: <code>--handoff-threshold</code> (default <code>3</code>) requires a waste class to show up in <code>3</code> or more of your recent sessions before the handoff suggests a <code>CLAUDE.md</code> line for it. That gate is deliberate — a one-off fluke never becomes a standing rule — and near-misses below the threshold still show up in the <code>--json</code> form's <code>aggregates</code>, so you can watch one build toward it.</p>
 
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
+<h2 id="4-set-a-budget">4. Set a budget</h2>
 
---- TOOL CALLS ---</code></pre>
+<p>A budget won't stop an agent mid-run, but it will tell you the moment you're near or over one, and give a script an exit code to key off:</p>
 
-<h2 id="apply-one">Apply one</h2>
+<pre class="doc-code"><code class="language-sh">aireceipts --check-budget || echo &quot;over budget this week&quot;</code></pre>
 
-<p>Pass <code>--template &lt;name&gt;</code> (<code>classic</code>, <code>grocery</code>, or <code>datavis</code>) with any selector:</p>
+<p>Full setup: <a href="08-budget.html">Set and watch a budget</a>.</p>
 
-<pre class="doc-code"><code class="language-sh">aireceipts --template grocery &quot;email format&quot;</code></pre>
+<h2 id="5-verify-the-fix-actually-cost-less">5. Verify the fix actually cost less</h2>
 
-<pre class="doc-code"><code>- - - - - - - - - - - - - - - - - - - - - - - - -
-                    AIRECEIPTS                    
- “Add email format validation to the signup for…” 
- Claude Code · Jun 18 2026 09:30:30 UTC · 10m 30s 
-    claude-opus-4-8 87% · claude-sonnet-5 13%     
-         cache served 85% of input tokens         
+<p>Once you've applied a handoff — or just changed how you prompt — compare the session before the fix to the one after:</p>
 
-TXN #A3E98D5C
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-Read                                1        $0.02
---------------------------------------------------
-TOTAL                                        $0.18
-same tokens on claude-haiku-4-5..............$0.04
-  (arithmetic, not a prediction)
+<pre class="doc-code"><code class="language-sh">aireceipts compare &lt;before&gt; &lt;after&gt;</code></pre>
 
-CARDHOLDER: claude-opus-4-8
-- - - - - - - - - - - - - - - - - - - - - - - - -
-      THANK YOU FOR VIBING WITH Claude Code       
-            || |||| || || | | || ||||             
-- - - - - - - - - - - - - - - - - - - - - - - - -</code></pre>
+<p>Each argument is a selector (index, session id, or title substring); the closing line states the ratio between the two, in dollars. Guide: <a href="05-compare.html">Compare two sessions</a>.</p>
 
-<p>The <code>TXN #</code> and barcode are a deterministic hash of the session — the same session always renders the same code. <code>datavis</code> instead draws each line as a proportional bar:</p>
+<h2 id="6-watch-the-week-trend-down">6. Watch the week trend down</h2>
 
-<pre class="doc-code"><code class="language-sh">aireceipts --template datavis &quot;email format&quot;</code></pre>
+<pre class="doc-code"><code class="language-sh">aireceipts week</code></pre>
 
-<pre class="doc-code"><code>[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---
-Bash............................$0.05 [##########]
-Edit............................$0.05 [#########-]
-Write...........................$0.03 [######----]
-Read............................$0.02 [####------]</code></pre>
-
-<p><code>--template</code> works with the image exports too — see <a href="11-share-and-export.html">Share and export</a>.</p>
-
-<h2 id="adding-a-template">Adding a template</h2>
-
-<p>Templates are built in, not user config files. A new style ships as a small contribution to the renderer — see <code>CONTRIBUTING.md</code> and the existing templates under <code>src/receipt/</code>. Open a PR with a template and its golden output, and it becomes available to everyone.</p>
+<p>prints a trailing-7-day digest, including <code>Top waste</code> — the number to watch shrink as fixes stick, and the one this whole loop is aimed at. See <a href="06-week.html">Aggregate the week</a>.</p>
 
 <h2 id="next">Next</h2>
 
 <ul>
-  <li><strong><a href="11-share-and-export.html">Share and export</a></strong> — save any template as an SVG or PNG.</li>
-  <li><strong><a href="04-read-a-receipt.html">Read a receipt</a></strong> — the default <code>classic</code> layout in detail.</li>
+  <li><strong><a href="09-handoff.html">Fix it next time</a></strong> — the handoff block in full, with the false-positive gate explained.</li>
+  <li><strong><a href="08-budget.html">Set and watch a budget</a></strong> — the advisory cap this loop feeds.</li>
 </ul>
     </article>
   </main>

--- a/site/docs/CHANGELOG.html
+++ b/site/docs/CHANGELOG.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/README.html
+++ b/site/docs/README.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Use a template — aireceipts docs</title>
+<title>Supported agents — aireceipts docs</title>
 <meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
 <meta name="theme-color" content="#e9edf0">
 <style>
@@ -286,8 +286,8 @@ footer{
     <div class="rule2" aria-hidden="true"></div>
     <div class="doc-hero">
       <p class="doc-label">Docs ledger</p>
-      <h1>Use a template</h1>
-      <p class="sub">Rendered from <code>docs/guide/10-templates.md</code>.</p>
+      <h1>Supported agents</h1>
+      <p class="sub">Rendered from <code>docs/agents/README.md</code>.</p>
     </div>
   </header>
   <main class="doc-grid">
@@ -345,100 +345,22 @@ footer{
       </ul>
     </aside>
     <article class="doc-content">
-<h1 id="use-a-template">Use a template</h1>
+<h1 id="supported-agents">Supported agents</h1>
 
-<p>Goal: render the same receipt in a different visual style — for a screenshot, a share, or just taste.</p>
+<p>One page per agent: what a receipt can prove there, where the transcripts live, and how to wire it in. Depth is stated honestly per adapter — full per-turn parsing where the agent records it, labeled degraded mode where it doesn't (I3/I6).</p>
 
-<p>A template changes only how the receipt is <em>drawn</em>. The numbers, the honesty rules, and the totals are identical across all of them.</p>
+<div class="table-wrap"><table>
+  <thead><tr><th>Agent</th><th>Depth</th><th>Page</th></tr></thead>
+  <tbody>
+    <tr><td>Claude Code</td><td>Full: per-turn models, tools, cache tiers, subagents</td><td><a href="claude-code.html">claude-code.md</a></td></tr>
+    <tr><td>Codex CLI</td><td>Full per-turn parsing + compaction waste</td><td><a href="codex.html">codex.md</a></td></tr>
+    <tr><td>Cursor</td><td>Honest degraded mode: session totals only</td><td><a href="cursor.html">cursor.md</a></td></tr>
+    <tr><td>Gemini CLI</td><td>Full: per-turn models, tools, cache tokens</td><td><a href="gemini.html">gemini.md</a></td></tr>
+    <tr><td>opencode</td><td>Full: per-message models, tools, cache read/write</td><td><a href="opencode.html">opencode.md</a></td></tr>
+  </tbody>
+</table></div>
 
-<h2 id="see-the-styles">See the styles</h2>
-
-<pre class="doc-code"><code class="language-sh">aireceipts templates</code></pre>
-
-<p>prints a short live preview of each built-in template:</p>
-
-<pre class="doc-code"><code>── classic  (default) ──
-Bash..............................$0.05  (3 calls)
-Edit..............................$0.05  (2 calls)
-(thinking/reply)..................$0.03  (2 turns)
-Write.............................$0.03  (2 calls)
-Read...............................$0.02  (1 call)
---------------------------------------------------
-
-── grocery ──
-TXN #A2998369
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-
-── datavis ──
-[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---</code></pre>
-
-<h2 id="apply-one">Apply one</h2>
-
-<p>Pass <code>--template &lt;name&gt;</code> (<code>classic</code>, <code>grocery</code>, or <code>datavis</code>) with any selector:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template grocery &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>- - - - - - - - - - - - - - - - - - - - - - - - -
-                    AIRECEIPTS                    
- “Add email format validation to the signup for…” 
- Claude Code · Jun 18 2026 09:30:30 UTC · 10m 30s 
-    claude-opus-4-8 87% · claude-sonnet-5 13%     
-         cache served 85% of input tokens         
-
-TXN #A3E98D5C
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-Read                                1        $0.02
---------------------------------------------------
-TOTAL                                        $0.18
-same tokens on claude-haiku-4-5..............$0.04
-  (arithmetic, not a prediction)
-
-CARDHOLDER: claude-opus-4-8
-- - - - - - - - - - - - - - - - - - - - - - - - -
-      THANK YOU FOR VIBING WITH Claude Code       
-            || |||| || || | | || ||||             
-- - - - - - - - - - - - - - - - - - - - - - - - -</code></pre>
-
-<p>The <code>TXN #</code> and barcode are a deterministic hash of the session — the same session always renders the same code. <code>datavis</code> instead draws each line as a proportional bar:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template datavis &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---
-Bash............................$0.05 [##########]
-Edit............................$0.05 [#########-]
-Write...........................$0.03 [######----]
-Read............................$0.02 [####------]</code></pre>
-
-<p><code>--template</code> works with the image exports too — see <a href="11-share-and-export.html">Share and export</a>.</p>
-
-<h2 id="adding-a-template">Adding a template</h2>
-
-<p>Templates are built in, not user config files. A new style ships as a small contribution to the renderer — see <code>CONTRIBUTING.md</code> and the existing templates under <code>src/receipt/</code>. Open a PR with a template and its golden output, and it becomes available to everyone.</p>
-
-<h2 id="next">Next</h2>
-
-<ul>
-  <li><strong><a href="11-share-and-export.html">Share and export</a></strong> — save any template as an SVG or PNG.</li>
-  <li><strong><a href="04-read-a-receipt.html">Read a receipt</a></strong> — the default <code>classic</code> layout in detail.</li>
-</ul>
+<p>Adding an agent? The adapter contract and registry are described in <a href="https://github.com/anandgupta42/receipts/blob/main/docs/internal/harness.md">docs/internal/harness.md</a> and the <code>add-vendor-adapter</code> skill; a new adapter ships with its page here (guarded by <code>test/agent-pages.test.ts</code>).</p>
     </article>
   </main>
   <footer>

--- a/site/docs/ROADMAP.html
+++ b/site/docs/ROADMAP.html
@@ -347,7 +347,7 @@ footer{
     <article class="doc-content">
 <h1 id="roadmap">Roadmap</h1>
 
-<p>Honest and short, on purpose: order and reasons, never dates. For what's actually shipped in the current release, see the current-state inventory in <a href="AGENTS.html">AGENTS.md</a>.</p>
+<p>Honest and short, on purpose: order and reasons, never dates. For what's actually shipped in the current release, see the current-state inventory in <a href="https://github.com/anandgupta42/receipts/blob/main/AGENTS.md">AGENTS.md</a>.</p>
 
 <h2 id="now">Now</h2>
 

--- a/site/docs/ROADMAP.html
+++ b/site/docs/ROADMAP.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Use a template — aireceipts docs</title>
+<title>Roadmap — aireceipts docs</title>
 <meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
 <meta name="theme-color" content="#e9edf0">
 <style>
@@ -286,8 +286,8 @@ footer{
     <div class="rule2" aria-hidden="true"></div>
     <div class="doc-hero">
       <p class="doc-label">Docs ledger</p>
-      <h1>Use a template</h1>
-      <p class="sub">Rendered from <code>docs/guide/10-templates.md</code>.</p>
+      <h1>Roadmap</h1>
+      <p class="sub">Rendered from <code>docs/ROADMAP.md</code>.</p>
     </div>
   </header>
   <main class="doc-grid">
@@ -345,100 +345,31 @@ footer{
       </ul>
     </aside>
     <article class="doc-content">
-<h1 id="use-a-template">Use a template</h1>
+<h1 id="roadmap">Roadmap</h1>
 
-<p>Goal: render the same receipt in a different visual style — for a screenshot, a share, or just taste.</p>
+<p>Honest and short, on purpose: order and reasons, never dates. For what's actually shipped in the current release, see the current-state inventory in <a href="AGENTS.html">AGENTS.md</a>.</p>
 
-<p>A template changes only how the receipt is <em>drawn</em>. The numbers, the honesty rules, and the totals are identical across all of them.</p>
+<h2 id="now">Now</h2>
 
-<h2 id="see-the-styles">See the styles</h2>
-
-<pre class="doc-code"><code class="language-sh">aireceipts templates</code></pre>
-
-<p>prints a short live preview of each built-in template:</p>
-
-<pre class="doc-code"><code>── classic  (default) ──
-Bash..............................$0.05  (3 calls)
-Edit..............................$0.05  (2 calls)
-(thinking/reply)..................$0.03  (2 turns)
-Write.............................$0.03  (2 calls)
-Read...............................$0.02  (1 call)
---------------------------------------------------
-
-── grocery ──
-TXN #A2998369
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-
-── datavis ──
-[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---</code></pre>
-
-<h2 id="apply-one">Apply one</h2>
-
-<p>Pass <code>--template &lt;name&gt;</code> (<code>classic</code>, <code>grocery</code>, or <code>datavis</code>) with any selector:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template grocery &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>- - - - - - - - - - - - - - - - - - - - - - - - -
-                    AIRECEIPTS                    
- “Add email format validation to the signup for…” 
- Claude Code · Jun 18 2026 09:30:30 UTC · 10m 30s 
-    claude-opus-4-8 87% · claude-sonnet-5 13%     
-         cache served 85% of input tokens         
-
-TXN #A3E98D5C
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-Read                                1        $0.02
---------------------------------------------------
-TOTAL                                        $0.18
-same tokens on claude-haiku-4-5..............$0.04
-  (arithmetic, not a prediction)
-
-CARDHOLDER: claude-opus-4-8
-- - - - - - - - - - - - - - - - - - - - - - - - -
-      THANK YOU FOR VIBING WITH Claude Code       
-            || |||| || || | | || ||||             
-- - - - - - - - - - - - - - - - - - - - - - - - -</code></pre>
-
-<p>The <code>TXN #</code> and barcode are a deterministic hash of the session — the same session always renders the same code. <code>datavis</code> instead draws each line as a proportional bar:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template datavis &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---
-Bash............................$0.05 [##########]
-Edit............................$0.05 [#########-]
-Write...........................$0.03 [######----]
-Read............................$0.02 [####------]</code></pre>
-
-<p><code>--template</code> works with the image exports too — see <a href="11-share-and-export.html">Share and export</a>.</p>
-
-<h2 id="adding-a-template">Adding a template</h2>
-
-<p>Templates are built in, not user config files. A new style ships as a small contribution to the renderer — see <code>CONTRIBUTING.md</code> and the existing templates under <code>src/receipt/</code>. Open a PR with a template and its golden output, and it becomes available to everyone.</p>
+<p>Cost-attribution confidence (SPEC-0044): the shipped slices — the <code>ConfidenceEvent</code> contract, the no-silent-drop guarantee, the per-model cost matrix, the cache-write caveat, and the subagent double-count fix — are already in the current release. The spec itself stays open until its <code>--self-check</code> kill-criterion and cost-model docs land.</p>
 
 <h2 id="next">Next</h2>
 
 <ul>
-  <li><strong><a href="11-share-and-export.html">Share and export</a></strong> — save any template as an SVG or PNG.</li>
-  <li><strong><a href="04-read-a-receipt.html">Read a receipt</a></strong> — the default <code>classic</code> layout in detail.</li>
+  <li><strong>Integration with coding agents.</strong> The handoff and standing rules are built to be read by a machine, not just pasted by a human. Claude Code hooks ship today (<code>aireceipts install-hook</code>); the deeper direction is agent-native integrations that consume <code>--handoff --json</code> directly — a hook or harness that reads the packet and acts on it without a human pasting anything.</li>
+  <li><strong>Broader adapter coverage.</strong> More coding agents parsed to the same per-turn depth Claude Code, Codex, Gemini CLI, and opencode already get.</li>
+  <li><strong>The opt-in cost-per-turn benchmark (SPEC-0015).</strong> The client contract — payload build, the allowlisted schema, <code>--dry-run</code>, the <code>[y/N]</code> consent flow — is shipped; sends stay disabled until a separate server spec owns cohort definitions, abuse policy, and the explicit network exception that would allow one (I1/I4).</li>
 </ul>
+
+<h2 id="later">Later</h2>
+
+<ul>
+  <li><strong>A hosted GitHub App stays parked, not planned</strong> (SPEC-0052). An App can't generate a receipt — the transcripts it would need live on the developer's machine, not on GitHub — and none of its three recorded revisit triggers (an org rejecting the per-repo workflow as the enforcement mechanism, a committed hosted org-aggregation product, or fork-PR contributors measurably losing receipts) has fired. It reopens only if one does.</li>
+</ul>
+
+<h2 id="principles">Principles</h2>
+
+<p>Local-first: your transcripts and code never leave your machine. Deterministic: the same transcript in always renders the same receipt out, byte for byte. No fabricated dollars, ever — every price traces to a dated, cited source. Facts, not rankings: a receipt reports what a session cost; it never grades or ranks one model or agent against another.</p>
     </article>
   </main>
   <footer>

--- a/site/docs/claude-code.html
+++ b/site/docs/claude-code.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Use a template — aireceipts docs</title>
+<title>Receipts for Claude Code — aireceipts docs</title>
 <meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
 <meta name="theme-color" content="#e9edf0">
 <style>
@@ -286,8 +286,8 @@ footer{
     <div class="rule2" aria-hidden="true"></div>
     <div class="doc-hero">
       <p class="doc-label">Docs ledger</p>
-      <h1>Use a template</h1>
-      <p class="sub">Rendered from <code>docs/guide/10-templates.md</code>.</p>
+      <h1>Receipts for Claude Code</h1>
+      <p class="sub">Rendered from <code>docs/agents/claude-code.md</code>.</p>
     </div>
   </header>
   <main class="doc-grid">
@@ -345,100 +345,43 @@ footer{
       </ul>
     </aside>
     <article class="doc-content">
-<h1 id="use-a-template">Use a template</h1>
+<h1 id="receipts-for-claude-code">Receipts for Claude Code</h1>
 
-<p>Goal: render the same receipt in a different visual style — for a screenshot, a share, or just taste.</p>
+<p>Full-depth support: per-turn models, per-tool attribution, cache tiers, subagent rollups. Claude Code is also the only agent with always-on surfaces — a session-end hook and a statusline. (SPEC-0058; depth facts match <code>src/parse/claudeCode.ts</code>.)</p>
 
-<p>A template changes only how the receipt is <em>drawn</em>. The numbers, the honesty rules, and the totals are identical across all of them.</p>
-
-<h2 id="see-the-styles">See the styles</h2>
-
-<pre class="doc-code"><code class="language-sh">aireceipts templates</code></pre>
-
-<p>prints a short live preview of each built-in template:</p>
-
-<pre class="doc-code"><code>── classic  (default) ──
-Bash..............................$0.05  (3 calls)
-Edit..............................$0.05  (2 calls)
-(thinking/reply)..................$0.03  (2 turns)
-Write.............................$0.03  (2 calls)
-Read...............................$0.02  (1 call)
---------------------------------------------------
-
-── grocery ──
-TXN #A2998369
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-
-── datavis ──
-[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---</code></pre>
-
-<h2 id="apply-one">Apply one</h2>
-
-<p>Pass <code>--template &lt;name&gt;</code> (<code>classic</code>, <code>grocery</code>, or <code>datavis</code>) with any selector:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template grocery &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>- - - - - - - - - - - - - - - - - - - - - - - - -
-                    AIRECEIPTS                    
- “Add email format validation to the signup for…” 
- Claude Code · Jun 18 2026 09:30:30 UTC · 10m 30s 
-    claude-opus-4-8 87% · claude-sonnet-5 13%     
-         cache served 85% of input tokens         
-
-TXN #A3E98D5C
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-Read                                1        $0.02
---------------------------------------------------
-TOTAL                                        $0.18
-same tokens on claude-haiku-4-5..............$0.04
-  (arithmetic, not a prediction)
-
-CARDHOLDER: claude-opus-4-8
-- - - - - - - - - - - - - - - - - - - - - - - - -
-      THANK YOU FOR VIBING WITH Claude Code       
-            || |||| || || | | || ||||             
-- - - - - - - - - - - - - - - - - - - - - - - - -</code></pre>
-
-<p>The <code>TXN #</code> and barcode are a deterministic hash of the session — the same session always renders the same code. <code>datavis</code> instead draws each line as a proportional bar:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template datavis &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---
-Bash............................$0.05 [##########]
-Edit............................$0.05 [#########-]
-Write...........................$0.03 [######----]
-Read............................$0.02 [####------]</code></pre>
-
-<p><code>--template</code> works with the image exports too — see <a href="11-share-and-export.html">Share and export</a>.</p>
-
-<h2 id="adding-a-template">Adding a template</h2>
-
-<p>Templates are built in, not user config files. A new style ships as a small contribution to the renderer — see <code>CONTRIBUTING.md</code> and the existing templates under <code>src/receipt/</code>. Open a PR with a template and its golden output, and it becomes available to everyone.</p>
-
-<h2 id="next">Next</h2>
+<h2 id="what-you-get">What you get</h2>
 
 <ul>
-  <li><strong><a href="11-share-and-export.html">Share and export</a></strong> — save any template as an SVG or PNG.</li>
-  <li><strong><a href="04-read-a-receipt.html">Read a receipt</a></strong> — the default <code>classic</code> layout in detail.</li>
+  <li><strong>Per-turn parsing.</strong> Every turn's model, token usage (input, output, cache read/write), and tool calls — so the receipt prices each tool line and shows the session's real model mix (e.g. <code>claude-opus-4-8 87% · claude-sonnet-5 13%</code>).</li>
+  <li><strong>Cache visibility.</strong> The <code>cache served N% of input tokens</code> masthead line and cache-tier pricing come straight from the transcript's usage records.</li>
+  <li><strong>Subagents counted.</strong> Sessions spawned via the Agent tool are discovered under the parent transcript and rolled into its receipt and PR attribution.</li>
+  <li><strong>Waste lines.</strong> Stuck tool loops, trivial spans, and context-thrash detection run at full precision on per-turn data.</li>
 </ul>
+
+<h2 id="where-transcripts-live">Where transcripts live</h2>
+
+<p><code>~/.claude/projects/&lt;project-slug&gt;/*.jsonl</code> — Claude Code writes these itself; aireceipts only reads them. Subagent transcripts nest under <code>&lt;session&gt;/subagents/</code>.</p>
+
+<h2 id="quick-start">Quick start</h2>
+
+<pre class="doc-code"><code class="language-sh">npx aireceipts-cli            # receipt for your newest session
+npx aireceipts-cli --list     # pick a specific session</code></pre>
+
+<h2 id="always-on-options">Always-on options</h2>
+
+<ul>
+  <li><strong>Session-end mini-receipt:</strong> <code>aireceipts install-hook</code> (consent-gated; undo with <code>uninstall-hook</code>) — <a href="03-install-hook.html">guide</a>.</li>
+  <li><strong>Live statusline:</strong> <code>aireceipts statusline</code> in Claude Code's <code>statusLine</code> config — <a href="statusline.html">setup</a>.</li>
+  <li><strong>Exact snippets:</strong> <code>npx aireceipts-cli integrations claude-code</code>.</li>
+</ul>
+
+<h2 id="receipts-on-your-prs">Receipts on your PRs</h2>
+
+<p><code>npx aireceipts-cli pr --post</code> from your worktree attributes Claude Code sessions (and their subagents) to the branch and posts the receipt comment — <a href="pr-receipts.html">how</a>.</p>
+
+<h2 id="privacy">Privacy</h2>
+
+<p>Read-only, local. Transcripts never leave your machine; rendering a receipt makes zero network calls (<a href="trust.html">what a receipt proves</a>).</p>
     </article>
   </main>
   <footer>

--- a/site/docs/codex.html
+++ b/site/docs/codex.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Use a template — aireceipts docs</title>
+<title>Receipts for Codex CLI — aireceipts docs</title>
 <meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
 <meta name="theme-color" content="#e9edf0">
 <style>
@@ -286,8 +286,8 @@ footer{
     <div class="rule2" aria-hidden="true"></div>
     <div class="doc-hero">
       <p class="doc-label">Docs ledger</p>
-      <h1>Use a template</h1>
-      <p class="sub">Rendered from <code>docs/guide/10-templates.md</code>.</p>
+      <h1>Receipts for Codex CLI</h1>
+      <p class="sub">Rendered from <code>docs/agents/codex.md</code>.</p>
     </div>
   </header>
   <main class="doc-grid">
@@ -345,100 +345,41 @@ footer{
       </ul>
     </aside>
     <article class="doc-content">
-<h1 id="use-a-template">Use a template</h1>
+<h1 id="receipts-for-codex-cli">Receipts for Codex CLI</h1>
 
-<p>Goal: render the same receipt in a different visual style — for a screenshot, a share, or just taste.</p>
+<p>Full per-turn parsing: models, token usage, tool calls, and Codex's context compactions surfaced as a waste signal. (SPEC-0058; depth facts match <code>src/parse/codex.ts</code>.)</p>
 
-<p>A template changes only how the receipt is <em>drawn</em>. The numbers, the honesty rules, and the totals are identical across all of them.</p>
-
-<h2 id="see-the-styles">See the styles</h2>
-
-<pre class="doc-code"><code class="language-sh">aireceipts templates</code></pre>
-
-<p>prints a short live preview of each built-in template:</p>
-
-<pre class="doc-code"><code>── classic  (default) ──
-Bash..............................$0.05  (3 calls)
-Edit..............................$0.05  (2 calls)
-(thinking/reply)..................$0.03  (2 turns)
-Write.............................$0.03  (2 calls)
-Read...............................$0.02  (1 call)
---------------------------------------------------
-
-── grocery ──
-TXN #A2998369
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-
-── datavis ──
-[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---</code></pre>
-
-<h2 id="apply-one">Apply one</h2>
-
-<p>Pass <code>--template &lt;name&gt;</code> (<code>classic</code>, <code>grocery</code>, or <code>datavis</code>) with any selector:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template grocery &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>- - - - - - - - - - - - - - - - - - - - - - - - -
-                    AIRECEIPTS                    
- “Add email format validation to the signup for…” 
- Claude Code · Jun 18 2026 09:30:30 UTC · 10m 30s 
-    claude-opus-4-8 87% · claude-sonnet-5 13%     
-         cache served 85% of input tokens         
-
-TXN #A3E98D5C
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-Read                                1        $0.02
---------------------------------------------------
-TOTAL                                        $0.18
-same tokens on claude-haiku-4-5..............$0.04
-  (arithmetic, not a prediction)
-
-CARDHOLDER: claude-opus-4-8
-- - - - - - - - - - - - - - - - - - - - - - - - -
-      THANK YOU FOR VIBING WITH Claude Code       
-            || |||| || || | | || ||||             
-- - - - - - - - - - - - - - - - - - - - - - - - -</code></pre>
-
-<p>The <code>TXN #</code> and barcode are a deterministic hash of the session — the same session always renders the same code. <code>datavis</code> instead draws each line as a proportional bar:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template datavis &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---
-Bash............................$0.05 [##########]
-Edit............................$0.05 [#########-]
-Write...........................$0.03 [######----]
-Read............................$0.02 [####------]</code></pre>
-
-<p><code>--template</code> works with the image exports too — see <a href="11-share-and-export.html">Share and export</a>.</p>
-
-<h2 id="adding-a-template">Adding a template</h2>
-
-<p>Templates are built in, not user config files. A new style ships as a small contribution to the renderer — see <code>CONTRIBUTING.md</code> and the existing templates under <code>src/receipt/</code>. Open a PR with a template and its golden output, and it becomes available to everyone.</p>
-
-<h2 id="next">Next</h2>
+<h2 id="what-you-get">What you get</h2>
 
 <ul>
-  <li><strong><a href="11-share-and-export.html">Share and export</a></strong> — save any template as an SVG or PNG.</li>
-  <li><strong><a href="04-read-a-receipt.html">Read a receipt</a></strong> — the default <code>classic</code> layout in detail.</li>
+  <li><strong>Per-turn parsing.</strong> Each turn's model and token usage, tool-by-tool cost attribution (<code>exec_command</code>, MCP tools, …), cache-read visibility.</li>
+  <li><strong>Compaction detection.</strong> Codex's context compactions are parsed and priced as context-thrash waste lines (SPEC-0040) — repeated compactions in one session are called out with their cost.</li>
+  <li><strong>PR attribution.</strong> Codex sessions that committed on the branch are credited as contributors; Codex sessions in the repo's worktrees with no git writes appear under <code>CODEX HELPERS</code> in PR receipts — grouped honestly by what the credit rule proved.</li>
 </ul>
+
+<h2 id="where-transcripts-live">Where transcripts live</h2>
+
+<p><code>~/.codex/sessions/**/*.jsonl</code> — written by Codex itself; aireceipts only reads them.</p>
+
+<h2 id="quick-start">Quick start</h2>
+
+<pre class="doc-code"><code class="language-sh">npx aireceipts-cli            # receipt for your newest session
+npx aireceipts-cli --list     # Codex sessions are listed alongside other agents</code></pre>
+
+<h2 id="integration">Integration</h2>
+
+<ul>
+  <li><strong>Exact snippets:</strong> <code>npx aireceipts-cli integrations codex</code> (e.g. an AGENTS.md instruction telling Codex to run the CLI at task end).</li>
+  <li>No hook/statusline surface exists in Codex today; the CLI and the PR command are the integration points.</li>
+</ul>
+
+<h2 id="receipts-on-your-prs">Receipts on your PRs</h2>
+
+<p><code>npx aireceipts-cli pr --post</code> — Codex helper sessions are attributed by worktree + time window, committing sessions by branch SHA — <a href="pr-receipts.html">how</a>.</p>
+
+<h2 id="privacy">Privacy</h2>
+
+<p>Read-only, local. Transcripts never leave your machine; rendering a receipt makes zero network calls (<a href="trust.html">what a receipt proves</a>).</p>
     </article>
   </main>
   <footer>

--- a/site/docs/cost-model.html
+++ b/site/docs/cost-model.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/cursor.html
+++ b/site/docs/cursor.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Use a template — aireceipts docs</title>
+<title>Receipts for Cursor — aireceipts docs</title>
 <meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
 <meta name="theme-color" content="#e9edf0">
 <style>
@@ -286,8 +286,8 @@ footer{
     <div class="rule2" aria-hidden="true"></div>
     <div class="doc-hero">
       <p class="doc-label">Docs ledger</p>
-      <h1>Use a template</h1>
-      <p class="sub">Rendered from <code>docs/guide/10-templates.md</code>.</p>
+      <h1>Receipts for Cursor</h1>
+      <p class="sub">Rendered from <code>docs/agents/cursor.md</code>.</p>
     </div>
   </header>
   <main class="doc-grid">
@@ -345,100 +345,49 @@ footer{
       </ul>
     </aside>
     <article class="doc-content">
-<h1 id="use-a-template">Use a template</h1>
+<h1 id="receipts-for-cursor">Receipts for Cursor</h1>
 
-<p>Goal: render the same receipt in a different visual style — for a screenshot, a share, or just taste.</p>
+<p><strong>Honest degraded mode: session totals only, tokens only.</strong> Cursor's local history carries no per-turn model ids, no cache/usage breakdown, and no real per-message timestamps — so a Cursor receipt shows the session's totals and <strong>never renders dollars</strong>: every Cursor session is flagged unpriceable and the pricing layer skips it (I2 — no fabricated precision, no fabricated dollars). aireceipts states what it can prove and nothing more. (SPEC-0058; depth facts match <code>src/parse/cursor.ts</code>.)</p>
 
-<p>A template changes only how the receipt is <em>drawn</em>. The numbers, the honesty rules, and the totals are identical across all of them.</p>
-
-<h2 id="see-the-styles">See the styles</h2>
-
-<pre class="doc-code"><code class="language-sh">aireceipts templates</code></pre>
-
-<p>prints a short live preview of each built-in template:</p>
-
-<pre class="doc-code"><code>── classic  (default) ──
-Bash..............................$0.05  (3 calls)
-Edit..............................$0.05  (2 calls)
-(thinking/reply)..................$0.03  (2 turns)
-Write.............................$0.03  (2 calls)
-Read...............................$0.02  (1 call)
---------------------------------------------------
-
-── grocery ──
-TXN #A2998369
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-
-── datavis ──
-[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---</code></pre>
-
-<h2 id="apply-one">Apply one</h2>
-
-<p>Pass <code>--template &lt;name&gt;</code> (<code>classic</code>, <code>grocery</code>, or <code>datavis</code>) with any selector:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template grocery &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>- - - - - - - - - - - - - - - - - - - - - - - - -
-                    AIRECEIPTS                    
- “Add email format validation to the signup for…” 
- Claude Code · Jun 18 2026 09:30:30 UTC · 10m 30s 
-    claude-opus-4-8 87% · claude-sonnet-5 13%     
-         cache served 85% of input tokens         
-
-TXN #A3E98D5C
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-Read                                1        $0.02
---------------------------------------------------
-TOTAL                                        $0.18
-same tokens on claude-haiku-4-5..............$0.04
-  (arithmetic, not a prediction)
-
-CARDHOLDER: claude-opus-4-8
-- - - - - - - - - - - - - - - - - - - - - - - - -
-      THANK YOU FOR VIBING WITH Claude Code       
-            || |||| || || | | || ||||             
-- - - - - - - - - - - - - - - - - - - - - - - - -</code></pre>
-
-<p>The <code>TXN #</code> and barcode are a deterministic hash of the session — the same session always renders the same code. <code>datavis</code> instead draws each line as a proportional bar:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template datavis &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---
-Bash............................$0.05 [##########]
-Edit............................$0.05 [#########-]
-Write...........................$0.03 [######----]
-Read............................$0.02 [####------]</code></pre>
-
-<p><code>--template</code> works with the image exports too — see <a href="11-share-and-export.html">Share and export</a>.</p>
-
-<h2 id="adding-a-template">Adding a template</h2>
-
-<p>Templates are built in, not user config files. A new style ships as a small contribution to the renderer — see <code>CONTRIBUTING.md</code> and the existing templates under <code>src/receipt/</code>. Open a PR with a template and its golden output, and it becomes available to everyone.</p>
-
-<h2 id="next">Next</h2>
+<h2 id="what-you-get">What you get</h2>
 
 <ul>
-  <li><strong><a href="11-share-and-export.html">Share and export</a></strong> — save any template as an SVG or PNG.</li>
-  <li><strong><a href="04-read-a-receipt.html">Read a receipt</a></strong> — the default <code>classic</code> layout in detail.</li>
+  <li><strong>Session totals, tokens only.</strong> One receipt per Cursor chat session: total tokens, tool-call counts, and session duration — no <code>$</code>, because Cursor's logs don't record which model ran each turn.</li>
+  <li><strong>No fabricated depth.</strong> Missing per-turn data renders as absent — never synthesized timestamps, usage, or prices. If Cursor starts recording richer usage, the adapter can grow with it.</li>
 </ul>
+
+<h2 id="where-transcripts-live">Where transcripts live</h2>
+
+<p>Cursor stores chat history in a SQLite database (<code>state.vscdb</code>), read-only:</p>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>OS</th><th>Path</th></tr></thead>
+  <tbody>
+    <tr><td>macOS</td><td><code>~/Library/Application Support/Cursor/User/globalStorage/state.vscdb</code></td></tr>
+    <tr><td>Linux</td><td><code>~/.config/Cursor/User/globalStorage/state.vscdb</code></td></tr>
+    <tr><td>Windows</td><td><code>%APPDATA%CursorUserglobalStoragestate.vscdb</code></td></tr>
+  </tbody>
+</table></div>
+
+<h2 id="quick-start">Quick start</h2>
+
+<pre class="doc-code"><code class="language-sh">npx aireceipts-cli --list     # Cursor sessions appear alongside other agents
+npx aireceipts-cli            # newest session across agents</code></pre>
+
+<h2 id="integration">Integration</h2>
+
+<ul>
+  <li><strong>Exact snippets:</strong> <code>npx aireceipts-cli integrations cursor</code>.</li>
+  <li>No hook/statusline surface exists for Cursor; the CLI is the integration point.</li>
+</ul>
+
+<h2 id="receipts-on-your-prs">Receipts on your PRs</h2>
+
+<p>Cursor sessions join PR attribution under the same conservative rules as every agent — <a href="pr-receipts.html">how</a>.</p>
+
+<h2 id="privacy">Privacy</h2>
+
+<p>Read-only, local. The database is opened read-only; nothing is written to it and nothing leaves your machine (<a href="trust.html">what a receipt proves</a>).</p>
     </article>
   </main>
   <footer>

--- a/site/docs/faq.html
+++ b/site/docs/faq.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/gemini.html
+++ b/site/docs/gemini.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Use a template — aireceipts docs</title>
+<title>Receipts for Gemini CLI — aireceipts docs</title>
 <meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
 <meta name="theme-color" content="#e9edf0">
 <style>
@@ -286,8 +286,8 @@ footer{
     <div class="rule2" aria-hidden="true"></div>
     <div class="doc-hero">
       <p class="doc-label">Docs ledger</p>
-      <h1>Use a template</h1>
-      <p class="sub">Rendered from <code>docs/guide/10-templates.md</code>.</p>
+      <h1>Receipts for Gemini CLI</h1>
+      <p class="sub">Rendered from <code>docs/agents/gemini.md</code>.</p>
     </div>
   </header>
   <main class="doc-grid">
@@ -345,100 +345,41 @@ footer{
       </ul>
     </aside>
     <article class="doc-content">
-<h1 id="use-a-template">Use a template</h1>
+<h1 id="receipts-for-gemini-cli">Receipts for Gemini CLI</h1>
 
-<p>Goal: render the same receipt in a different visual style — for a screenshot, a share, or just taste.</p>
+<p>Full-depth support: per-turn models, tools, and cache tokens, including nested subagent chats. (SPEC-0058; depth facts match <code>src/parse/gemini.ts</code>.)</p>
 
-<p>A template changes only how the receipt is <em>drawn</em>. The numbers, the honesty rules, and the totals are identical across all of them.</p>
-
-<h2 id="see-the-styles">See the styles</h2>
-
-<pre class="doc-code"><code class="language-sh">aireceipts templates</code></pre>
-
-<p>prints a short live preview of each built-in template:</p>
-
-<pre class="doc-code"><code>── classic  (default) ──
-Bash..............................$0.05  (3 calls)
-Edit..............................$0.05  (2 calls)
-(thinking/reply)..................$0.03  (2 turns)
-Write.............................$0.03  (2 calls)
-Read...............................$0.02  (1 call)
---------------------------------------------------
-
-── grocery ──
-TXN #A2998369
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-
-── datavis ──
-[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---</code></pre>
-
-<h2 id="apply-one">Apply one</h2>
-
-<p>Pass <code>--template &lt;name&gt;</code> (<code>classic</code>, <code>grocery</code>, or <code>datavis</code>) with any selector:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template grocery &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>- - - - - - - - - - - - - - - - - - - - - - - - -
-                    AIRECEIPTS                    
- “Add email format validation to the signup for…” 
- Claude Code · Jun 18 2026 09:30:30 UTC · 10m 30s 
-    claude-opus-4-8 87% · claude-sonnet-5 13%     
-         cache served 85% of input tokens         
-
-TXN #A3E98D5C
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-Read                                1        $0.02
---------------------------------------------------
-TOTAL                                        $0.18
-same tokens on claude-haiku-4-5..............$0.04
-  (arithmetic, not a prediction)
-
-CARDHOLDER: claude-opus-4-8
-- - - - - - - - - - - - - - - - - - - - - - - - -
-      THANK YOU FOR VIBING WITH Claude Code       
-            || |||| || || | | || ||||             
-- - - - - - - - - - - - - - - - - - - - - - - - -</code></pre>
-
-<p>The <code>TXN #</code> and barcode are a deterministic hash of the session — the same session always renders the same code. <code>datavis</code> instead draws each line as a proportional bar:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template datavis &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---
-Bash............................$0.05 [##########]
-Edit............................$0.05 [#########-]
-Write...........................$0.03 [######----]
-Read............................$0.02 [####------]</code></pre>
-
-<p><code>--template</code> works with the image exports too — see <a href="11-share-and-export.html">Share and export</a>.</p>
-
-<h2 id="adding-a-template">Adding a template</h2>
-
-<p>Templates are built in, not user config files. A new style ships as a small contribution to the renderer — see <code>CONTRIBUTING.md</code> and the existing templates under <code>src/receipt/</code>. Open a PR with a template and its golden output, and it becomes available to everyone.</p>
-
-<h2 id="next">Next</h2>
+<h2 id="what-you-get">What you get</h2>
 
 <ul>
-  <li><strong><a href="11-share-and-export.html">Share and export</a></strong> — save any template as an SVG or PNG.</li>
-  <li><strong><a href="04-read-a-receipt.html">Read a receipt</a></strong> — the default <code>classic</code> layout in detail.</li>
+  <li><strong>Per-turn parsing.</strong> Each turn's model, token usage (with cache tokens), and tool calls — priced per tool line when a cited price row matches the model and date.</li>
+  <li><strong>Subagent chats recognized.</strong> A chat recorded as a subagent is labeled a sidechain and joins discovery alongside the main session's chats.</li>
+  <li><strong>Honest unpriced rendering.</strong> A Gemini model without a cited, dated price row shows tokens only — never a guessed dollar (I2).</li>
 </ul>
+
+<h2 id="where-transcripts-live">Where transcripts live</h2>
+
+<p><code>~/.gemini/tmp/&lt;projectHash&gt;/chats/*.jsonl</code> — one file per session, written by Gemini CLI itself; aireceipts only reads them.</p>
+
+<h2 id="quick-start">Quick start</h2>
+
+<pre class="doc-code"><code class="language-sh">npx aireceipts-cli            # receipt for your newest session
+npx aireceipts-cli --list     # Gemini sessions appear alongside other agents</code></pre>
+
+<h2 id="integration">Integration</h2>
+
+<ul>
+  <li><strong>Exact snippets:</strong> <code>npx aireceipts-cli integrations</code> (recipes list).</li>
+  <li>No hook/statusline surface exists for Gemini CLI; the CLI and the PR command are the integration points.</li>
+</ul>
+
+<h2 id="receipts-on-your-prs">Receipts on your PRs</h2>
+
+<p><code>npx aireceipts-cli pr --post</code> attributes Gemini sessions under the same conservative branch rules as every agent — <a href="pr-receipts.html">how</a>.</p>
+
+<h2 id="privacy">Privacy</h2>
+
+<p>Read-only, local. Transcripts never leave your machine; rendering a receipt makes zero network calls (<a href="trust.html">what a receipt proves</a>).</p>
     </article>
   </main>
   <footer>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">
@@ -442,6 +456,39 @@ footer{
     <p>All notable changes to aireceipts-cli. Factual, grouped by conventional-commit type (I6: a log, not marketing). Dates are UTC.</p>
   </li>
 </ul>
+<h2>Agents</h2>
+<ul class="doc-index-list">
+  <li>
+    <a href="README.html">Supported agents</a>
+    <span class="path">docs/agents/README.md</span>
+    <p>One page per agent: what a receipt can prove there, where the transcripts live, and how to wire it in.</p>
+  </li>
+  <li>
+    <a href="claude-code.html">Receipts for Claude Code</a>
+    <span class="path">docs/agents/claude-code.md</span>
+    <p>Full-depth support: per-turn models, per-tool attribution, cache tiers, subagent rollups.</p>
+  </li>
+  <li>
+    <a href="codex.html">Receipts for Codex CLI</a>
+    <span class="path">docs/agents/codex.md</span>
+    <p>Full per-turn parsing: models, token usage, tool calls, and Codex's context compactions surfaced as a waste signal. (SPEC-0058; depth facts match src/parse/codex.ts.)</p>
+  </li>
+  <li>
+    <a href="cursor.html">Receipts for Cursor</a>
+    <span class="path">docs/agents/cursor.md</span>
+    <p>Honest degraded mode: session totals only, tokens only. Cursor's local history carries no per-turn model ids, no cache/usage breakdown, and no real per-message timestamps — so a…</p>
+  </li>
+  <li>
+    <a href="gemini.html">Receipts for Gemini CLI</a>
+    <span class="path">docs/agents/gemini.md</span>
+    <p>Full-depth support: per-turn models, tools, and cache tokens, including nested subagent chats. (SPEC-0058; depth facts match src/parse/gemini.ts.)</p>
+  </li>
+  <li>
+    <a href="opencode.html">Receipts for opencode</a>
+    <span class="path">docs/agents/opencode.md</span>
+    <p>Full-depth support: per-message models, tools, and cache read/write, with multi-provider pricing resolved per turn from the model id.</p>
+  </li>
+</ul>
 <h2>Why</h2>
 <ul class="doc-index-list">
   <li>
@@ -463,6 +510,19 @@ footer{
     <a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a>
     <span class="path">docs/cost-model.md</span>
     <p>This is the living account of how aireceipts turns a transcript into priced numbers, per scenario and per agent, and — the part that matters most — exactly when the receipt tells…</p>
+  </li>
+  <li>
+    <a href="ROADMAP.html">Roadmap</a>
+    <span class="path">docs/ROADMAP.md</span>
+    <p>Honest and short, on purpose: order and reasons, never dates. For what's actually shipped in the current release, see the current-state inventory in AGENTS.md.</p>
+  </li>
+</ul>
+<h2>Advanced</h2>
+<ul class="doc-index-list">
+  <li>
+    <a href="16-improve-your-next-session.html">Improve your next session</a>
+    <span class="path">docs/guide/16-improve-your-next-session.md</span>
+    <p>Goal: turn today's receipt into a cheaper session tomorrow — a six-step loop, in order, using commands you already have.</p>
   </li>
 </ul>
     </article>

--- a/site/docs/json-schema.html
+++ b/site/docs/json-schema.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">
@@ -511,7 +525,10 @@ footer{
     <tr><td><code>totals</code></td><td>object</td><td><code>tokens</code> (TokenUsage object) + <code>turnCount</code> + <code>toolCallCount</code>.</td></tr>
     <tr><td><code>turnCount</code></td><td>number</td><td>(totals) Assistant turns in the session.</td></tr>
     <tr><td><code>toolCallCount</code></td><td>number</td><td>(totals) Tool calls in the session.</td></tr>
-    <tr><td><code>wasteLines</code></td><td>array</td><td>Same WasteLine union as the receipt.</td></tr>
+    <tr><td><code>wasteLines</code></td><td>array</td><td>Same WasteLine union as the receipt, plus a per-line <code>rule</code> (SPEC-0059).</td></tr>
+    <tr><td><code>rule</code></td><td>string | null</td><td>(wasteLines) The class's fixed one-line next-time rule; <code>null</code> for a class without one.</td></tr>
+    <tr><td><code>couldHaveSaved</code></td><td>object</td><td>SPEC-0059: the extracted savings ceiling — <code>usd</code> (sum of priced waste lines, <code>null</code> when none priced), <code>tokens</code> (sum over all fired lines), <code>pctOfTotal</code>. Arithmetic, never a prediction.</td></tr>
+    <tr><td><code>pctOfTotal</code></td><td>number | null</td><td>(couldHaveSaved) <code>round(100 · usd / totalUsd)</code>; <code>null</code> without both dollar sides.</td></tr>
     <tr><td><code>suggestions</code></td><td>array</td><td>Standing-rule suggestion strings (SPEC-0013), possibly empty.</td></tr>
     <tr><td><code>threshold</code></td><td>number</td><td>The distinct-session recurrence threshold in effect.</td></tr>
     <tr><td><code>coverage</code></td><td>object</td><td>What the packet covers, checkably: <code>turns</code>, <code>toolCalls</code>, <code>compactions</code>, <code>wasteLines</code> (all numbers).</td></tr>
@@ -521,6 +538,25 @@ footer{
     <tr><td><code>aggregates</code></td><td>array</td><td><code>{class, distinctSessionCount}</code> — exactly the waste classes that fired in the trailing recurrence window, below-threshold classes included (inspectable, not silent).</td></tr>
     <tr><td><code>class</code></td><td>string</td><td>(aggregates) Waste class name.</td></tr>
     <tr><td><code>distinctSessionCount</code></td><td>number</td><td>(aggregates) Distinct recent sessions the class fired in.</td></tr>
+  </tbody>
+</table></div>
+
+<h3 id="backfill-envelope-backfilljsonschema-spec-0056">Backfill envelope (<code>backfillJsonSchema</code>) — SPEC-0056</h3>
+
+<p><code>aireceipts backfill --json</code>: the bulk-sweep summary. Counts are honest per SPEC-0045 — degraded/unloadable sessions are counted in <code>loadFailureCount</code>, never silently dropped. <code>sessions</code> is one row per matched session (after <code>--since</code>/<code>--limit</code>), newest-first; rows also carry <code>source</code>, <code>sessionId</code>, <code>title</code>, <code>startedAtMs</code> with the same meanings as the handoff envelope above.</p>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>Field</th><th>Type</th><th>Notes</th></tr></thead>
+  <tbody>
+    <tr><td><code>schemaVersion</code></td><td>number</td><td>Same envelope as receipt/compare/handoff.</td></tr>
+    <tr><td><code>discoveredCount</code></td><td>number</td><td>Every discovered session summary, degraded ones included.</td></tr>
+    <tr><td><code>matchedCount</code></td><td>number</td><td>After the <code>--since</code>/<code>--limit</code> filters.</td></tr>
+    <tr><td><code>loadFailureCount</code></td><td>number</td><td>Honest per SPEC-0045, mode-dependent: on an <code>--out</code> run (loads attempted), degraded summaries plus failed loads; on a dry run only known-unreadable summaries — a lower bound (labelled <code>Known unreadable</code> in the text summary).</td></tr>
+    <tr><td><code>writtenCount</code></td><td>number</td><td>Receipt files written this run; <code>0</code> without <code>--out</code>.</td></tr>
+    <tr><td><code>wroteFiles</code></td><td>boolean</td><td><code>true</code> only when <code>--out</code> wrote files.</td></tr>
+    <tr><td><code>sessions</code></td><td>array</td><td>One row per matched session, newest-first.</td></tr>
+    <tr><td><code>fileName</code></td><td>string | null</td><td>(sessions) File written under <code>--out</code>, or <code>null</code> (dry run / load failed).</td></tr>
+    <tr><td><code>loadFailed</code></td><td>boolean</td><td>(sessions) <code>true</code> when the session is known unreadable or (on an <code>--out</code> run) its load failed.</td></tr>
   </tbody>
 </table></div>
 

--- a/site/docs/opencode.html
+++ b/site/docs/opencode.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Use a template — aireceipts docs</title>
+<title>Receipts for opencode — aireceipts docs</title>
 <meta name="description" content="Static aireceipts documentation rendered from the repository docs folder.">
 <meta name="theme-color" content="#e9edf0">
 <style>
@@ -286,8 +286,8 @@ footer{
     <div class="rule2" aria-hidden="true"></div>
     <div class="doc-hero">
       <p class="doc-label">Docs ledger</p>
-      <h1>Use a template</h1>
-      <p class="sub">Rendered from <code>docs/guide/10-templates.md</code>.</p>
+      <h1>Receipts for opencode</h1>
+      <p class="sub">Rendered from <code>docs/agents/opencode.md</code>.</p>
     </div>
   </header>
   <main class="doc-grid">
@@ -345,100 +345,49 @@ footer{
       </ul>
     </aside>
     <article class="doc-content">
-<h1 id="use-a-template">Use a template</h1>
+<h1 id="receipts-for-opencode">Receipts for opencode</h1>
 
-<p>Goal: render the same receipt in a different visual style — for a screenshot, a share, or just taste.</p>
+<p>Full-depth support: per-message models, tools, and cache read/write, with multi-provider pricing resolved per turn from the model id. (SPEC-0058; depth facts match <code>src/parse/opencode.ts</code>.)</p>
 
-<p>A template changes only how the receipt is <em>drawn</em>. The numbers, the honesty rules, and the totals are identical across all of them.</p>
-
-<h2 id="see-the-styles">See the styles</h2>
-
-<pre class="doc-code"><code class="language-sh">aireceipts templates</code></pre>
-
-<p>prints a short live preview of each built-in template:</p>
-
-<pre class="doc-code"><code>── classic  (default) ──
-Bash..............................$0.05  (3 calls)
-Edit..............................$0.05  (2 calls)
-(thinking/reply)..................$0.03  (2 turns)
-Write.............................$0.03  (2 calls)
-Read...............................$0.02  (1 call)
---------------------------------------------------
-
-── grocery ──
-TXN #A2998369
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-
-── datavis ──
-[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---</code></pre>
-
-<h2 id="apply-one">Apply one</h2>
-
-<p>Pass <code>--template &lt;name&gt;</code> (<code>classic</code>, <code>grocery</code>, or <code>datavis</code>) with any selector:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template grocery &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>- - - - - - - - - - - - - - - - - - - - - - - - -
-                    AIRECEIPTS                    
- “Add email format validation to the signup for…” 
- Claude Code · Jun 18 2026 09:30:30 UTC · 10m 30s 
-    claude-opus-4-8 87% · claude-sonnet-5 13%     
-         cache served 85% of input tokens         
-
-TXN #A3E98D5C
-ITEM                              QTY          AMT
-Bash                                3        $0.05
-Edit                                2        $0.05
-(thinking/reply)                    2        $0.03
-Write                               2        $0.03
-Read                                1        $0.02
---------------------------------------------------
-TOTAL                                        $0.18
-same tokens on claude-haiku-4-5..............$0.04
-  (arithmetic, not a prediction)
-
-CARDHOLDER: claude-opus-4-8
-- - - - - - - - - - - - - - - - - - - - - - - - -
-      THANK YOU FOR VIBING WITH Claude Code       
-            || |||| || || | | || ||||             
-- - - - - - - - - - - - - - - - - - - - - - - - -</code></pre>
-
-<p>The <code>TXN #</code> and barcode are a deterministic hash of the session — the same session always renders the same code. <code>datavis</code> instead draws each line as a proportional bar:</p>
-
-<pre class="doc-code"><code class="language-sh">aireceipts --template datavis &quot;email format&quot;</code></pre>
-
-<pre class="doc-code"><code>[##########] = priciest line; others in proportion
-
---- MODEL OUTPUT ---
-(thinking/reply)................$0.03 [######----]
-
---- TOOL CALLS ---
-Bash............................$0.05 [##########]
-Edit............................$0.05 [#########-]
-Write...........................$0.03 [######----]
-Read............................$0.02 [####------]</code></pre>
-
-<p><code>--template</code> works with the image exports too — see <a href="11-share-and-export.html">Share and export</a>.</p>
-
-<h2 id="adding-a-template">Adding a template</h2>
-
-<p>Templates are built in, not user config files. A new style ships as a small contribution to the renderer — see <code>CONTRIBUTING.md</code> and the existing templates under <code>src/receipt/</code>. Open a PR with a template and its golden output, and it becomes available to everyone.</p>
-
-<h2 id="next">Next</h2>
+<h2 id="what-you-get">What you get</h2>
 
 <ul>
-  <li><strong><a href="11-share-and-export.html">Share and export</a></strong> — save any template as an SVG or PNG.</li>
-  <li><strong><a href="04-read-a-receipt.html">Read a receipt</a></strong> — the default <code>classic</code> layout in detail.</li>
+  <li><strong>Per-message parsing.</strong> Models, token usage (cache read and write), and tool parts from opencode's local store.</li>
+  <li><strong>Multi-provider pricing.</strong> opencode routes to many providers; each turn's cost resolves from its own model id against the cited price tables. Unknown models stay tokens-only — never a guessed dollar (I2).</li>
+  <li><strong>Schema resilience.</strong> Both opencode's current <code>session_message</code> schema and the legacy message/part rows are parsed; mixed-schema databases resolve per session.</li>
 </ul>
+
+<h2 id="where-transcripts-live">Where transcripts live</h2>
+
+<p>opencode's local data directory, read-only:</p>
+
+<div class="table-wrap"><table>
+  <thead><tr><th>OS</th><th>Path</th></tr></thead>
+  <tbody>
+    <tr><td>macOS / Linux</td><td><code>~/.local/share/opencode</code></td></tr>
+    <tr><td>Windows</td><td><code>%LOCALAPPDATA%opencode</code></td></tr>
+  </tbody>
+</table></div>
+
+<h2 id="quick-start">Quick start</h2>
+
+<pre class="doc-code"><code class="language-sh">npx aireceipts-cli            # receipt for your newest session
+npx aireceipts-cli --list     # opencode sessions appear alongside other agents</code></pre>
+
+<h2 id="integration">Integration</h2>
+
+<ul>
+  <li><strong>Exact snippets:</strong> <code>npx aireceipts-cli integrations opencode</code>.</li>
+  <li>No hook/statusline surface exists for opencode; the CLI and the PR command are the integration points.</li>
+</ul>
+
+<h2 id="receipts-on-your-prs">Receipts on your PRs</h2>
+
+<p><code>npx aireceipts-cli pr --post</code> attributes opencode sessions under the same conservative branch rules as every agent — <a href="pr-receipts.html">how</a>.</p>
+
+<h2 id="privacy">Privacy</h2>
+
+<p>Read-only, local. The store is opened read-only; nothing is written to it and nothing leaves your machine (<a href="trust.html">what a receipt proves</a>).</p>
     </article>
   </main>
   <footer>

--- a/site/docs/org-rollout.html
+++ b/site/docs/org-rollout.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/pr-receipts.html
+++ b/site/docs/pr-receipts.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">
@@ -396,9 +410,10 @@ git receipt                  # after pushing your branch</code></pre>
 
 <ul>
   <li>A marker line (<code>&lt;!-- aireceipts-dogfood --&gt;</code>) so the upsert and the CI check can find exactly one comment to keep current.</li>
-  <li>A fenced receipt headed <code>N sessions behind this PR</code>: one row per contributing session (<code>&lt;role&gt; · &lt;model mix&gt; · &lt;cost&gt;</code>), a muted provenance line under each (session id + <code>session slice: turns A–B of N</code>, or <code>entire session (slice unavailable)</code> when the work can't be cut cleanly — ambiguity is labeled, never presented as PR cost), and indented <code>SUBAGENTS</code> sub-rows for any subagent sessions a contributor launched.</li>
+  <li>A fenced receipt headed <code>N sessions behind this PR</code>: one row per contributing session (<code>&lt;role&gt; · &lt;model mix&gt; · &lt;cost&gt;</code>), a muted provenance line under each (session id + <code>session slice: turns A–B of N</code>, or <code>entire session (slice unavailable)</code> when the work can't be cut cleanly — ambiguity is labeled, never presented as PR cost), and one indented <code>SUBAGENTS (N)</code> aggregate row summing any subagent sessions a contributor launched (SPEC-0060).</li>
   <li>One combined total. Priced and unpriced sessions are never blended: dollars and tokens total separately.</li>
   <li>An honest note counting any plausible-but-unproven sessions that were <strong>not</strong> attributed.</li>
+  <li>A collapsed <code>full receipts</code> section: a per-session ledger table, each session's full receipt, and — for a session that launched subagents — a <code>subagents (N)</code> table under its receipt, sorted by cost and capped at 20 rows where the last row carries the remainder's sum (a capped list never silently drops value).</li>
 </ul>
 
 <h2 id="how-sessions-are-matched-to-a-pr">How sessions are matched to a PR</h2>

--- a/site/docs/statusline.html
+++ b/site/docs/statusline.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">
@@ -359,7 +373,7 @@ footer{
     <tr><td><code>cliVersion</code></td><td>string</td><td>semver</td><td>From this package's <code>package.json</code>.</td></tr>
     <tr><td><code>os</code></td><td>enum</td><td><code>darwin</code> | <code>linux</code> | <code>win32</code> | <code>other</code></td><td>Collapsed from <code>process.platform</code>.</td></tr>
     <tr><td><code>nodeMajor</code></td><td>integer</td><td>e.g. <code>22</code></td><td>Major Node version only.</td></tr>
-    <tr><td><code>commandClass</code></td><td>enum</td><td><code>benchmark</code> | <code>check-budget</code> | <code>compare</code> | <code>demo</code> | <code>handoff</code> | <code>help</code> | <code>install-hook</code> | <code>list</code> | <code>methodology</code> | <code>mini</code> | <code>pr</code> | <code>quota</code> | <code>receipt</code> | <code>stats</code> | <code>statusline</code> | <code>telemetry-show</code> | <code>templates</code> | <code>uninstall-hook</code> | <code>version</code> | <code>week</code></td><td>Selected command name only; never raw argv or flag values.</td></tr>
+    <tr><td><code>commandClass</code></td><td>enum</td><td><code>backfill</code> | <code>benchmark</code> | <code>check-budget</code> | <code>compare</code> | <code>demo</code> | <code>handoff</code> | <code>help</code> | <code>install-hook</code> | <code>list</code> | <code>methodology</code> | <code>mini</code> | <code>pr</code> | <code>quota</code> | <code>receipt</code> | <code>stats</code> | <code>statusline</code> | <code>telemetry-show</code> | <code>templates</code> | <code>uninstall-hook</code> | <code>version</code> | <code>week</code></td><td>Selected command name only; never raw argv or flag values.</td></tr>
     <tr><td><code>agentType</code></td><td>enum</td><td><code>claude-code</code> | <code>codex</code> | <code>cursor</code> | <code>gemini</code> | <code>opencode</code> | <code>unknown</code></td><td>Which agent format was parsed, if known.</td></tr>
     <tr><td><code>durationBucket</code></td><td>enum</td><td><code>&lt;100ms</code> | <code>100-500ms</code> | <code>500ms-2s</code> | <code>2-10s</code> | <code>&gt;10s</code></td><td>Coarse bucket; never raw milliseconds.</td></tr>
     <tr><td><code>ok</code></td><td>boolean</td><td></td><td>Whether the command returned exit code 0.</td></tr>
@@ -376,7 +390,7 @@ footer{
   <thead><tr><th>Field</th><th>Type</th><th>Values</th><th>Notes</th></tr></thead>
   <tbody>
     <tr><td><code>errorClass</code></td><td>enum</td><td><code>parse_error</code> | <code>io_error</code> | <code>network_error</code> | <code>validation_error</code> | <code>unknown_error</code></td><td>Derived from bounded error metadata; never <code>error.message</code>.</td></tr>
-    <tr><td><code>command</code></td><td>enum</td><td>same 19-command enum as <code>cli_run.commandClass</code></td><td>Never raw argv.</td></tr>
+    <tr><td><code>command</code></td><td>enum</td><td>same command enum as <code>cli_run.commandClass</code></td><td>Never raw argv.</td></tr>
     <tr><td><code>agentType</code></td><td>enum</td><td><code>claude-code</code> | <code>codex</code> | <code>cursor</code> | <code>gemini</code> | <code>opencode</code> | <code>unknown</code></td><td></td></tr>
     <tr><td><code>inPackage</code></td><td>boolean</td><td></td><td>Whether the top stack frame is inside aireceipts; the stack text never leaves the process.</td></tr>
   </tbody>
@@ -420,8 +434,8 @@ footer{
 <div class="table-wrap"><table>
   <thead><tr><th>Field</th><th>Type</th><th>Values</th><th>Notes</th></tr></thead>
   <tbody>
-    <tr><td><code>surface</code></td><td>enum</td><td><code>receipt</code> | <code>compare</code> | <code>week</code> | <code>list</code> | <code>pr</code></td><td></td></tr>
-    <tr><td><code>format</code></td><td>enum</td><td><code>json</code> | <code>csv_session</code> | <code>csv_tool</code> | <code>svg</code> | <code>png</code> | <code>markdown</code> | <code>html</code></td><td></td></tr>
+    <tr><td><code>surface</code></td><td>enum</td><td><code>receipt</code> | <code>compare</code> | <code>week</code> | <code>list</code> | <code>pr</code> | <code>backfill</code></td><td></td></tr>
+    <tr><td><code>format</code></td><td>enum</td><td><code>json</code> | <code>csv_session</code> | <code>csv_tool</code> | <code>svg</code> | <code>png</code> | <code>markdown</code> | <code>html</code> | <code>text</code></td><td></td></tr>
     <tr><td><code>wroteFile</code></td><td>boolean</td><td></td><td>False for stdout exports.</td></tr>
     <tr><td><code>result</code></td><td>enum</td><td><code>success</code> | <code>no_data</code> | <code>invalid_args</code> | <code>declined</code> | <code>external_missing</code> | <code>external_failed</code> | <code>write_failed</code> | <code>internal_error</code></td><td></td></tr>
   </tbody>
@@ -439,6 +453,7 @@ footer{
     <tr><td><code>commentResult</code></td><td>enum</td><td><code>success</code> | <code>failed</code> | <code>skipped</code></td><td></td></tr>
     <tr><td><code>artifactResult</code></td><td>enum</td><td><code>success</code> | <code>failed</code> | <code>skipped</code></td><td></td></tr>
     <tr><td><code>shareResult</code></td><td>enum</td><td><code>success</code> | <code>failed</code> | <code>skipped</code></td><td></td></tr>
+    <tr><td><code>handoffSectionIncluded</code></td><td>boolean</td><td></td><td>SPEC-0059: the rendered body carried the handoff section (rendering rate only — never engagement, never contents).</td></tr>
     <tr><td><code>result</code></td><td>enum</td><td><code>success</code> | <code>no_data</code> | <code>invalid_args</code> | <code>declined</code> | <code>external_missing</code> | <code>external_failed</code> | <code>write_failed</code> | <code>internal_error</code></td><td></td></tr>
   </tbody>
 </table></div>
@@ -472,7 +487,7 @@ footer{
   <thead><tr><th>Field</th><th>Type</th><th>Values</th><th>Notes</th></tr></thead>
   <tbody>
     <tr><td><code>milestone</code></td><td>enum</td><td><code>first_run</code> | <code>first_receipt</code> | <code>third_receipt</code> | <code>tenth_receipt</code> | <code>first_export</code> | <code>first_compare</code> | <code>first_week</code> | <code>first_hook_install</code> | <code>first_pr</code> | <code>first_pr_post</code> | <code>first_artifact</code></td><td></td></tr>
-    <tr><td><code>command</code></td><td>enum</td><td>same 19-command enum as <code>cli_run.commandClass</code></td><td>Command that caused the milestone.</td></tr>
+    <tr><td><code>command</code></td><td>enum</td><td>same command enum as <code>cli_run.commandClass</code></td><td>Command that caused the milestone.</td></tr>
     <tr><td><code>installAgeBucket</code></td><td>enum</td><td><code>first_day</code> | <code>2-7d</code> | <code>8-30d</code> | <code>31-90d</code> | <code>&gt;90d</code> | <code>unavailable</code></td><td>Derived locally from <code>firstRunAt</code>; raw date is not sent.</td></tr>
   </tbody>
 </table></div>

--- a/site/docs/trust.html
+++ b/site/docs/trust.html
@@ -322,12 +322,26 @@ footer{
         <li><a href="telemetry.html">Diagnostics and adoption telemetry</a></li>
         <li><a href="CHANGELOG.html">Changelog</a></li>
       </ul>
+      <p class="toc-section">Agents</p>
+      <ul>
+        <li><a href="README.html">Supported agents</a></li>
+        <li><a href="claude-code.html">Receipts for Claude Code</a></li>
+        <li><a href="codex.html">Receipts for Codex CLI</a></li>
+        <li><a href="cursor.html">Receipts for Cursor</a></li>
+        <li><a href="gemini.html">Receipts for Gemini CLI</a></li>
+        <li><a href="opencode.html">Receipts for opencode</a></li>
+      </ul>
       <p class="toc-section">Why</p>
       <ul>
         <li><a href="13-pricing.html">How pricing is estimated</a></li>
         <li><a href="14-session-attribution.html">How session attribution works</a></li>
         <li><a href="trust.html">What a receipt proves — and what it can't</a></li>
         <li><a href="cost-model.html">The cost model — how a receipt's numbers are computed, and when it flags</a></li>
+        <li><a href="ROADMAP.html">Roadmap</a></li>
+      </ul>
+      <p class="toc-section">Advanced</p>
+      <ul>
+        <li><a href="16-improve-your-next-session.html">Improve your next session</a></li>
       </ul>
     </aside>
     <article class="doc-content">

--- a/site/index.html
+++ b/site/index.html
@@ -133,7 +133,8 @@
     display:grid;grid-template-columns:minmax(0,1fr);
     gap:clamp(28px,3vw,36px);
   }
-  @media (min-width:820px){.scenarios{grid-template-columns:repeat(3,minmax(0,1fr))}}
+  @media (min-width:620px){.scenarios{grid-template-columns:repeat(2,minmax(0,1fr))}}
+  @media (min-width:1040px){.scenarios{grid-template-columns:repeat(4,minmax(0,1fr))}}
   .scn{min-width:0;border-top:2px solid var(--ink);padding-top:20px}
   .scn h3{
     font-family:var(--sans);font-weight:700;
@@ -366,6 +367,15 @@
 builder · opus ············ $43.80
 TOTAL ····················· <span class="grnl">$56.10</span></pre></div>
         </div>
+        <div class="scn">
+          <img class="scnimg" src="assets/scn-loop.png" alt="" width="76" height="76">
+          <h3>Waste becomes an instruction</h3>
+          <p>The handoff turns the waste a session actually hit into a paste-ready block for the next one — never a summary, always the transcript's own numbers.</p>
+          <pre class="art cardart">- Bash loop ×5: <span class="redl">$0.08</span>, 3m 45s wall-clock
+<span class="dim">covers: 6 turns · 5 tool calls · 1 waste line</span>
+<span class="dim">fires only after 3+ sessions repeat it —</span>
+<span class="dim">otherwise: "nothing to hand off"</span></pre>
+        </div>
       </div>
     </section>
   </div>
@@ -402,6 +412,7 @@ TOTAL ····················· <span class="grnl">$56.10</span
   <div class="wrap">
     <section aria-label="Three steps">
         <h2 class="lede">Sixty seconds to your first receipt.</h2>
+        <p class="proofcap">It reads the sessions you've already run — first receipt works on last month's history, no new session needed.</p>
       <div class="steps">
         <div class="step">
           <span class="k">01</span>

--- a/site/index.html
+++ b/site/index.html
@@ -371,7 +371,7 @@ TOTAL ····················· <span class="grnl">$56.10</span
           <img class="scnimg" src="assets/scn-loop.png" alt="" width="76" height="76">
           <h3>Waste becomes an instruction</h3>
           <p>The handoff turns the waste a session actually hit into a paste-ready block for the next one — never a summary, always the transcript's own numbers.</p>
-          <pre class="art cardart">- Bash loop ×5: <span class="redl">$0.08</span>, 3m 45s wall-clock
+          <pre class="art cardart">⚠ Bash loop ×5......<span class="redl">$0.08</span> (3m 45s)
 <span class="dim">covers: 6 turns · 5 tool calls · 1 waste line</span>
 <span class="dim">fires only after 3+ sessions repeat it —</span>
 <span class="dim">otherwise: "nothing to hand off"</span></pre>


### PR DESCRIPTION
## Summary

GTM-readiness pass across the launch surfaces, requested for `--handoff`
messaging (with its false-positive control), a roadmap, an "Advanced"
sessions guide, and a retroactivity claim. **Docs/GTM-copy only — no
product code changes.** Does not document the in-flight `backfill`
command; that PR owns its own docs.

### What changed, per surface

**A. `site/index.html`** — added a fourth scenario card, "Waste becomes an
instruction," to the existing waste/week/PR-receipts row (new CSS grid
breakpoints: 2-col at 620px, 4-col at 1040px so four cards lay out
cleanly). Copy covers the `--handoff` block, the 3+-session false-positive
gate, and the `nothing to hand off` default. Added a one-line
retroactivity claim under "Sixty seconds to your first receipt."

**B. `docs/internal/launch-kit.md`** — reworked the Show HN post body to
cover the handoff and retroactivity while keeping the existing honesty
framing (fabricated-dollar disclaimer, telemetry disclosure, `npx` line).
**Word count: 148** (cap is 150). This dropped the earlier "$965
mis-attributed session" dogfooding anecdote to make room — flagging that
tradeoff here since it was a real, cited story. Added a new "Prepared
handoff answer" subsection: a ready-to-paste reply on the false-positive
gate for if an HN commenter asks.

**C. `README.md`** — two new bullets in "What you get" (retroactivity;
handoff with the false-positive gate phrasing), plus a Roadmap link in the
Docs footer line. `npx vitest run test/readme-guard.test.ts` — 9/9 pass
(fenced receipt untouched, tagline untouched, zero emoji, 186/260 lines).

**D. `docs/ROADMAP.md`** (new) — Now / Next / Later / Principles, no
dates. "Integration with coding agents" is prominent under Next (Claude
Code hooks today, deeper direction is agent-native `--handoff --json`
consumption), alongside broader adapter coverage and the SPEC-0015 opt-in
benchmark (client contract shipped, sends disabled). SPEC-0052 (GitHub
App) is named explicitly as parked with its three revisit triggers.
Closes with the four invariant-derived principles (local-first,
deterministic, no fabricated dollars, facts not rankings). Lives at
`docs/ROADMAP.md`, not repo root — `scripts/hygiene.mjs`'s
`ROOT_ALLOWLIST` doesn't include a bare `ROADMAP.md`.

**E. `docs/guide/16-improve-your-next-session.md`** (new, "Advanced"
section) — a six-step loop: read the waste lines → `--handoff` → let
recurring waste (3+ sessions) graduate into a standing rule → set a local
budget with `--check-budget` → `compare <before> <after>` to confirm a fix
got cheaper → watch `week`'s Top waste trend. Wired into
`NAV_SECTIONS` in `scripts/build-docs-site.mjs` under a new "Advanced"
section (nav completeness is build-enforced). Docs site regenerated via
`node scripts/build-docs-site.mjs` — **`build-docs-site: wrote 27 page(s)
to site/docs`**, exit 0.

**F. `docs/guide/09-handoff.md`** — added a paragraph naming the
false-positive control explicitly: recurrence across `N` distinct recent
sessions (default 3), not repetition inside one session; empty handoff
still prints `nothing to hand off`, never invented advice.

**Incidental fix**: `scripts/build-docs-site.mjs`'s `NAV_SECTIONS` was
missing `guide/15-integrations.md` (added in #119) — this broke
`node scripts/build-docs-site.mjs` even on `main` with zero other
changes (confirmed via `git stash`). Fixed as part of wiring in this
PR's new pages, since the build has to pass either way.

### Codex review (recorded, per `.claude/skills/review-pr`)

Ran `codex exec --sandbox read-only` against the diff. Findings and
resolution:
- **Fixed**: `docs/guide/16-improve-your-next-session.md` had an uncited
  `$12` example dollar figure (I2 violation) — reworded to avoid
  fabricating a number.
- **Fixed**: `docs/ROADMAP.md` linked `../AGENTS.md`, which 404s once
  published under `site/docs/` (AGENTS.md lives outside `docs/`) — switched
  to the absolute GitHub blob URL, the same working pattern `docs/faq.md`
  already uses for root-level files.
- **Confirmed pre-existing, out of scope** (present verbatim on `main`
  before this branch, unrelated to this diff): three other docs-site
  links that 404 the same way (`docs/pr-receipts.md`'s SPEC-0052 link,
  `docs/adopt/org-rollout.md`'s `pr-receipt-check-caller.yml` link,
  `docs/cost-model.md`'s link into the unpublished `internal/` dir), and
  a stale "same 19-command enum" line in `docs/telemetry.md` against its
  own 20-value `commandClass` table.
- I6 (facts not rankings), scope discipline on `build-docs-site.mjs`, no
  promised dates in the roadmap, and the HN word cap: all passed.

### Verification (AGENTS.md gate, each exit checked with `echo $?`, never piped)

| Gate | Result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npx eslint . --max-warnings 0` | exit 0 |
| `npx vitest run` | exit 0 — 111 files / 1355 tests passed |
| `node scripts/verify-goldens.mjs` | exit 0 — 95 artifacts byte-identical |
| `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs` | exit 0 — 10/10 byte-identical |
| `node scripts/spec-lint.mjs` | exit 0 — 51 specs OK |
| `node scripts/hygiene.mjs` | exit 0 |

All seven exit 0. (Two vitest tests — `test/cli/hook-commands.test.ts`'s
TTY-consent case and `test/cli-e2e/built-cli.test.ts`'s packed-tarball
smoke test — were observed failing once mid-session due to a transient
local `node_modules` corruption unrelated to any file in this diff;
`npm ci` restored a clean install and the full suite now passes
111/111 files, 1355/1355 tests, reproducibly.)

### Not done / judgment calls to flag

- Dropped the "$965 mis-attributed session" dogfooding anecdote from the
  HN post body to stay under the 150-word cap while adding handoff +
  retroactivity coverage (see B above).
- Reused `assets/scn-loop.png` for the new handoff scenario card on
  `site/index.html` — no dedicated handoff icon asset exists yet.
- Left the three pre-existing dead docs-site links and the
  `telemetry.md` enum-count mismatch as-is; fixing them is outside this
  PR's docs/GTM-copy scope (the first three need a `build-docs-site.mjs`
  link-rewrite change, the fourth needs an update to a file this PR
  never otherwise touches).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx eslint . --max-warnings 0`
- [x] `npx vitest run` (111/111 files, 1355/1355 tests)
- [x] `node scripts/verify-goldens.mjs`
- [x] `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`
- [x] `node scripts/spec-lint.mjs`
- [x] `node scripts/hygiene.mjs`
- [x] `npx vitest run test/readme-guard.test.ts` (9/9)
- [x] `node scripts/build-docs-site.mjs` (27 pages written)
- [x] Codex review recorded (`.review-ok`), findings resolved or triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Rebase onto current main (2026-07-05, post #145/#146/#148/#150)

Main moved and this branch went CONFLICTING; rebased onto `47f2cf9`.

- **NAV_SECTIONS collision resolved**: both this branch and merged #145
  added `guide/15-integrations.md` — kept exactly one entry, in main's
  placement ("Using it"), and dropped this branch's duplicate. This
  branch's own additions (`ROADMAP.md` under "Why", the "Advanced"
  section) survive.
- **Declared minimal unbreak (same class as the 15-integrations fix
  above)**: merged #146 added `docs/agents/*.md` (SPEC-0058 per-agent
  pages) without NAV_SECTIONS entries, so `node scripts/build-docs-site.mjs`
  hard-fails on current main (manifest completeness is build-enforced).
  Added an "Agents" section listing all six pages
  (`agents/README.md`, `claude-code`, `codex`, `cursor`, `gemini`,
  `opencode`). This folded into the first commit because the build cannot
  pass at that point in history without it.
- **site/docs/ regenerated wholesale** from current sources (no
  hand-merged HTML): `build-docs-site: wrote 33 page(s) to site/docs`,
  exit 0. No conflict markers; the samosa footer on docs pages is the
  generator's own shared template, already on main (#145's intentional
  tip-jar surface on non-receipt pages) — no stale receipt-footer text in
  this branch's new content.
- **All seven gates re-run on the rebased HEAD, each exit checked with
  `echo $?`**: tsc 0 · eslint 0 · vitest 0 (112 files / 1361 tests) ·
  verify-goldens 0 (95 artifacts) · determinism x10 0 · spec-lint 0
  (55 specs) · hygiene 0.
- **Codex delta review** re-run against the rebase delta and recorded
  (`.review-ok`): NAV dedup + Agents section + scope all pass; its two
  flagged items were false positives (its read-only sandbox cannot write
  `site/docs/` during the build check; the samosa footer is main's own
  generator template, verified identical on main-generated pages).


## Second rebase (post #143/#147/#149/#151/#152, main at 46929c3)

- Only real conflict: generated `site/docs/15-integrations.html` — took a
  side and regenerated `site/docs/` wholesale (33 pages, exit 0; the
  regen produced zero further diff, confirming the merge result matched a
  fresh build). NAV_SECTIONS auto-merged clean and covers every
  publishable doc — no new unbreak needed.
- Output-bytes re-sync (#149/#151/#152): the branch's guide pages embed
  no receipt output of their own; `docs/guide/09-handoff.md`'s example
  block is main's own post-#152 content (this branch's delta there is
  one added paragraph). One fix (new commit `aa2c519`): the landing-page
  handoff card mimicked the pre-#152 waste-line format — re-synced to the
  current `⚠ Bash loop ×5......$0.08 (3m 45s)` shape.
- Gates on rebased HEAD, each `echo $?` direct: tsc 0 · eslint 0 ·
  vitest 0 (118 files / 1479 tests) · verify-goldens 0 (100 artifacts) ·
  determinism x10 0 · spec-lint 0 (58 specs) · hygiene 0.
- Codex delta review re-run and recorded: 4/4 pass (NAV completeness,
  card-sync commit isolation, no conflict markers, scope).
