### PR TITLE
feat: SPEC-0062 statusline v2 — brand, quota, --format segments, ≈ ETA

### DIFF
--- a/docs/guide/07-statusline.md
+++ b/docs/guide/07-statusline.md
@@ -7,7 +7,7 @@ running a command yourself.
 Code's `statusLine` config:
 
 ```
-[Claude Code] $0.18 · 147k tok
+[aireceipts] $0.18 · 147k tok
 ```
 
 ## Set it up

--- a/docs/statusline.md
+++ b/docs/statusline.md
@@ -31,19 +31,59 @@ instead of `aireceipts` in the `command` field (for example, the output of
 ## Output
 
 ```
-[Claude Code] $1.23 · 12k tok
-[Claude Code] $2.50 · 20k tok · ⚠ Bash loop ×5
-[Cursor] 8k tok
+[aireceipts] $1.23 · 12k tok · 5h 24%
+[aireceipts] $2.50 · 20k tok · ⚠ Bash loop ×5
+[aireceipts · Cursor] 8k tok
 ```
 
 - `$X.XX · Nk tok` when the session's cost is priced; `Nk tok` only when it
   isn't (never a fabricated `$` amount).
+- `5h N%` is your official 5-hour rate-limit window usage, straight from the
+  payload Claude Code pipes in (subscribers) — omitted when the payload doesn't
+  carry it, never guessed.
 - The waste flag (`⚠ ...`) appears only when a waste detector actually fired
   on the session — its absence is not itself a claim that nothing was found.
 - Outside a piped invocation (or when stdin carries no usable payload),
   `aireceipts statusline` falls back to the most-recently-ended session found
-  on disk. If no sessions are detected at all, it prints a neutral placeholder
-  line rather than an error, so the statusline layout never breaks.
+  on disk — the prefix then names whose session it is (`[aireceipts · Codex]`).
+  If no sessions are detected at all, it prints a neutral placeholder line
+  rather than an error, so the statusline layout never breaks.
+
+## Custom formats (`--format`)
+
+The default line is the format `brand,cost,tokens,waste,quota5h`. Pick your own
+segments with `--format` (comma-separated; a segment with nothing honest to say
+is omitted, and an unknown name exits 1 with the valid list on stderr):
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "aireceipts statusline --format brand,cost,quota5h,quotaEta"
+  }
+}
+```
+
+| Segment | Renders | Source |
+|---|---|---|
+| `brand` | `[aireceipts]` (stdin) / `[aireceipts · <agent>]` (disk fallback) | — |
+| `cost` | `$X.XX` | priced session total incl. subagents; omitted when unpriced (I2) |
+| `tokens` | `Nk tok` | session + subagent tokens |
+| `waste` | `⚠ ...` | first fired waste detector |
+| `quota5h` / `quota7d` | `5h N%` / `7d N%` | official `rate_limits` passthrough (stdin only) |
+| `quotaEta` | `≈ 5h cap HH:MM UTC` | labeled arithmetic, see below |
+
+### `quotaEta` honesty rules
+
+The ETA is straight-line arithmetic between exactly two observed readings of
+your 5h window (the previous invocation's, cached in
+`~/.aireceipts/quota-window.json`, and this one's) — the `≈` label is
+mandatory, and the segment renders **only** when every guard holds: same window
+(unchanged `resets_at`), rising usage, readings at least 60s apart, no
+clock-skew between them, and the projected crossing landing before the window
+resets. Anything ambiguous renders nothing — an omitted segment, never a
+guessed time. It is an extrapolation of your recent burn rate, not a
+prediction of what you'll do next.
 
 ## Notes
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -107,6 +107,7 @@ Every field below is validated against a `.strict()` zod schema before it is que
 | `integration` | enum | `statusline` \| `quota` | `mini` is a receipt, not an integration event. |
 | `inputMode` | enum | `stdin_payload` \| `disk_fallback` \| `none` | |
 | `payloadValid` | boolean | | Whether the stdin payload was usable for the integration. |
+| `customFormat` | boolean (optional) | | statusline only (SPEC-0062): an explicit `--format` was passed. The boolean only — never the format string. |
 | `result` | enum | `success` \| `no_data` \| `invalid_args` \| `declined` \| `external_missing` \| `external_failed` \| `write_failed` \| `internal_error` | |
 
 ### `activation_milestone` — once per milestone per local state file

--- a/goldens/cli/help.txt
+++ b/goldens/cli/help.txt
@@ -42,7 +42,7 @@ Usage:
   aireceipts --mini [selector]          6-line mini-receipt (newest session)
   aireceipts install-hook               add a Claude Code SessionEnd auto-receipt hook
   aireceipts uninstall-hook             remove that hook
-  aireceipts statusline                 one-line summary for Claude Code's statusLine
+  aireceipts statusline [--format <s>]  one-line summary for Claude Code's statusLine
   aireceipts --help                     show this help
   aireceipts --version                  print the installed version
 

--- a/scripts/site-assets.mts
+++ b/scripts/site-assets.mts
@@ -12,7 +12,8 @@ import { buildReceiptModel } from "../src/receipt/model.js";
 import { renderReceiptSvg } from "../src/receipt/svg.js";
 import { rasterizeSvgToPng } from "../src/receipt/png.js";
 import { renderCompare } from "../src/receipt/compare.js";
-import { renderStatusline } from "../src/receipt/mini.js";
+import { buildMiniSummary } from "../src/receipt/mini.js";
+import { parseFormat, renderSegments, DEFAULT_FORMAT } from "../src/cli/statuslineSegments.js";
 import { renderWeek } from "../src/receipt/week.js";
 import { assembleWeekDigest, windowBounds } from "../src/aggregate/week.js";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
@@ -60,7 +61,10 @@ const digest = await assembleWeekDigest(windowBounds(now), [
 
 const compareText = renderCompare(clean, loop, { color: false, termWidth: 120 });
 const weekText = renderWeek(digest, { color: false });
-const statuslineText = renderStatusline(loop);
+// SPEC-0062 — the site sample shows the stdin-mode default line (no quota payload here, so the quota segment self-omits).
+const statuslineFormat = parseFormat(DEFAULT_FORMAT);
+if ("unknown" in statuslineFormat) { throw new Error("default statusline format failed to parse"); }
+const statuslineText = renderSegments(statuslineFormat.segments, { summary: buildMiniSummary(loop), inputMode: "stdin_payload", payload: null, nowMs: 0 });
 
 const banner = (t: string) => `\n===== ${t} =====\n`;
 process.stdout.write(banner("COMPARE (clean vs loop, side-by-side)") + compareText + "\n");

--- a/specs/SPEC-0062-statusline-segments.md
+++ b/specs/SPEC-0062-statusline-segments.md
@@ -1,0 +1,182 @@
+---
+id: SPEC-0062
+title: "Statusline v2 — brand prefix, quota default-on, opt-in segments with a labeled quota ETA"
+status: draft
+milestone: M5
+depends: [SPEC-0007, SPEC-0014, SPEC-0061]
+---
+
+# SPEC-0062: Statusline v2 — brand prefix, quota default-on, opt-in segments with a labeled quota ETA
+
+## Purpose
+
+The statusline is aireceipts' most-seen surface, and it currently spends its first
+segment naming the host (`[Claude Code]`) inside the host's own status bar while
+saying nothing about who produced the number. Meanwhile the stdin payload Claude Code
+already sends carries official rate-limit state (`rate_limits.*.used_percentage`,
+`resets_at` — SPEC-0014 spike) that subscribers only see via a separate `--quota`
+call. This spec rebrands the prefix, folds one quota fact into the default line, and
+adds an opt-in `--format` segments engine whose segments include a clearly-labeled
+`≈` quota-exhaustion estimate. All four features maintainer-picked 2026-07-06.
+Serves **I2/I3** (every new segment is an official passthrough fact or labeled
+arithmetic on two observed readings — never a prediction dressed as a fact) and
+**I5** (default-line changes are deliberate and test-pinned). Staged build: R1/R2
+first (small, self-contained), R3/R4 second on the same spec.
+
+## Requirements
+
+- **R1 — Brand prefix.** The default line's prefix becomes `[aireceipts]` when the
+  session came from the stdin payload (the host is Claude Code by construction — its
+  name is redundant in its own status bar). In disk-fallback mode the agent label
+  still matters (the newest session may be Codex/Gemini/etc.), so the prefix renders
+  `[aireceipts · <agentLabel>]`. `renderMiniSummary`'s 6-line surface is untouched
+  (test-pinned).
+- **R2 — Quota default-on.** When the stdin payload carries a usable
+  `rate_limits.five_hour.used_percentage` (the same `isUsablePercentage` guard
+  `src/cli/quota.ts:20` applies), the default line appends ` · 5h <pct>%`
+  (integer-rounded passthrough; the 7d window stays off the default line — one quota
+  fact at default width). Absent/malformed payload fields → segment omitted,
+  byte-identical to SPEC-0061's tail (SPEC-0014 R4 semantics; never a guess).
+- **R3 — `--format` segments engine.** `aireceipts statusline --format "<spec>"`
+  renders a `·`-joined line from comma-separated segment names (whitespace around
+  commas ignored; duplicates render twice — the format is literal). New value-flag
+  plumbing in `src/cli/options.ts` (no `--format` option exists today — building the
+  seam is part of this spec, same pattern as existing value flags). An unknown or
+  empty segment name fails: exit 1, the valid segment list on stderr, nothing on
+  stdout (fail-fast — a typo'd format must not silently render a partial line).
+  Segments — exactly the picked set, nothing speculative:
+  `brand, cost, tokens, waste, quota5h, quota7d, quotaEta`.
+  `cost`/`tokens`/`waste` reuse the SPEC-0007/0061 values byte-for-byte;
+  `quota5h`/`quota7d` are R2's passthrough facts (7d available here even though the
+  default omits it). Stdin-only segments (`quota*`) omit themselves in disk-fallback
+  mode. The default line ≡ `brand, cost, tokens, waste, quota5h` — one renderer, the
+  default is just a format (no duplicated truths).
+- **R4 — Quota ETA, labeled arithmetic.** `quotaEta` renders
+  `≈ 5h cap <UTC HH:MM>` by straight-line interpolation between exactly two observed
+  `(observedAtMs, used_percentage)` readings: the current invocation's and the
+  previous one persisted in `~/.aireceipts/quota-window.json`. State-file contract:
+  write is atomic (temp file + rename, the repo's existing pattern), any unreadable/
+  unparseable/schema-invalid state is discarded and rewritten (self-healing, exit 0),
+  and a lost race between concurrent invocations is harmless (last writer wins; the
+  file is a cache of one reading, never a ledger). The segment renders only when ALL
+  hold, each decidable from the two readings + payload alone: same window
+  (`resets_at` identical), rising usage (`pct2 > pct1`), readings ≥ 60s apart (kills
+  near-zero-denominator noise), the prior reading is not in the future (clock-skew
+  guard), and the projected crossing lands before `resets_at`. Otherwise the segment
+  is omitted entirely — an ETA after reset is meaningless; flat/falling usage
+  projects nothing. The `≈` label is mandatory; never on the default line; opt-in
+  via `--format` only.
+- **R5 — Parity, latency, telemetry, docs.** All segments obey I2 (`cost` omits
+  itself on an unpriced session, never zero-fills). Latency: the existing 200ms
+  in-process budget test (`test/cli/statusline.test.ts:194` — model build + rollup)
+  gains a variant that also runs quota parsing and the R4 state read/write; the
+  budget is that in-process pipeline, not wall-clock process spawn. Telemetry:
+  `integration_surface_rendered` gains a `customFormat` boolean (strict schema,
+  fixtures, and `docs/telemetry.md` updated together — the SPEC-0043 pattern);
+  `docs/statusline.md` documents every segment and the ETA's honesty rules in the
+  same PR.
+
+## Scenarios
+
+- **Given** a stdin invocation with quota data, **When** the default line renders,
+  **Then** it reads `[aireceipts] $12.40 · 1,012k tok · 5h 23%` (waste segment when
+  fired).
+- **Given** `--format "brand,quotaEta"` with two same-window rising readings 5m
+  apart, **When** the line renders, **Then** the ETA segment carries the `≈` label
+  and a UTC time before the window's `resets_at`.
+- **Given** a first-ever invocation (no state file), **When** `quotaEta` is
+  requested, **Then** the segment is omitted and the rest of the format renders.
+- **Given** `--format "brand,bogus"`, **When** the command runs, **Then** exit 1
+  with the valid segment list on stderr and empty stdout.
+
+## Non-goals
+
+- **Colors/ANSI, powerline glyphs, themes, width contracts** — the host owns
+  presentation; plain `·`-joined text (SPEC-0007's constraint stands).
+- **Segments beyond the picked set** (cache %, model id, reset time, `week`/budget) —
+  each is either speculative UX with no named consumer or a per-invocation corpus
+  scan; propose separately with a consumer attached.
+- **A quota history beyond two readings** — one prior reading bounds the state file
+  and keeps the arithmetic explainable ("straight line between two observations");
+  curve-fitting is prediction territory (I3).
+- **`--quota` command changes** — it stays the verbose passthrough surface.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 stdin brand | stdin payload session | line starts `[aireceipts] ` |
+| R1 disk fallback | no payload, newest is codex | line starts `[aireceipts · Codex] ` |
+| R1 mini untouched | 6-line mini render before/after | byte-identical |
+| R2 quota on | payload with `five_hour.used_percentage: 23.5` | ` · 5h 23%` appended |
+| R2 quota absent/malformed | payload without/with out-of-range rate_limits | tail byte-identical to SPEC-0061's line |
+| R3 format render | `--format "cost,tokens"` | exactly those segments, `·`-joined |
+| R3 whitespace + duplicate | `--format " brand , brand "` | two brand segments; whitespace ignored |
+| R3 unknown/empty segment | `--format "bogus"` / `--format ""` | exit 1, stderr lists valid segments, stdout empty |
+| R3 default ≡ format | default vs `--format "brand,cost,tokens,waste,quota5h"` | byte-identical output |
+| R3 waste segment | session with a fired waste line | `⚠` segment renders in a custom format |
+| R3 quota7d | payload with both windows, `--format "quota7d"` | `7d <pct>%` renders |
+| R3 disk-fallback quota | no payload, `--format "brand,quota5h"` | quota segment omitted, brand renders |
+| R4 eta happy path | two same-window readings, rising, 5m apart | `≈ 5h cap <UTC HH:MM>`, time < resets_at |
+| R4 eta cold start | no state file | segment omitted, no error |
+| R4 eta window rollover | `resets_at` differs between readings | segment omitted, state replaced |
+| R4 eta falling/flat usage | second reading ≤ first | segment omitted |
+| R4 eta near-zero gap | readings 5s apart | segment omitted (60s guard) |
+| R4 eta clock skew | prior reading timestamped in the future | segment omitted, state replaced |
+| R4 eta corrupt state | state file is garbage | segment omitted, file rewritten, exit 0 |
+| R4 eta post-reset projection | crossing lands after resets_at | segment omitted |
+| R5 I2 | unpriced session with `--format "cost,tokens"` | no `$` bytes; tokens render |
+| R5 latency | children fixture + quota payload + state file, full pipeline | within the 200ms in-process budget |
+| R5 telemetry | default vs `--format` run | `customFormat` false/true, strict schema passes |
+
+## Success criteria
+
+- [ ] R1–R5 implemented (staged: R1/R2 may land first); statusline tests updated
+      (no loosened assertions) plus the R4 state-file battery.
+- [ ] `docs/statusline.md` segment reference + ETA honesty note; `docs/telemetry.md`
+      `customFormat` row — same PR as the code they describe.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`,
+      `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
+      `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked
+      (`echo $?`).
+
+## Validation
+
+*2026-07-06 — S1 self-audit, S2 Codex (read-only sandbox), S3 worth gate, S4 lint.*
+
+- **S1:** every rendered value is an official payload passthrough, an existing
+  SPEC-0007/0061 value, or two-point interpolation with a mandatory `≈` label and
+  omission-on-ambiguity guards — nothing unmeasurable; I2 preserved by cost-segment
+  omission; I6 untouched (facts, no rankings).
+- **S2 (Codex) — accepted:** no `--format` plumbing exists (`src/cli/options.ts`) →
+  spec now names building the value-flag seam as in-scope; missing matrix rows
+  (tokens/waste/quota7d, whitespace, duplicates, empty format, malformed payload,
+  disk-fallback omission, mini-untouched) → added; state-file contract
+  underspecified → atomic-rename, self-healing, last-writer-wins race semantics
+  specified with a test battery; near-zero denominator + clock skew undecidable →
+  60s-gap and future-timestamp guards added; latency claim overbroad → scoped to
+  the in-process pipeline the existing 200ms test measures; `resets <HH:MM>`
+  date-ambiguous → the `quotaReset` segment was cut entirely; scope creep
+  (`cache`/`model`/`quotaReset`) → cut to the picked set.
+- **S2 — noted, overridden by maintainer selection:** Codex recommends cutting R4
+  (quotaEta) as the weakest requirement and deferring R3 as over-engineering
+  ("smallest valuable change is R1+R2"). Both were explicitly picked by the
+  maintainer (2026-07-06 interactive session); the staged-build note (R1/R2 first)
+  adopts the risk-ordering half of the recommendation while keeping the picked
+  scope. If R4's guards prove noisy in practice, the segment's omission-first
+  design means it degrades to silence, not wrong numbers.
+- **S3 — worth:** *Who/how often:* the maintainer (subscriber, statusline always on)
+  plus every subscriber who installs `statusline` — the quota question ("how close am
+  I to the cap?") recurs every working session; the branding question is a
+  GTM-surface fact (every screenshot of the status bar currently advertises nothing).
+  *Recurring:* structurally, per session. *Do-nothing:* the default line keeps
+  spending its prefix on redundant host naming, and quota stays a separate command
+  nobody discovers. *Smaller fix:* R1+R2 alone — acknowledged as the core; kept as
+  the first build stage. *Steelman the cut:* segments/ETA serve power users only and
+  add a state file; countered by opt-in-only placement (never on the default line)
+  and omission-first honesty. *Kill criterion:* if the R5 latency variant cannot
+  hold 200ms, or R4's guards omit the segment in >90% of real invocations (making it
+  dead weight), the corresponding stage is reworked or tombstoned before ship.
+  **Verdict: build now, staged (R1/R2 → R3/R4).**
+- **S4:** `node scripts/spec-lint.mjs` — pass.

--- a/specs/SPEC-0062-statusline-segments.md
+++ b/specs/SPEC-0062-statusline-segments.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0062
 title: "Statusline v2 — brand prefix, quota default-on, opt-in segments with a labeled quota ETA"
-status: approved # maintainer button 1, 2026-07-06 (interactive session)
+status: building # PR open; shipped flips on merge
 milestone: M5
 depends: [SPEC-0007, SPEC-0014, SPEC-0061]
 ---
@@ -48,8 +48,11 @@ first (small, self-contained), R3/R4 second on the same spec.
   `brand, cost, tokens, waste, quota5h, quota7d, quotaEta`.
   `cost`/`tokens`/`waste` reuse the SPEC-0007/0061 values byte-for-byte;
   `quota5h`/`quota7d` are R2's passthrough facts (7d available here even though the
-  default omits it). Stdin-only segments (`quota*`) omit themselves in disk-fallback
-  mode. The default line ≡ `brand, cost, tokens, waste, quota5h` — one renderer, the
+  default omits it). Quota segments are payload-derived, not
+  session-derived: they render whenever the stdin payload carries usable
+  fields — including when the payload's `transcript_path` fails to load and
+  the SESSION falls back to disk (the reading is official either way) — and
+  omit themselves only when no payload arrived (true R3b disk fallback). The default line ≡ `brand, cost, tokens, waste, quota5h` — one renderer, the
   default is just a format (no duplicated truths).
 - **R4 — Quota ETA, labeled arithmetic.** `quotaEta` renders
   `≈ 5h cap <UTC HH:MM>` by straight-line interpolation between exactly two observed
@@ -117,6 +120,7 @@ first (small, self-contained), R3/R4 second on the same spec.
 | R3 waste segment | session with a fired waste line | `⚠` segment renders in a custom format |
 | R3 quota7d | payload with both windows, `--format "quota7d"` | `7d <pct>%` renders |
 | R3 disk-fallback quota | no payload, `--format "brand,quota5h"` | quota segment omitted, brand renders |
+| R3 mixed mode | payload with quota but dead `transcript_path` | brand renders the fallback form; quota still renders (payload-derived) |
 | R4 eta happy path | two same-window readings, rising, 5m apart | `≈ 5h cap <UTC HH:MM>`, time < resets_at |
 | R4 eta cold start | no state file | segment omitted, no error |
 | R4 eta window rollover | `resets_at` differs between readings | segment omitted, state replaced |
@@ -131,11 +135,11 @@ first (small, self-contained), R3/R4 second on the same spec.
 
 ## Success criteria
 
-- [ ] R1–R5 implemented (staged: R1/R2 may land first); statusline tests updated
+- [x] R1–R5 implemented (staged: R1/R2 may land first); statusline tests updated
       (no loosened assertions) plus the R4 state-file battery.
-- [ ] `docs/statusline.md` segment reference + ETA honesty note; `docs/telemetry.md`
+- [x] `docs/statusline.md` segment reference + ETA honesty note; `docs/telemetry.md`
       `customFormat` row — same PR as the code they describe.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`,
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked

--- a/specs/SPEC-0062-statusline-segments.md
+++ b/specs/SPEC-0062-statusline-segments.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0062
 title: "Statusline v2 — brand prefix, quota default-on, opt-in segments with a labeled quota ETA"
-status: draft
+status: approved # maintainer button 1, 2026-07-06 (interactive session)
 milestone: M5
 depends: [SPEC-0007, SPEC-0014, SPEC-0061]
 ---

--- a/src/cli/commands/statusline.ts
+++ b/src/cli/commands/statusline.ts
@@ -2,12 +2,16 @@
 // (SPEC-0007). priority 90, matches the `statusline` positional subcommand. The
 // stdin/disk resolution seams are exported (and re-exported from
 // `src/cli/index.js`) so the existing statusline integration tests keep their
-// injectable listSessions/loadSession/stdin entry points.
+// injectable listSessions/loadSession/stdin entry points. SPEC-0062: the line
+// renders through the segments engine — the default line IS the format
+// `brand,cost,tokens,waste,quota5h`, and `--format` selects any other segment
+// list (unknown names fail fast, exit 1).
 import { listSessions, loadById, loadSession } from "../../index.js";
 import type { Session, SessionSummary } from "../../parse/types.js";
 import { buildReceiptModel } from "../../receipt/model.js";
 import { attachSubagentRollup } from "../../receipt/subagents.js";
-import { renderStatusline } from "../../receipt/mini.js";
+import { buildMiniSummary } from "../../receipt/mini.js";
+import { DEFAULT_FORMAT, parseFormat, renderSegments, SEGMENT_NAMES } from "../statuslineSegments.js";
 import type { CommandContext, CommandDef } from "../types.js";
 import type { InputModeValue, ResultValue } from "../../telemetry/schemas.js";
 
@@ -15,6 +19,8 @@ export interface StatuslineTelemetryInfo {
   inputMode: InputModeValue;
   payloadValid: boolean;
   result: ResultValue;
+  /** SPEC-0062 R5 — the invocation carried an explicit `--format` (boolean, never the format string). */
+  customFormat: boolean;
 }
 
 /**
@@ -32,22 +38,26 @@ export async function readStdin(stream: NodeJS.ReadStream): Promise<string> {
   return Buffer.concat(chunks).toString("utf8");
 }
 
+/** The parsed stdin payload, or `null` for absent/malformed input — never throws. */
+export function parsePayload(raw: string): unknown {
+  if (!raw.trim()) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
 /**
- * R3a: parse Claude Code's statusLine stdin payload (`{"transcript_path": "...", ...}`)
- * and load the referenced session directly — no session-list scan needed.
+ * R3a: load the session referenced by Claude Code's statusLine stdin payload
+ * (`{"transcript_path": "...", ...}`) directly — no session-list scan needed.
  * Returns `null` on any malformed/absent payload so the caller can fall back to
  * R3b disk mode; never throws.
  */
 export async function loadFromStdinPayload(raw: string): Promise<Session | null> {
-  if (!raw.trim()) {
-    return null;
-  }
-  let payload: unknown;
-  try {
-    payload = JSON.parse(raw);
-  } catch {
-    return null;
-  }
+  const payload = parsePayload(raw);
   const transcriptPath = (payload as { transcript_path?: unknown } | null)?.transcript_path;
   if (typeof transcriptPath !== "string" || !transcriptPath) {
     return null;
@@ -72,11 +82,23 @@ export async function loadFromDisk(
   return loadSessionFn(summary);
 }
 
+export interface RunStatuslineOptions {
+  /** SPEC-0062 R3 — explicit `--format` segment spec; absent → `DEFAULT_FORMAT`. */
+  format?: string;
+  /** Error sink for the fail-fast unknown-segment path; defaults to `process.stderr`. */
+  writeError?: (s: string) => void;
+  /** Clock + state-file seams for the `quotaEta` segment (tests). */
+  nowMs?: number;
+  quotaStatePath?: string;
+}
+
 /**
- * R3/R4: statusline one-liner. stdin mode first, then disk fallback, then a
- * neutral no-session placeholder (never an error, always exit 0). `write` is the
- * output seam — the command passes `ctx.stdout` so output routes through the
- * context (R3); it defaults to `process.stdout` for the direct-call tests.
+ * R3/R4 (SPEC-0007) + SPEC-0062: stdin mode first, then disk fallback, then a
+ * neutral no-session placeholder (never an error, always exit 0 — except a
+ * malformed `--format`, which is a caller mistake and fails fast with exit 1,
+ * segment list on stderr, nothing on stdout). `write` is the output seam — the
+ * command passes `ctx.stdout` so output routes through the context; it defaults
+ * to `process.stdout` for the direct-call tests.
  */
 export async function runStatusline(
   stdin: NodeJS.ReadStream = process.stdin,
@@ -85,8 +107,21 @@ export async function runStatusline(
     process.stdout.write(s);
   },
   record?: (info: StatuslineTelemetryInfo) => void | Promise<void>,
+  opts: RunStatuslineOptions = {},
 ): Promise<number> {
+  const customFormat = opts.format !== undefined;
+  const parsed = parseFormat(opts.format ?? DEFAULT_FORMAT);
+  if ("unknown" in parsed) {
+    const writeError =
+      opts.writeError ??
+      ((s: string) => {
+        process.stderr.write(s);
+      });
+    writeError(`unknown statusline segment "${parsed.unknown}" (valid: ${SEGMENT_NAMES.join(", ")})\n`);
+    return 1;
+  }
   const raw = await readStdin(stdin);
+  const payload = parsePayload(raw);
   let inputMode: InputModeValue = raw.trim() ? "stdin_payload" : "none";
   let payloadValid = false;
   let session = await loadFromStdinPayload(raw);
@@ -101,19 +136,30 @@ export async function runStatusline(
   }
   if (!session) {
     write("aireceipts: no sessions detected\n");
-    await record?.({ inputMode, payloadValid, result: "no_data" });
+    await record?.({ inputMode, payloadValid, result: "no_data", customFormat });
     return 0;
   }
   // SPEC-0061 R3 — the one-liner covers parent + subagents (no children → zero extra transcript reads).
   const model = await attachSubagentRollup(await buildReceiptModel(session), session.filePath);
-  write(`${renderStatusline(model)}\n`);
-  await record?.({ inputMode, payloadValid, result: "success" });
+  const line = renderSegments(parsed.segments, {
+    summary: buildMiniSummary(model),
+    inputMode: payloadValid ? "stdin_payload" : "disk_fallback",
+    payload,
+    nowMs: opts.nowMs ?? Date.now(),
+    ...(opts.quotaStatePath !== undefined ? { quotaStatePath: opts.quotaStatePath } : {}),
+  });
+  write(`${line}\n`);
+  await record?.({ inputMode, payloadValid, result: "success", customFormat });
   return 0;
 }
 
 function run(ctx: CommandContext): Promise<number> {
-  return runStatusline(ctx.stdin, loadFromDisk, (s) => ctx.stdout.write(s), (info) =>
-    ctx.telemetry.recordIntegrationSurfaceRendered({ integration: "statusline", ...info }),
+  return runStatusline(
+    ctx.stdin,
+    loadFromDisk,
+    (s) => ctx.stdout.write(s),
+    (info) => ctx.telemetry.recordIntegrationSurfaceRendered({ integration: "statusline", ...info }),
+    { format: ctx.options.format, writeError: (s) => ctx.stderr.write(s) },
   );
 }
 
@@ -124,6 +170,6 @@ export const command: CommandDef = {
   run,
   help: {
     order: 180,
-    lines: ["  aireceipts statusline                 one-line summary for Claude Code's statusLine"],
+    lines: ["  aireceipts statusline [--format <s>]  one-line summary for Claude Code's statusLine"],
   },
 };

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -58,6 +58,8 @@ export interface CliOptions {
   readonly demo: boolean;
   /** SPEC-0054 R4: render the opt-in DETAILS section (classic template only). */
   readonly details: boolean;
+  /** SPEC-0062 R3: `aireceipts statusline --format "<segments>"` — comma-separated segment names. */
+  readonly format?: string;
 }
 
 /** Value-consuming flags: `--theme dark`, `-o out.svg`. Anything else is a boolean flag or positional. */
@@ -91,6 +93,7 @@ export function parseOptions(argv: string[]): CliOptions {
   let share = false;
   let limit: number | undefined;
   let outDir: string | undefined;
+  let format: string | undefined;
   const positional: string[] = [];
 
   for (let i = 0; i < argv.length; i++) {
@@ -151,6 +154,12 @@ export function parseOptions(argv: string[]): CliOptions {
       outDir = argv[++i];
     } else if (arg.startsWith("--out=")) {
       outDir = arg.slice("--out=".length);
+    } else if (arg === "--format") {
+      // A bare `--format` (no value) must fail fast downstream, not silently
+      // fall back to the default line (SPEC-0062 R3) — normalize to "".
+      format = argv[++i] ?? "";
+    } else if (arg.startsWith("--format=")) {
+      format = arg.slice("--format=".length);
     } else if (arg === "--svg") {
       svg = true;
     } else if (arg === "--png") {
@@ -203,5 +212,6 @@ export function parseOptions(argv: string[]): CliOptions {
     version,
     demo,
     details,
+    format,
   };
 }

--- a/src/cli/quotaWindow.ts
+++ b/src/cli/quotaWindow.ts
@@ -1,0 +1,99 @@
+// SPEC-0062 R4 — the quota-window state file behind the `quotaEta` segment.
+// One prior reading, `~/.aireceipts/quota-window.json`: a cache, never a
+// ledger. Atomic write (temp + rename), self-healing on any unreadable/
+// invalid content, last-writer-wins under concurrent invocations. The ETA is
+// straight-line interpolation between exactly two observed readings, and it
+// renders ONLY when every guard holds — ambiguity is answered with omission,
+// never a number (I3).
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+/** One observed reading of the 5h window, as Claude Code's payload states it. */
+export interface QuotaReading {
+  observedAtMs: number;
+  usedPercentage: number;
+  /** `rate_limits.five_hour.resets_at`, Unix epoch seconds. */
+  resetsAt: number;
+}
+
+/** Minimum spacing between readings for the interpolation to mean anything. */
+export const MIN_READING_GAP_MS = 60_000;
+
+export function quotaWindowPath(homeOverride?: string): string {
+  return join(homeOverride ?? process.env.AIRECEIPTS_HOME ?? homedir(), ".aireceipts", "quota-window.json");
+}
+
+function isReading(value: unknown): value is QuotaReading {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.observedAtMs === "number" &&
+    Number.isFinite(v.observedAtMs) &&
+    typeof v.usedPercentage === "number" &&
+    Number.isFinite(v.usedPercentage) &&
+    v.usedPercentage >= 0 &&
+    v.usedPercentage <= 100 &&
+    typeof v.resetsAt === "number" &&
+    Number.isFinite(v.resetsAt)
+  );
+}
+
+/** Read the prior reading; any unreadable/invalid state is `null` (self-healing — the next write replaces it). */
+export function readPriorReading(filePath: string): QuotaReading | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(filePath, "utf8"));
+    return isReading(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the current reading atomically (temp + rename); failures are swallowed — the segment simply stays cold. */
+export function writeReading(filePath: string, reading: QuotaReading): void {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true });
+    const tmp = `${filePath}.${process.pid}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(reading)}\n`);
+    renameSync(tmp, filePath);
+  } catch {
+    // Best-effort cache: an unwritable state dir must never break the statusline.
+  }
+}
+
+/**
+ * The projected cap-crossing time, or `null` when any guard fails. Guards, each
+ * decidable from the two readings alone: same window (`resetsAt` identical),
+ * rising usage, readings ≥ 60s apart, the prior reading not in the future
+ * (clock skew), and the straight-line crossing landing before the window
+ * resets (an ETA after reset is meaningless).
+ */
+export function projectCapCrossingMs(prior: QuotaReading, current: QuotaReading): number | null {
+  if (prior.resetsAt !== current.resetsAt) {
+    return null;
+  }
+  if (prior.observedAtMs > current.observedAtMs) {
+    return null;
+  }
+  const gapMs = current.observedAtMs - prior.observedAtMs;
+  if (gapMs < MIN_READING_GAP_MS) {
+    return null;
+  }
+  if (current.usedPercentage <= prior.usedPercentage) {
+    return null;
+  }
+  const ratePerMs = (current.usedPercentage - prior.usedPercentage) / gapMs;
+  const crossingMs = current.observedAtMs + (100 - current.usedPercentage) / ratePerMs;
+  if (crossingMs >= current.resetsAt * 1000) {
+    return null;
+  }
+  // Garbage-payload backstop: a finite-but-absurd `resets_at` could admit a
+  // crossing outside `Date`'s representable range — omit rather than render
+  // `NaN:NaN` (max ECMAScript time value: ±8.64e15 ms).
+  if (!Number.isFinite(crossingMs) || Math.abs(crossingMs) > 8.64e15) {
+    return null;
+  }
+  return crossingMs;
+}

--- a/src/cli/statuslineSegments.ts
+++ b/src/cli/statuslineSegments.ts
@@ -1,0 +1,149 @@
+// SPEC-0062 — the statusline segments engine. One renderer for the default
+// line and `--format`: the default IS the format `brand,cost,tokens,waste,quota5h`
+// (no duplicated truths). Every segment is an official payload passthrough, an
+// existing SPEC-0007/0061 value, or the R4 labeled `≈` interpolation — a segment
+// with nothing honest to say returns `null` and is omitted, never zero-filled
+// (I2/I3). Unknown segment names fail fast: a typo'd format must not silently
+// render a partial line.
+import type { MiniSummary } from "../receipt/mini.js";
+import { statuslineWasteFlag } from "../receipt/mini.js";
+import { formatTokensK, formatUsd } from "../receipt/format.js";
+import {
+  projectCapCrossingMs,
+  quotaWindowPath,
+  readPriorReading,
+  writeReading,
+  type QuotaReading,
+} from "./quotaWindow.js";
+
+export const DEFAULT_FORMAT = "brand,cost,tokens,waste,quota5h";
+
+export const SEGMENT_NAMES = ["brand", "cost", "tokens", "waste", "quota5h", "quota7d", "quotaEta"] as const;
+export type SegmentName = (typeof SEGMENT_NAMES)[number];
+
+export interface SegmentContext {
+  summary: MiniSummary;
+  /** stdin payload mode vs. R3b disk fallback — drives the brand form and quota availability. */
+  inputMode: "stdin_payload" | "disk_fallback";
+  /** The parsed statusline stdin payload (unknown shape — every read is guarded). */
+  payload: unknown;
+  nowMs: number;
+  /** State-file location override for tests; default resolves under `~/.aireceipts`. */
+  quotaStatePath?: string;
+}
+
+/** Parse a format spec into segment names. Whitespace around commas is ignored; duplicates render twice (the format is literal). Returns the unknown/empty name on failure. */
+export function parseFormat(spec: string): { segments: SegmentName[] } | { unknown: string } {
+  const names = spec.split(",").map((s) => s.trim());
+  const segments: SegmentName[] = [];
+  for (const name of names) {
+    if (!(SEGMENT_NAMES as readonly string[]).includes(name)) {
+      return { unknown: name };
+    }
+    segments.push(name as SegmentName);
+  }
+  return { segments };
+}
+
+/** The official per-window payload fields, guarded exactly like `renderQuotaLines` (SPEC-0014 R4: absent/out-of-range → nothing). */
+function quotaWindow(payload: unknown, key: "five_hour" | "seven_day"): { usedPercentage: number; resetsAt: number | null } | null {
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+  const rateLimits = (payload as Record<string, unknown>).rate_limits;
+  if (typeof rateLimits !== "object" || rateLimits === null) {
+    return null;
+  }
+  const window = (rateLimits as Record<string, unknown>)[key];
+  if (typeof window !== "object" || window === null) {
+    return null;
+  }
+  const pct = (window as Record<string, unknown>).used_percentage;
+  if (typeof pct !== "number" || !Number.isFinite(pct) || pct < 0 || pct > 100) {
+    return null;
+  }
+  const resets = (window as Record<string, unknown>).resets_at;
+  return {
+    usedPercentage: pct,
+    resetsAt: typeof resets === "number" && Number.isFinite(resets) ? resets : null,
+  };
+}
+
+function utcHhMm(ms: number): string {
+  const d = new Date(ms);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())} UTC`;
+}
+
+/**
+ * R4 — the `≈` ETA segment: reads the prior reading, persists the current one
+ * (atomic, last-writer-wins), and projects only when every guard holds.
+ */
+function quotaEtaSegment(ctx: SegmentContext): string | null {
+  const window = quotaWindow(ctx.payload, "five_hour");
+  if (!window || window.resetsAt === null) {
+    return null;
+  }
+  const current: QuotaReading = {
+    observedAtMs: ctx.nowMs,
+    usedPercentage: window.usedPercentage,
+    resetsAt: window.resetsAt,
+  };
+  const statePath = ctx.quotaStatePath ?? quotaWindowPath();
+  const prior = readPriorReading(statePath);
+  writeReading(statePath, current);
+  if (!prior) {
+    return null;
+  }
+  const crossingMs = projectCapCrossingMs(prior, current);
+  return crossingMs === null ? null : `≈ 5h cap ${utcHhMm(crossingMs)}`;
+}
+
+const SEGMENTS: Record<SegmentName, (ctx: SegmentContext) => string | null> = {
+  // R1 — inside Claude Code's own status bar the host name is redundant; in
+  // disk-fallback mode the newest session may be another agent's, so say whose.
+  brand: (ctx) => (ctx.inputMode === "stdin_payload" ? "[aireceipts]" : `[aireceipts · ${ctx.summary.agentLabel}]`),
+  cost: (ctx) =>
+    !ctx.summary.unpriceable && ctx.summary.totalUsd !== null ? `$${formatUsd(ctx.summary.totalUsd)}` : null,
+  tokens: (ctx) => formatTokensK(ctx.summary.totalTokens),
+  waste: (ctx) => (ctx.summary.topWaste ? statuslineWasteFlag(ctx.summary.topWaste) : null),
+  quota5h: (ctx) => {
+    const w = quotaWindow(ctx.payload, "five_hour");
+    return w ? `5h ${Math.round(w.usedPercentage)}%` : null;
+  },
+  quota7d: (ctx) => {
+    const w = quotaWindow(ctx.payload, "seven_day");
+    return w ? `7d ${Math.round(w.usedPercentage)}%` : null;
+  },
+  quotaEta: quotaEtaSegment,
+};
+
+/**
+ * Render a segment list: `null` segments are omitted; a leading `brand` is a
+ * prefix (space-joined, SPEC-0007's shape), everything else `·`-joined.
+ * Each segment is evaluated at most once per render (memoized by name), so a
+ * duplicated segment renders the same text twice — R3's "the format is
+ * literal" — and the stateful `quotaEta` reads/writes its state file exactly
+ * once per invocation regardless of how many times the format names it.
+ */
+export function renderSegments(segments: SegmentName[], ctx: SegmentContext): string {
+  const memo = new Map<SegmentName, string | null>();
+  const rendered: { name: SegmentName; text: string }[] = [];
+  for (const name of segments) {
+    if (!memo.has(name)) {
+      memo.set(name, SEGMENTS[name](ctx));
+    }
+    const text = memo.get(name) ?? null;
+    if (text !== null) {
+      rendered.push({ name, text });
+    }
+  }
+  if (rendered.length === 0) {
+    return "";
+  }
+  if (segments[0] === "brand" && rendered[0]?.name === "brand") {
+    const rest = rendered.slice(1).map((r) => r.text);
+    return rest.length > 0 ? `${rendered[0].text} ${rest.join(" · ")}` : rendered[0].text;
+  }
+  return rendered.map((r) => r.text).join(" · ");
+}

--- a/src/receipt/mini.ts
+++ b/src/receipt/mini.ts
@@ -6,7 +6,7 @@
 // renderer emits exactly 6 lines of plain text (no ANSI — the hook/statusline
 // context is not guaranteed to interpret it), deterministic and golden-gated
 // (I5), obeying the same $-honesty rules as the full receipt (I2).
-import { formatDuration, formatInt, formatTokensK, formatUsd } from "./format.js";
+import { formatDuration, formatInt, formatUsd } from "./format.js";
 import type { ReceiptModel, ToolRow, WasteLine } from "./model.js";
 
 export interface MiniTopTool {
@@ -145,9 +145,12 @@ export function renderMiniSummary(s: MiniSummary): string {
  * Terse, factual waste flag for the one-line statusline (I6: never a
  * good/bad framing, just what fired). Deliberately shorter than the 6-line
  * receipt's `wasteLine` — no `$`/token value, since the total is already on
- * the same line.
+ * the same line. SPEC-0062 moved the one-line renderer itself to the segments
+ * engine (`src/cli/statuslineSegments.ts`), which composes this flag; the
+ * `waste` segment's copy is still pinned here so both surfaces share one
+ * truth.
  */
-function statuslineWasteFlag(waste: WasteLine): string {
+export function statuslineWasteFlag(waste: WasteLine): string {
   if (waste.kind === "stuck-loop") {
     return `⚠ ${waste.tool} loop ×${waste.runLength}`;
   }
@@ -155,28 +158,4 @@ function statuslineWasteFlag(waste: WasteLine): string {
     return `⚠ context thrash ×${waste.compactionCount}`;
   }
   return `⚠ ${formatInt(waste.eligibleTurnCount)} trivial spans`;
-}
-
-/**
- * Render `model` as SPEC-0007's R1 one-line statusline string:
- * `[agent] $X.XX · Nk tok · <waste-flag>` when priced,
- * `[agent] Nk tok · <waste-flag>` when unpriced (I2). The waste-flag segment
- * is omitted entirely when no waste fired (I6: absence of a flag, not a
- * "no waste detected" statement, is the neutral-good signal).
- */
-export function renderStatusline(model: ReceiptModel): string {
-  return renderStatuslineSummary(buildMiniSummary(model));
-}
-
-/** Render a pre-built `MiniSummary` as the R1 one-liner. */
-export function renderStatuslineSummary(s: MiniSummary): string {
-  const segments = [`[${s.agentLabel}]`];
-  if (!s.unpriceable && s.totalUsd !== null) {
-    segments.push(`$${formatUsd(s.totalUsd)}`);
-  }
-  segments.push(formatTokensK(s.totalTokens));
-  if (s.topWaste) {
-    segments.push(statuslineWasteFlag(s.topWaste));
-  }
-  return `${segments[0]} ${segments.slice(1).join(" · ")}`;
 }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -231,6 +231,8 @@ export interface RecordIntegrationSurfaceRenderedInput {
   inputMode: InputModeValue;
   payloadValid: boolean;
   result: ResultValue;
+  /** SPEC-0062 R5 — statusline only: an explicit `--format` was passed (boolean, never the format string). */
+  customFormat?: boolean;
 }
 
 export function recordIntegrationSurfaceRendered(input: RecordIntegrationSurfaceRenderedInput): void {

--- a/src/telemetry/schemas.ts
+++ b/src/telemetry/schemas.ts
@@ -250,6 +250,8 @@ export const integrationSurfaceRenderedPropertiesSchema = z
     inputMode: z.enum(INPUT_MODE_VALUES),
     payloadValid: z.boolean(),
     result: z.enum(RESULT_VALUES),
+    /** SPEC-0062 R5 — statusline only: the invocation carried an explicit `--format` (boolean, never the format string). */
+    customFormat: z.boolean().optional(),
   })
   .strict();
 export type IntegrationSurfaceRenderedProperties = z.infer<typeof integrationSurfaceRenderedPropertiesSchema>;

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -549,7 +549,7 @@ describe("built CLI e2e", () => {
 
     expect(result.code, result.stderr).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("[Claude Code]");
+    expect(result.stdout).toContain("[aireceipts]");
     expect(result.stdout).toContain("$0.18");
     expect(result.stdout).toContain("147k tok");
     expect(result.stdout.endsWith("\n")).toBe(true);

--- a/test/cli/statusline-segments.test.ts
+++ b/test/cli/statusline-segments.test.ts
@@ -1,0 +1,253 @@
+// SPEC-0062 R3/R4 test matrix — the `--format` segments engine and the
+// quota-window state file behind `quotaEta`. Pure-function tests against
+// constructed contexts, plus the state-file battery on a temp dir.
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { buildMiniSummary } from "../../src/receipt/mini.js";
+import type { ReceiptModel } from "../../src/receipt/model.js";
+import type { TokenUsage } from "../../src/parse/types.js";
+import {
+  DEFAULT_FORMAT,
+  parseFormat,
+  renderSegments,
+  SEGMENT_NAMES,
+  type SegmentContext,
+  type SegmentName,
+} from "../../src/cli/statuslineSegments.js";
+import {
+  MIN_READING_GAP_MS,
+  projectCapCrossingMs,
+  readPriorReading,
+  writeReading,
+  type QuotaReading,
+} from "../../src/cli/quotaWindow.js";
+import { runStatusline } from "../../src/cli/index.js";
+
+function usage(total: number): TokenUsage {
+  return { input: total, output: 0, cacheRead: 0, cacheCreation: 0, total };
+}
+
+function model(overrides: Partial<ReceiptModel> = {}): ReceiptModel {
+  return {
+    agentLabel: "Claude Code",
+    source: "claude-code",
+    sessionId: "s",
+    modelMix: [],
+    toolRows: [],
+    totalUsd: 0.5,
+    totalTokens: usage(1000),
+    sessionTotalTokens: usage(1000),
+    wasteLines: [],
+    caveats: [],
+    priceDelta: null,
+    methodology: "test",
+    priceRowsUsed: [],
+    unpriceable: false,
+    costLowerBoundCacheTier: false,
+    turnCount: 1,
+    toolCallCount: 0,
+    cacheReadAtInputRateUsd: null,
+    ...overrides,
+  };
+}
+
+function ctx(over: Partial<SegmentContext> = {}): SegmentContext {
+  return { summary: buildMiniSummary(model()), inputMode: "stdin_payload", payload: null, nowMs: 0, ...over };
+}
+
+function segs(spec: string): SegmentName[] {
+  const parsed = parseFormat(spec);
+  if ("unknown" in parsed) {
+    throw new Error(`unexpected parse failure: ${parsed.unknown}`);
+  }
+  return parsed.segments;
+}
+
+const WINDOW = { resets_at: 1_800_018_000 }; // epoch seconds
+const RESETS_AT_MS = WINDOW.resets_at * 1000;
+
+function quotaPayload(pct: number): unknown {
+  return { rate_limits: { five_hour: { used_percentage: pct, resets_at: WINDOW.resets_at } } };
+}
+
+describe("SPEC-0062 R3 — parseFormat", () => {
+  it("ignores whitespace around commas and keeps duplicates (the format is literal)", () => {
+    expect(segs(" brand , brand ,cost")).toEqual(["brand", "brand", "cost"]);
+  });
+
+  it("rejects unknown and empty segment names with the offending name", () => {
+    expect(parseFormat("brand,bogus")).toEqual({ unknown: "bogus" });
+    expect(parseFormat("")).toEqual({ unknown: "" });
+    expect(parseFormat("brand,,cost")).toEqual({ unknown: "" });
+  });
+});
+
+describe("SPEC-0062 R3 — renderSegments", () => {
+  it("renders exactly the requested segments, ·-joined", () => {
+    expect(renderSegments(segs("cost,tokens"), ctx())).toBe("$0.50 · 1k tok");
+  });
+
+  it("duplicate segments render twice", () => {
+    expect(renderSegments(segs("brand,brand"), ctx())).toBe("[aireceipts] [aireceipts]");
+  });
+
+  it("quota7d renders from the payload when requested explicitly", () => {
+    const payload = { rate_limits: { seven_day: { used_percentage: 41.2 } } };
+    expect(renderSegments(segs("quota7d"), ctx({ payload }))).toBe("7d 41%");
+  });
+
+  it("quota segments omit themselves in disk-fallback mode (stdin-only facts)", () => {
+    const line = renderSegments(segs("brand,quota5h"), ctx({ inputMode: "disk_fallback", payload: null }));
+    expect(line).toBe("[aireceipts · Claude Code]");
+  });
+
+  it("I2: cost omits itself on an unpriced session — no zero-fill, no $ bytes", () => {
+    const unpriced = ctx({ summary: buildMiniSummary(model({ totalUsd: null })) });
+    expect(renderSegments(segs("cost,tokens"), unpriced)).toBe("1k tok");
+  });
+
+  it("the default format constant matches the spec-pinned list", () => {
+    expect(DEFAULT_FORMAT).toBe("brand,cost,tokens,waste,quota5h");
+    expect(SEGMENT_NAMES).toContain("quotaEta");
+  });
+});
+
+describe("SPEC-0062 R3 — runStatusline fail-fast on a malformed format", () => {
+  it("unknown segment: exit 1, valid list on stderr, nothing on stdout", async () => {
+    const stdin = Readable.from([]) as unknown as NodeJS.ReadStream;
+    (stdin as unknown as { isTTY: boolean }).isTTY = true;
+    let out = "";
+    let err = "";
+    const code = await runStatusline(
+      stdin,
+      async () => null,
+      (s) => {
+        out += s;
+      },
+      undefined,
+      {
+        format: "brand,bogus",
+        writeError: (s) => {
+          err += s;
+        },
+      },
+    );
+    expect(code).toBe(1);
+    expect(out).toBe("");
+    expect(err).toContain('unknown statusline segment "bogus"');
+    for (const name of SEGMENT_NAMES) {
+      expect(err).toContain(name);
+    }
+  });
+});
+
+describe("SPEC-0062 R4 — quota-window state file", () => {
+  const dir = () => mkdtempSync(join(tmpdir(), "aireceipts-quota-"));
+
+  it("round-trips a reading atomically and self-heals from garbage", () => {
+    const file = join(dir(), "quota-window.json");
+    const reading: QuotaReading = { observedAtMs: 1000, usedPercentage: 10, resetsAt: WINDOW.resets_at };
+    writeReading(file, reading);
+    expect(readPriorReading(file)).toEqual(reading);
+    writeFileSync(file, "{not json");
+    expect(readPriorReading(file)).toBeNull();
+    writeReading(file, reading);
+    expect(readPriorReading(file)).toEqual(reading);
+  });
+
+  it("rejects schema-invalid state (missing/out-of-range fields)", () => {
+    const file = join(dir(), "quota-window.json");
+    writeFileSync(file, JSON.stringify({ observedAtMs: 1, usedPercentage: 130, resetsAt: 2 }));
+    expect(readPriorReading(file)).toBeNull();
+  });
+});
+
+describe("SPEC-0062 R4 — projectCapCrossingMs guards", () => {
+  const base: QuotaReading = { observedAtMs: 0, usedPercentage: 20, resetsAt: WINDOW.resets_at };
+
+  it("projects the straight-line crossing when every guard holds", () => {
+    // 20% → 30% over 5 minutes = 2%/min; 70% remaining → +35 min.
+    const current: QuotaReading = { ...base, observedAtMs: 300_000, usedPercentage: 30 };
+    expect(projectCapCrossingMs(base, current)).toBe(300_000 + 35 * 60_000);
+  });
+
+  it("omits across a window rollover (resets_at changed)", () => {
+    const current: QuotaReading = { observedAtMs: 300_000, usedPercentage: 30, resetsAt: WINDOW.resets_at + 18_000 };
+    expect(projectCapCrossingMs(base, current)).toBeNull();
+  });
+
+  it("omits on falling or flat usage", () => {
+    expect(projectCapCrossingMs(base, { ...base, observedAtMs: 300_000, usedPercentage: 20 })).toBeNull();
+    expect(projectCapCrossingMs(base, { ...base, observedAtMs: 300_000, usedPercentage: 15 })).toBeNull();
+  });
+
+  it("omits when readings are under the 60s gap (near-zero denominator)", () => {
+    expect(projectCapCrossingMs(base, { ...base, observedAtMs: MIN_READING_GAP_MS - 1, usedPercentage: 30 })).toBeNull();
+  });
+
+  it("omits when the prior reading is in the future (clock skew)", () => {
+    const future: QuotaReading = { ...base, observedAtMs: 900_000 };
+    expect(projectCapCrossingMs(future, { ...base, observedAtMs: 300_000, usedPercentage: 30 })).toBeNull();
+  });
+
+  it("omits an out-of-Date-range crossing instead of rendering NaN:NaN (garbage resets_at backstop)", () => {
+    // Crossing ≈ 6.4e16 ms: BEFORE the absurd reset (9e21 ms) so the post-reset
+    // guard passes, but beyond Date's ±8.64e15 range — only the backstop can omit it.
+    const prior: QuotaReading = { observedAtMs: 0, usedPercentage: 20, resetsAt: 9e18 };
+    const current: QuotaReading = { observedAtMs: 8e15, usedPercentage: 30, resetsAt: 9e18 };
+    expect(projectCapCrossingMs(prior, current)).toBeNull();
+  });
+
+  it("omits when the crossing would land after the window resets", () => {
+    // 0.1%/5min an hour before reset: the straight line crosses ~66h later, far past resets_at.
+    const prior: QuotaReading = { ...base, observedAtMs: RESETS_AT_MS - 3_600_000 };
+    const current: QuotaReading = { ...base, observedAtMs: RESETS_AT_MS - 3_300_000, usedPercentage: 20.1 };
+    expect(projectCapCrossingMs(prior, current)).toBeNull();
+  });
+});
+
+describe("SPEC-0062 R3 — duplicate stateful segments stay literal", () => {
+  it("quotaEta named twice renders identical text twice and touches state once", () => {
+    const file = join(mkdtempSync(join(tmpdir(), "aireceipts-quota-")), "quota-window.json");
+    // Seed a prior reading so the ETA actually renders.
+    writeReading(file, { observedAtMs: RESETS_AT_MS - 3_600_000, usedPercentage: 20, resetsAt: WINDOW.resets_at });
+    const line = renderSegments(segs("quotaEta,quotaEta"), ctx({ payload: quotaPayload(30), nowMs: RESETS_AT_MS - 3_300_000, quotaStatePath: file }));
+    const parts = line.split(" · ");
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toBe(parts[1]);
+    expect(parts[0]).toMatch(/^≈ 5h cap \d{2}:\d{2} UTC$/);
+    // State holds the CURRENT reading exactly once (a second evaluation would have overwritten it after reading it back).
+    expect(readPriorReading(file)).toMatchObject({ usedPercentage: 30 });
+  });
+});
+
+describe("SPEC-0062 R4 — quotaEta segment end-to-end", () => {
+  it("cold start: writes state, omits the segment; second reading renders the labeled ≈ ETA", () => {
+    const file = join(mkdtempSync(join(tmpdir(), "aireceipts-quota-")), "quota-window.json");
+    const first = renderSegments(segs("quotaEta"), ctx({ payload: quotaPayload(20), nowMs: RESETS_AT_MS - 3_600_000, quotaStatePath: file }));
+    expect(first).toBe("");
+    expect(readPriorReading(file)).not.toBeNull();
+    // +5 minutes, +10% → 2%/min → cap in 35 min, well before reset.
+    const second = renderSegments(segs("quotaEta"), ctx({ payload: quotaPayload(30), nowMs: RESETS_AT_MS - 3_300_000, quotaStatePath: file }));
+    expect(second).toMatch(/^≈ 5h cap \d{2}:\d{2} UTC$/);
+  });
+
+  it("corrupt state: segment omitted, file rewritten with the current reading, no throw", () => {
+    const file = join(mkdtempSync(join(tmpdir(), "aireceipts-quota-")), "quota-window.json");
+    writeFileSync(file, "garbage");
+    const line = renderSegments(segs("quotaEta"), ctx({ payload: quotaPayload(20), nowMs: RESETS_AT_MS - 3_600_000, quotaStatePath: file }));
+    expect(line).toBe("");
+    expect(JSON.parse(readFileSync(file, "utf8"))).toMatchObject({ usedPercentage: 20 });
+  });
+
+  it("payload without resets_at: segment omitted, state untouched", () => {
+    const file = join(mkdtempSync(join(tmpdir(), "aireceipts-quota-")), "quota-window.json");
+    const payload = { rate_limits: { five_hour: { used_percentage: 20 } } };
+    const line = renderSegments(segs("quotaEta"), ctx({ payload, quotaStatePath: file }));
+    expect(line).toBe("");
+    expect(readPriorReading(file)).toBeNull();
+  });
+});

--- a/test/cli/statusline.test.ts
+++ b/test/cli/statusline.test.ts
@@ -130,7 +130,7 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
     const { code, output } = await captureStdout(() => runStatusline(stdin, loadFromDiskFn));
     expect(code).toBe(0);
     expect(diskFallbackCalled.value).toBe(false);
-    expect(output).toContain("[Claude Code]");
+    expect(output).toContain("[aireceipts]");
   });
 
   it("R3b: falls back to disk when stdin is empty (TTY)", async () => {
@@ -139,7 +139,7 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
     const loadFromDiskFn = async (): Promise<Session | null> => loadById("claude-code", transcriptPath);
     const { code, output } = await captureStdout(() => runStatusline(stdin, loadFromDiskFn));
     expect(code).toBe(0);
-    expect(output).toContain("[Claude Code]");
+    expect(output).toContain("[aireceipts · Claude Code]");
   });
 
   it("R3b: falls back to disk when stdin is malformed JSON", async () => {
@@ -148,7 +148,7 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
     const loadFromDiskFn = async (): Promise<Session | null> => loadById("claude-code", transcriptPath);
     const { code, output } = await captureStdout(() => runStatusline(stdin, loadFromDiskFn));
     expect(code).toBe(0);
-    expect(output).toContain("[Claude Code]");
+    expect(output).toContain("[aireceipts · Claude Code]");
   });
 
   it("R1: renders a stuck-loop waste flag for the 5x Bash loop fixture", async () => {
@@ -156,7 +156,7 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
     const stdin = stdinStub(JSON.stringify({ transcript_path: transcriptPath }));
     const { code, output } = await captureStdout(() => runStatusline(stdin));
     expect(code).toBe(0);
-    expect(output).toContain("[Claude Code]");
+    expect(output).toContain("[aireceipts]");
     expect(output).toContain("⚠");
     expect(output).toContain("Bash loop ×");
   });
@@ -166,7 +166,7 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
     const stdin = stdinStub(JSON.stringify({ transcript_path: transcriptPath }));
     const { code, output } = await captureStdout(() => runStatusline(stdin));
     expect(code).toBe(0);
-    expect(output).toContain("[Claude Code]");
+    expect(output).toContain("[aireceipts]");
     // Whichever waste kind this fixture actually trips (stuck-loop or
     // trivial-spans), the line must carry exactly one factual waste flag —
     // asserting on the flag's presence/shape rather than a hardcoded magic
@@ -202,6 +202,67 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
       const elapsedMs = performance.now() - started;
       expect(elapsedMs).toBeLessThanOrEqual(200);
     }
+  });
+
+  it("SPEC-0062 R3: a bare --format (no value) fails fast instead of silently rendering the default line", async () => {
+    const { parseOptions } = await import("../../src/cli/options.js");
+    expect(parseOptions(["statusline", "--format"]).format).toBe("");
+    let err = "";
+    const code = await runStatusline(stdinStub("", true), async () => null, () => {}, undefined, {
+      format: "",
+      writeError: (s) => {
+        err += s;
+      },
+    });
+    expect(code).toBe(1);
+    expect(err).toContain("unknown statusline segment");
+  });
+
+  it("SPEC-0062 R5: telemetry customFormat is false by default and true under --format", async () => {
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    const stdin1 = stdinStub(JSON.stringify({ transcript_path: transcriptPath }));
+    const infos: { customFormat: boolean }[] = [];
+    await captureStdout(() => runStatusline(stdin1, async () => null, undefined, (i) => void infos.push(i)));
+    const stdin2 = stdinStub(JSON.stringify({ transcript_path: transcriptPath }));
+    await captureStdout(() => runStatusline(stdin2, async () => null, undefined, (i) => void infos.push(i), { format: "brand,cost" }));
+    expect(infos.map((i) => i.customFormat)).toEqual([false, true]);
+  });
+
+  it("SPEC-0062 R3 mixed mode: dead transcript_path falls back to disk for the session, but payload quota still renders", async () => {
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    const payload = JSON.stringify({
+      transcript_path: "/no/such/file.jsonl",
+      rate_limits: { five_hour: { used_percentage: 50, resets_at: 1_800_018_000 } },
+    });
+    const loadFromDiskFn = async (): Promise<Session | null> => loadById("claude-code", transcriptPath);
+    const { code, output } = await captureStdout(() => runStatusline(stdinStub(payload), loadFromDiskFn));
+    expect(code).toBe(0);
+    expect(output).toContain("[aireceipts · Claude Code]");
+    expect(output).toContain("5h 50%");
+  });
+
+  it("SPEC-0062 R5 latency: rollup + quota parsing + state read/write stays within the 200ms budget", async () => {
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const statePath = path.join(mkdtempSync(path.join(tmpdir(), "aireceipts-lat-")), "quota-window.json");
+    const transcriptPath = fixturePath("clean-with-subagents.jsonl");
+    const payload = JSON.stringify({
+      transcript_path: transcriptPath,
+      rate_limits: { five_hour: { used_percentage: 23.5, resets_at: 1_800_018_000 } },
+    });
+    const started = performance.now();
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub(payload), async () => null, undefined, undefined, {
+        format: "brand,cost,tokens,waste,quota5h,quota7d,quotaEta",
+        nowMs: 1_800_000_000_000,
+        quotaStatePath: statePath,
+      }),
+    );
+    const elapsedMs = performance.now() - started;
+    expect(code).toBe(0);
+    expect(output).toContain("[aireceipts]");
+    expect(output).toContain("5h 24%");
+    expect(elapsedMs).toBeLessThanOrEqual(200);
   });
 
   it("SPEC-0061 R3 latency: the subagent rollup (children present) stays within the same 200ms budget", async () => {

--- a/test/receipt/statusline-render.test.ts
+++ b/test/receipt/statusline-render.test.ts
@@ -1,8 +1,10 @@
-// SPEC-0007 R1 test matrix: the statusline one-liner's rendering rules,
-// exercised directly against constructed `ReceiptModel`s (no fixture I/O
-// needed — `renderStatusline` is a pure function of the model).
+// SPEC-0007 R1 rules on the SPEC-0062 segments engine: the one-liner's
+// rendering rules, exercised directly against constructed `ReceiptModel`s (no
+// fixture I/O — `renderSegments` over `buildMiniSummary` is pure given a
+// context). The default line is the format `brand,cost,tokens,waste,quota5h`.
 import { describe, expect, it } from "vitest";
-import { buildMiniSummary, renderStatusline } from "../../src/receipt/mini.js";
+import { buildMiniSummary } from "../../src/receipt/mini.js";
+import { DEFAULT_FORMAT, parseFormat, renderSegments, type SegmentContext } from "../../src/cli/statuslineSegments.js";
 import type { ReceiptModel, StuckLoopWasteLine, ToolRow, TrivialSpansWasteLine } from "../../src/receipt/model.js";
 import type { TokenUsage } from "../../src/parse/types.js";
 
@@ -31,18 +33,46 @@ function baseModel(overrides: Partial<ReceiptModel> = {}): ReceiptModel {
     methodology: "test",
     priceRowsUsed: [],
     unpriceable: false,
+    costLowerBoundCacheTier: false,
+    turnCount: 4,
+    toolCallCount: 4,
+    cacheReadAtInputRateUsd: null,
     ...overrides,
   };
 }
 
-describe("renderStatusline (R1 priced, no waste)", () => {
-  it("renders [agent] $usd · Nk tok with no waste-flag segment", () => {
+const DEFAULT_SEGMENTS = (() => {
+  const parsed = parseFormat(DEFAULT_FORMAT);
+  if ("unknown" in parsed) {
+    throw new Error("default format failed to parse");
+  }
+  return parsed.segments;
+})();
+
+/** Render the default line the way the command does — stdin mode, no quota payload unless supplied. */
+function renderDefault(model: ReceiptModel, over: Partial<SegmentContext> = {}): string {
+  return renderSegments(DEFAULT_SEGMENTS, {
+    summary: buildMiniSummary(model),
+    inputMode: "stdin_payload",
+    payload: null,
+    nowMs: 0,
+    ...over,
+  });
+}
+
+describe("default line (R1 priced, no waste)", () => {
+  it("renders [aireceipts] $usd · Nk tok with no waste-flag segment", () => {
     const model = baseModel({ totalUsd: 1.23, totalTokens: usage(12345) });
-    expect(renderStatusline(model)).toBe("[Claude Code] $1.23 · 12k tok");
+    expect(renderDefault(model)).toBe("[aireceipts] $1.23 · 12k tok");
+  });
+
+  it("disk-fallback mode names the session's agent in the brand", () => {
+    const model = baseModel({ agentLabel: "Codex", source: "codex" });
+    expect(renderDefault(model, { inputMode: "disk_fallback" })).toBe("[aireceipts · Codex] $1.23 · 12k tok");
   });
 });
 
-describe("renderStatusline (R1 unpriced — I2: zero $ bytes)", () => {
+describe("default line (R1 unpriced — I2: zero $ bytes)", () => {
   it("renders tokens-only when unpriceable, even if totalUsd is somehow set", () => {
     const model = baseModel({
       agentLabel: "Cursor",
@@ -54,20 +84,20 @@ describe("renderStatusline (R1 unpriced — I2: zero $ bytes)", () => {
       totalTokens: usage(0),
       sessionTotalTokens: usage(8000),
     });
-    const line = renderStatusline(model);
-    expect(line).toBe("[Cursor] 8k tok");
+    const line = renderDefault(model);
+    expect(line).toBe("[aireceipts] 8k tok");
     expect(line).not.toContain("$");
   });
 
   it("renders tokens-only when nothing in the session priced (totalUsd null)", () => {
     const model = baseModel({ totalUsd: null, totalTokens: usage(500) });
-    const line = renderStatusline(model);
-    expect(line).toBe("[Claude Code] 1k tok");
+    const line = renderDefault(model);
+    expect(line).toBe("[aireceipts] 1k tok");
     expect(line).not.toContain("$");
   });
 });
 
-describe("renderStatusline (R1 waste flags)", () => {
+describe("default line (R1 waste flags)", () => {
   it("appends a stuck-loop flag with the tool name and run length", () => {
     const waste: StuckLoopWasteLine = {
       kind: "stuck-loop",
@@ -78,7 +108,7 @@ describe("renderStatusline (R1 waste flags)", () => {
       wallClockMs: 15000,
     };
     const model = baseModel({ totalUsd: 2.5, totalTokens: usage(20000), wasteLines: [waste] });
-    expect(renderStatusline(model)).toBe("[Claude Code] $2.50 · 20k tok · ⚠ Bash loop ×5");
+    expect(renderDefault(model)).toBe("[aireceipts] $2.50 · 20k tok · ⚠ Bash loop ×5");
   });
 
   it("appends a trivial-spans flag with the eligible turn count", () => {
@@ -90,12 +120,12 @@ describe("renderStatusline (R1 waste flags)", () => {
       cheaperModel: "claude-haiku-4-5",
     };
     const model = baseModel({ totalUsd: 2.5, totalTokens: usage(20000), wasteLines: [waste] });
-    expect(renderStatusline(model)).toBe("[Claude Code] $2.50 · 20k tok · ⚠ 7 trivial spans");
+    expect(renderDefault(model)).toBe("[aireceipts] $2.50 · 20k tok · ⚠ 7 trivial spans");
   });
 
   it("omits the waste segment entirely when nothing fired (I6: absence, not a claim)", () => {
     const model = baseModel({ wasteLines: [] });
-    expect(renderStatusline(model)).not.toContain("⚠");
+    expect(renderDefault(model)).not.toContain("⚠");
   });
 
   it("only surfaces the first waste line (wasteLines[0]) even when multiple fired", () => {
@@ -115,9 +145,34 @@ describe("renderStatusline (R1 waste flags)", () => {
       cheaperModel: "claude-haiku-4-5",
     };
     const model = baseModel({ wasteLines: [stuckLoop, trivialSpans] });
-    const line = renderStatusline(model);
+    const line = renderDefault(model);
     expect(line).toContain("Read loop ×3");
     expect(line).not.toContain("trivial spans");
+  });
+});
+
+describe("SPEC-0062 R2 — quota on the default line", () => {
+  const payload = { rate_limits: { five_hour: { used_percentage: 23.5, resets_at: 1_800_000_000 } } };
+
+  it("appends the official 5h percentage, integer-rounded", () => {
+    expect(renderDefault(baseModel(), { payload })).toBe("[aireceipts] $1.23 · 12k tok · 5h 24%");
+  });
+
+  it("omits the segment for an out-of-range percentage (SPEC-0014 R4: never a guess)", () => {
+    const bad = { rate_limits: { five_hour: { used_percentage: 130 } } };
+    expect(renderDefault(baseModel(), { payload: bad })).toBe("[aireceipts] $1.23 · 12k tok");
+  });
+
+  it("the 7d window stays off the default line", () => {
+    const both = {
+      rate_limits: {
+        five_hour: { used_percentage: 10 },
+        seven_day: { used_percentage: 55 },
+      },
+    };
+    const line = renderDefault(baseModel(), { payload: both });
+    expect(line).toContain("5h 10%");
+    expect(line).not.toContain("7d");
   });
 });
 

--- a/test/receipt/subagents.test.ts
+++ b/test/receipt/subagents.test.ts
@@ -11,12 +11,26 @@ import type { ReceiptModel, SubagentAggregate, ToolRow } from "../../src/receipt
 import { attachSubagentRollup, foldSubagentRows, subagentCaveats } from "../../src/receipt/subagents.js";
 import { renderReceipt } from "../../src/receipt/render.js";
 import { renderReceiptSvg } from "../../src/receipt/svg.js";
-import { renderMiniReceipt, renderStatusline } from "../../src/receipt/mini.js";
+import { buildMiniSummary, renderMiniReceipt } from "../../src/receipt/mini.js";
+import { DEFAULT_FORMAT, parseFormat, renderSegments } from "../../src/cli/statuslineSegments.js";
 import { toJsonModel } from "../../src/receipt/json.js";
 import { receiptJsonSchema } from "../../src/receipt/exportSchema.js";
 import { receiptTelemetryFromModels } from "../../src/cli/common/telemetry.js";
 
 const PARENT_FIXTURE = "test/fixtures/claude-code/clean-with-subagents.jsonl";
+
+const DEFAULT_SEGMENTS = (() => {
+  const parsed = parseFormat(DEFAULT_FORMAT);
+  if ("unknown" in parsed) {
+    throw new Error("default format failed to parse");
+  }
+  return parsed.segments;
+})();
+
+function renderStatusline(model: ReceiptModel): string {
+  return renderSegments(DEFAULT_SEGMENTS, { summary: buildMiniSummary(model), inputMode: "stdin_payload", payload: null, nowMs: 0 });
+}
+
 
 function usage(total: number): TokenUsage {
   return { input: total, output: 0, cacheRead: 0, cacheCreation: 0, total };
@@ -195,7 +209,7 @@ describe("SPEC-0061 R1 — the SUBAGENTS row across templates", () => {
 describe("SPEC-0061 R3/R4 — statusline and mini fold the aggregate in", () => {
   it("statusline $ and tokens cover parent + children, format unchanged", () => {
     const model = baseModel({ subagents: { ...AGG, pricedUsd: 9.85, tokensTotal: 1_000_000 } });
-    expect(renderStatusline(model)).toBe("[Claude Code] $10.03 · 1,012k tok");
+    expect(renderStatusline(model)).toBe("[aireceipts] $10.03 · 1,012k tok");
   });
 
   it("statusline stays tokens-only when the parent is unpriced (I2)", () => {


### PR DESCRIPTION
## What this adds

SPEC-0062: the statusline brands itself, shows official quota, and takes custom formats. The default line becomes `[aireceipts] $X · Nk tok · ⚠ … · 5h N%`; `--format` picks any segment list; `quotaEta` projects a labeled ≈ cap-crossing time from two observed readings.

## Why it matters to users

- The most-screenshotted surface stops advertising the host inside the host's own status bar and starts saying who priced the number.
- Subscribers see their official 5h window usage on every prompt without a separate `--quota` call.
- Power users compose their own line (`--format brand,cost,quota5h,quotaEta`) — every segment either an official fact or labeled arithmetic; ambiguity renders nothing.

## See it

Live invocations against this session's transcript (real payload shape):

```
$ aireceipts statusline                     # default line, quota in payload
[aireceipts] $389.81 · 299,513k tok · ⚠ 1 trivial spans · 5h 24%

$ aireceipts statusline --format brand,cost,quota5h,quota7d
[aireceipts] $389.81 · 5h 24% · 7d 41%

$ aireceipts statusline --format bogus
unknown statusline segment "bogus" (valid: brand, cost, tokens, waste, quota5h, quota7d, quotaEta)
→ exit 1
```

## What changed

- `src/cli/statuslineSegments.ts` (new) → the segments engine; default line ≡ `brand,cost,tokens,waste,quota5h`; per-name memoization keeps duplicate stateful segments literal
- `src/cli/quotaWindow.ts` (new) → `quota-window.json` state (atomic tmp+rename, self-healing, last-writer-wins) + `projectCapCrossingMs` with five omission guards and a Date-range backstop
- `src/cli/commands/statusline.ts` → renders through the engine; `--format` fail-fast (exit 1, valid list on stderr); payload retained for quota segments
- `src/cli/options.ts` → `--format` value flag (bare flag normalizes to `""` → fail-fast, never a silent default)
- `src/receipt/mini.ts` → one-line renderer retired (`statuslineWasteFlag` exported); 6-line mini untouched
- telemetry → `integration_surface_rendered.customFormat` optional boolean; `scripts/site-assets.mts` rewired; `goldens/cli/help.txt` updated deliberately
- docs → `docs/statusline.md` (segment table + ETA honesty rules), `docs/guide/07-statusline.md`, `docs/telemetry.md`
- spec → `specs/SPEC-0062-statusline-segments.md` (approved 2026-07-06; payload-derived quota semantics amendment recorded)

## What to review, in order

1. `src/cli/quotaWindow.ts` — the ETA guards (riskiest honesty decision: when does ≈ render at all).
2. `src/cli/statuslineSegments.ts` — quota segments are payload-derived (render on a dead-transcript-path fallback), and the memoized render.
3. `src/cli/commands/statusline.ts` — fail-fast path ordering (format validated before any I/O).
4. `test/cli/statusline-segments.test.ts` — the R4 guard battery incl. the un-masked Date-range backstop test.

## Evidence

Gates unmasked: tsc 0 · eslint 0 · vitest 1535/1535 · goldens 102 byte-identical · determinism 10× OK · spec-lint 60 OK · hygiene OK. (Two flaky full-suite runs under host load — the known local-Mac concurrency flake — pass clean bounded and in isolation.) Spec: SPEC-0062, maintainer-approved, Validation record attached. Codex deep review: 4 findings — duplicate-`quotaEta` statefulness, bare-`--format` silent default, spec/impl quota-semantics mismatch, NaN backstop — all fixed with regression tests; re-review confirmed, including catching my first backstop test as masked (now exercises the intended branch). Build receipt below.

## Notes

**Stacked on #157** (SPEC-0061) — base is `fix/154-subagent-session-rollup`; retarget to `main` after #157 merges. Same-author flag: built by a Claude session; independent critic was Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
