### PR TITLE
chore: release v0.3.0 — subagent rollups, statusline v2, details, backfill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,15 +81,19 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.2.0):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.3.0):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
-  incl. Codex compactions), price-delta + routable-spend, `compare`, `week`, `--handoff`
-  (resume packet + standing rules), local budget line, quota context, statusline, PR
-  receipts (multi-session, SHA-anchored, artifact/share), SVG/PNG export, receipt
-  templates, the landing + docs sites, adoption telemetry + a local `stats`
-  counter command (SPEC-0043), and disclosed opt-out diagnostics telemetry. 21
-  specs at `status: shipped`.
+  incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,
+  `week`, `--handoff` (resume packet + standing rules + savings slip), local budget
+  line, quota context, statusline v2 (brand prefix, quota default-on, `--format`
+  segments, labeled `≈` quota ETA — SPEC-0062), subagent rollups on every surface (PR
+  fence + details table, session receipt `SUBAGENTS` row, statusline/mini/`--json` —
+  SPEC-0060/0061), `--details`, `backfill`, `--demo`, `setup` + `integrations`
+  (day-1 kit), per-agent docs pages, PR receipts (multi-session, SHA-anchored,
+  artifact/share), SVG/PNG export, receipt templates, the landing + docs sites,
+  adoption telemetry + a local `stats` counter command (SPEC-0043), and disclosed
+  opt-out diagnostics telemetry. 35 specs at `status: shipped`.
 - **In progress (`building`):** SPEC-0044 cost-attribution confidence — its
   implemented slices ship in v0.2.0 (ConfidenceEvent contract + no-silent-drop,
   cost matrix, rows-sum-to-total, cache-write caveat, parse-skip/load-failure

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,68 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.3.0 — 2026-07-06
+
+Minor: background-agent (subagent) spend becomes visible on every surface, the
+statusline is rebranded and extensible, and receipts get sharper defaults plus
+retroactive/first-run tooling. Per the 0.x policy, this minor deliberately
+changes rendered output — the callouts below list every change.
+
+### Output changes (deliberate, golden-gated)
+
+- Statusline prefix is now `[aireceipts]` in stdin mode and
+  `[aireceipts · <agent>]` in disk-fallback mode (was `[Claude Code]` etc.),
+  and the default line appends your official 5h quota window (`5h N%`) when
+  Claude Code's payload carries it (SPEC-0062).
+- Session receipts draw one `SUBAGENTS (N)` row (with `TOTAL` covering it) when
+  the session has child transcripts; SPEC-0061 itself adds nothing to childless
+  sessions (their v0.2.0→v0.3.0 rendering differences come only from the
+  SPEC-0054/0055 changes above).
+- The receipt footer now carries the install CTA (`npx aireceipts-cli`) instead
+  of the samosa link, and the inline methodology paragraph moved behind
+  `--methodology` (SPEC-0055).
+- The `same tokens on <model>` line gains a `(N% less)` suffix when it is real
+  savings (SPEC-0054).
+
+### Added
+
+- **Subagent rollups everywhere** (SPEC-0060, SPEC-0061): PR comments aggregate
+  each contributor's subagents into one fence row plus a capped details table;
+  session receipts, the statusline, the `install-hook` mini-receipt, and
+  `--json` (optional `subagents` object) fold the same priced atoms in, with
+  floor caveats for anything unreadable or unpriced — never a fabricated `$`.
+- **Statusline v2** (SPEC-0062): `--format <segments>` engine
+  (`brand,cost,tokens,waste,quota5h,quota7d,quotaEta`); `quotaEta` is a
+  labeled `≈` cap-crossing estimate from two observed readings, rendered only
+  when its guards hold (state file: `~/.aireceipts/quota-window.json`).
+- **`--details`** (SPEC-0054): opt-in receipt section — token/cache anatomy,
+  turns, peak turn, cache-read repricing, BY MODEL split.
+- **`backfill`** (SPEC-0056): bulk retroactive receipts for every existing
+  session on disk.
+- **`--demo`** (SPEC-0051): a bundled sample session renders a real receipt on
+  a machine with no sessions yet; both empty-state messages point at it.
+- **`setup` + `integrations`** (SPEC-0050): first-run report and exact local
+  integration snippets for Claude Code, Codex, opencode, Cursor, and GitHub.
+- **Savings slip** (SPEC-0059): could-have-saved handoff block and PR section.
+- **`--version`**, NOTICE file, and the OIDC release pipeline (#134); OpenSSF
+  Scorecard, community files, and CI telemetry default-off (#139).
+- Per-agent docs pages for the five supported agents (SPEC-0058); discovery
+  now flags unreadable sessions instead of silently skipping them (SPEC-0045).
+
+### Fixed
+
+- Weekly-digest delta-direction labels now match the sign of the change
+  (SPEC-0008, #150).
+- spec-lint catches duplicate spec ids across filenames (#136).
+
+### Docs
+
+- README rebuilt PR-receipt-first with a real merged-PR receipt comment as the
+  hero, then trimmed to one receipt showing per format (SPEC-0053, #153).
+- Positioning pass across README/FAQ/landing (SPEC-0048/0049); Show HN launch
+  kit and GTM sequencing docs; statusline docs cover the new segments and the
+  host refresh-cadence limitation.
+
 ## v0.2.0 — 2026-07-05
 
 Minor: adds adoption telemetry + a local `stats` command (SPEC-0043), and lands

--- a/docs/guide/01-getting-started.md
+++ b/docs/guide/01-getting-started.md
@@ -36,7 +36,7 @@ Write.............................$0.03  (2 calls)
 Read...............................$0.02  (1 call)
 --------------------------------------------------
 TOTAL........................................$0.18
-same tokens on claude-haiku-4-5..............$0.04
+same tokens on claude-haiku-4-5...$0.04 (78% less)
   (arithmetic, not a prediction)
 - - - - - - - - - - - - - - - - - - - - - - - - -
      aireceipts · local · npx aireceipts-cli      

--- a/docs/internal/readme-evidence.md
+++ b/docs/internal/readme-evidence.md
@@ -45,7 +45,7 @@ renderer didn't produce it, the README can't show it.
 ## Prior art & the prepared launch-thread reply (SPEC-0030 R2)
 
 Positioning rules: never argue priority or state of mind; cite the lineage
-(ccusage → claude-receipts → Infracost-for-infra); make the difference
+(ccusage → claude-receipts → the cost-diff-PR-bot pattern from infra tooling); make the difference
 categorical ("a souvenir vs bookkeeping"). Facts checked 2026-07-03:
 claude-receipts created 2026-01-29, 616 stars, no HN front-page moment
 (4 and 1 points on its two submissions), thermal-printer novelty over
@@ -62,7 +62,7 @@ Paste-ready reply for "this already exists":
 > attribution — every PR in our repo carries the receipt of the agent
 > sessions that built it, with explicit floors when anything can't be
 > proven, and a doc on what a receipt can and can't prove. Same good
-> metaphor — Infracost did it for Terraform PRs years ago — different
+> metaphor — infra cost-diff bots did it for Terraform PRs years ago — different
 > category of tool.
 
 If someone asks directly whether the author knew of claude-receipts:

--- a/docs/internal/research/2026-07-05-receipt-details.md
+++ b/docs/internal/research/2026-07-05-receipt-details.md
@@ -8,11 +8,11 @@ below is the top consensus cluster.*
 
 ## What the research found
 
-**Adoption surfaces (Infracost, Codecov, size-limit, Lighthouse CI, npm audit,
+**Adoption surfaces (cost-diff PR bots, Codecov, size-limit, Lighthouse CI, npm audit,
 Receiptify/Wrapped, GH job summaries):**
 - Every number should carry its delta/context, not sit alone — Codecov renders
-  `absolute <relative> (impact)`; Infracost leads with the diff and its cause
-  (docs.codecov.com/docs/pull-request-comments, infracost.io/docs).
+  `absolute <relative> (impact)`; cost-diff PR bots lead with the diff and its cause
+  (docs.codecov.com/docs/pull-request-comments).
 - Progressive disclosure is a first-class feature: short scannable top, full detail
   behind an expand (Codecov `condensed_*` modes; GH `<details>` guidance —
   github.blog "Supercharging GitHub Actions with job summaries").

--- a/docs/releases/0.3.0-verdict.md
+++ b/docs/releases/0.3.0-verdict.md
@@ -1,0 +1,64 @@
+# Release verdict — aireceipts-cli v0.3.0
+
+- **Candidate:** v0.3.0, a **minor** cut from `main` covering everything landed
+  since v0.2.0 — 23 commits, 276 files. Headliners: subagent rollups on every
+  surface (SPEC-0060/0061, fixes #154), statusline v2 (SPEC-0062), `--details`
+  (SPEC-0054), `backfill` (SPEC-0056), `--demo` (SPEC-0051), the day-1 setup
+  kit (SPEC-0050), savings slip (SPEC-0059), the PR-receipt-first README
+  (SPEC-0053) and launch-readiness hardening (#134/#139).
+- **Board SHA:** `8635a80` (main tip at board start; CI green on the exact SHA —
+  CI, scorecard, push-on-main all success). The release PR containing this
+  verdict (version bump, changelog, ledger flips, `AGENTS.md` inventory, the
+  three doc fixes below) is the only delta between the board SHA and the SHA
+  the workflow tags — same convention as the v0.2.0 verdict.
+- **Nature:** minor per the release rule (new capabilities). This minor
+  DELIBERATELY changes rendered output — statusline prefix + default quota
+  segment (SPEC-0062), the `SUBAGENTS (N)` row (SPEC-0061), footer/methodology
+  card cleanup (SPEC-0055), price-delta `% less` suffix (SPEC-0054) — every
+  change golden-gated and called out in the v0.3.0 changelog's "Output changes"
+  section, as the 0.x policy requires. SPEC-0061 adds no bytes to childless
+  sessions; their rendering delta vs v0.2.0 comes only from the other listed
+  changes.
+
+## Panel votes (four personas, separate agent contexts)
+
+| Persona | Vote | Core reasoning |
+|---|---|---|
+| Product Manager | **GO** | Coherent four-story release (subagent visibility, receipt sharpness, retroactive/first-run UX, GTM); tweetable with the `$18 shown vs $271 real` hook. Findings: stale `guide/01` example (fixed in this PR), spec ledger stale (fixed), competitor name in a public research doc (scrubbed, originals archived to the research vault). |
+| Engineering Manager | **GO** | 79 golden changes all traceable to disclosed specs; zero dependency delta, `npm audit` clean; rollback to 0.2.0 verified safe (new `quota-window.json` is isolated + self-healing, no shared-state drift); CI green on exact SHA; no open P0s (only two advisory price-drift reports at drift 0). Findings: changelog + ledger gaps (both fixed in this PR). |
+| Designer | **GO** | All surfaces rendered fresh from fixtures: priced/subagent/degraded terminal receipts byte-exact vs goldens; grocery/datavis/details verified; SVG light+dark byte-exact, subagent SVG visually verified; PNG perforation/alpha correct; README images resolve. Finding: a parent transcript whose `subagents/` dir was stripped (partial rsync) silently under-counts with no caveat — follow-up ticket, not a blocker (requires an abnormal on-disk state). |
+| QA / adversarial | **GO** | 20+ abuse cases (empty machine, garbage transcripts/budget/stdin, hostile fixtures, locale/pipe variants, quota payload fuzzing, `--format` abuse): zero crashes, zero fabricated `$` (I2 clean). Findings: zero-session default exits 1 (defensible contract, on record); 0-byte transcript invisible rather than named; cosmetic model-name truncation at very large amounts. |
+
+## Mechanical checks (lead, unmasked, on the board SHA)
+
+- `tsc` 0 · `eslint` 0 · goldens 102 byte-identical · determinism ×10 OK ·
+  spec-lint 60 OK · hygiene OK · cite-check LIVE: 4 files, all cited URLs live.
+- **Preflight (`scripts/preflight-release.mjs`): RELEASE-READY — 11 checks**,
+  including the packed-tarball install+run e2e. One earlier preflight run
+  red-flagged the documented local-host-load flake (`hook-commands` spawn
+  timeout, passes in isolation and in CI); the clean run followed on a quiet
+  host. CI (which gates the actual publish) is green on the SHA.
+- **Tarball smoke (manual, beyond preflight):** `npm pack` → install into a
+  clean prefix → binary renders the subagent fixture (`SUBAGENTS (2)` /
+  `TOTAL $0.04`) and statusline v2 with quota. 63 files, 106.9 kB packed — no
+  sourcemaps, no fixtures, no internal docs; `data/prices` + `data/demo` +
+  LICENSE/NOTICE present.
+- **gitleaks full-history:** clean locally (`--log-opts=--all`, 448 commits)
+  AND a fresh CI `workflow_dispatch` run on the candidate: success. (A stale
+  July-3 dispatch failure on `726a0b0` predates this candidate.)
+- `/review-docs`: PM cold-read found one correctness issue (guide/01's example
+  missing SPEC-0054's `(78% less)` suffix) — fixed in this PR; correctness
+  auditor pass on the changed docs rides in this PR's Codex review.
+
+## Open risks (accepted, on the record)
+
+1. Local vitest full-suite runs can flake under heavy host load (spawn-heavy
+   tests time out; pass in isolation/CI). Mitigation exists
+   (`AIRECEIPTS_SKIP_STRESS`, bounded workers); consider the DGX runner for
+   local full-suite work.
+2. Designer finding: stripped `subagents/` directories silently under-count —
+   follow-up issue to file, abnormal-state only.
+3. QA finding: zero-session default invocation exits 1 — defensible but worth
+   an explicit contract decision before 1.0.
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",

--- a/specs/SPEC-0045-discovery-load-failure.md
+++ b/specs/SPEC-0045-discovery-load-failure.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0045
 title: "Discovery-layer load failures — the session that never became a candidate"
-status: building
+status: shipped
 milestone: M4
 depends: [SPEC-0044]
 ---
@@ -130,13 +130,13 @@ event.
 
 ## Success criteria
 
-- [ ] A repo-scoped degraded session flags `unreadable-session`; a no-cwd /
+- [x] A repo-scoped degraded session flags `unreadable-session`; a no-cwd /
       out-of-repo degraded file does NOT (red-then-green, both directions).
-- [ ] `week`/`compare`/budget/`--list`/`--json`/default-receipt never render a
+- [x] `week`/`compare`/budget/`--list`/`--json`/default-receipt never render a
       degraded summary's total (a test per surface).
-- [ ] Sub-case 2 + unscopeable degraded are docs-only; no receipt caveat.
-- [ ] `docs/trust.md` gains the discovery-layer limitation entry.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] Sub-case 2 + unscopeable degraded are docs-only; no receipt caveat.
+- [x] `docs/trust.md` gains the discovery-layer limitation entry.
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`,
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` pass unmasked; the

--- a/specs/SPEC-0048-positioning-readme-docs-faq.md
+++ b/specs/SPEC-0048-positioning-readme-docs-faq.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0048
 title: "Positioning pass — work-unit receipts lead the README, plus an end-user FAQ"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0025, SPEC-0029]
 ---

--- a/specs/SPEC-0049-landing-dogfood-proof.md
+++ b/specs/SPEC-0049-landing-dogfood-proof.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0049
 title: "Landing-page parity — the dogfood proof on the PR-receipt tile"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0021, SPEC-0048]
 ---
@@ -77,10 +77,10 @@ Exact paragraph, verbatim (link text and href verbatim):
 
 ## Success criteria
 
-- [ ] The dogfood line renders on the PR-receipt tile; the PRs link resolves.
-- [ ] `node scripts/check-landing-css.mjs` passes; landing page issues zero external
+- [x] The dogfood line renders on the PR-receipt tile; the PRs link resolves.
+- [x] `node scripts/check-landing-css.mjs` passes; landing page issues zero external
       requests (text + anchor only).
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`,
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked

--- a/specs/SPEC-0050-day-1-setup-integration-kit.md
+++ b/specs/SPEC-0050-day-1-setup-integration-kit.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0050
 title: "Day-1 setup and integration kit"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0036, SPEC-0037]
 ---

--- a/specs/SPEC-0051-demo-sample-receipt.md
+++ b/specs/SPEC-0051-demo-sample-receipt.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0051
 title: "Demo sample receipt — `--demo` renders a bundled example so an empty machine still sees value"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0001, SPEC-0018, SPEC-0043]
 ---
@@ -130,12 +130,12 @@ default receipt command computes it; stdout gets `renderReceipt(...)` with no ba
 
 ## Success criteria
 
-- [ ] `aireceipts --demo` prints the sample receipt on a machine with zero sessions;
+- [x] `aireceipts --demo` prints the sample receipt on a machine with zero sessions;
       stdout equals the golden with colour off.
-- [ ] `data/demo` ships in the package and matches its source fixture byte-for-byte.
-- [ ] Empty-state message points to `--demo`; JSON empty paths unchanged.
-- [ ] `demo` is a telemetry command value; docs updated; help golden updated.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `data/demo` ships in the package and matches its source fixture byte-for-byte.
+- [x] Empty-state message points to `--demo`; JSON empty paths unchanged.
+- [x] `demo` is a telemetry command value; docs updated; help golden updated.
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`,
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked

--- a/specs/SPEC-0053-pr-receipt-first-readme.md
+++ b/specs/SPEC-0053-pr-receipt-first-readme.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0053
 title: "PR-receipt-first README — the receipt on a merged PR is the first visual"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0029, SPEC-0048, SPEC-0050]
 ---
@@ -97,8 +97,8 @@ visual in the first 30 lines in 86% of the winning corpus). Maintainer-directed
 
 ## Success criteria
 
-- [ ] R1–R6 implemented; readme-guard extended for R1 and green.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] R1–R6 implemented; readme-guard extended for R1 and green.
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`,
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked

--- a/specs/SPEC-0054-receipt-details.md
+++ b/specs/SPEC-0054-receipt-details.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0054
 title: "Full-receipt details — sharper default lines + an opt-in `--details` section"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0001, SPEC-0017, SPEC-0018, SPEC-0020, SPEC-0043]
 ---
@@ -215,7 +215,7 @@ The `--details` section (opt-in; default output untouched):
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked
       (`echo $?`).
-- [ ] Mutation testing on `src/pricing/**` (per-model + counterfactual
+- [x] Mutation testing on `src/pricing/**` (per-model + counterfactual
       accumulators) survives Stryker.
 
 ## Validation

--- a/specs/SPEC-0055-receipt-card-cleanup.md
+++ b/specs/SPEC-0055-receipt-card-cleanup.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0055
 title: "Receipt card cleanup — drop the samosa footer + methodology brief, samosa link goes real"
-status: approved
+status: shipped
 milestone: M4
 depends: [SPEC-0020, SPEC-0034]
 ---

--- a/specs/SPEC-0056-backfill-existing-sessions.md
+++ b/specs/SPEC-0056-backfill-existing-sessions.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0056
 title: "aireceipts backfill — bulk retroactive receipts for sessions you already ran"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0001, SPEC-0018, SPEC-0043, SPEC-0045]
 ---
@@ -203,16 +203,16 @@ GitHub/PR involvement at all; the shared word "backfill" is coincidental.
 
 ## Success criteria
 
-- [ ] `aireceipts backfill` prints a deterministic summary with zero sessions on disk and
+- [x] `aireceipts backfill` prints a deterministic summary with zero sessions on disk and
       with a real history, and writes files only when `--out` is given.
-- [ ] `--out` produces one byte-stable receipt per session (I5) plus a deterministic
+- [x] `--out` produces one byte-stable receipt per session (I5) plus a deterministic
       `index.txt`; a second identical run reproduces the same bytes (I1).
-- [ ] The refuse-to-clobber check protects a non-empty, non-backfill directory.
-- [ ] `--since`/`--limit` filter correctly and compose; degraded/unreadable/load-failed
+- [x] The refuse-to-clobber check protects a non-empty, non-backfill directory.
+- [x] `--since`/`--limit` filter correctly and compose; degraded/unreadable/load-failed
       sessions are counted, never silently dropped (SPEC-0045).
-- [ ] `backfill` is a valid telemetry command; `export_generated` fires exactly per the
+- [x] `backfill` is a valid telemetry command; `export_generated` fires exactly per the
       decision tree in R9; `docs/telemetry.md` stays in parity.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`,
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked

--- a/specs/SPEC-0058-per-agent-pages.md
+++ b/specs/SPEC-0058-per-agent-pages.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0058
 title: "Per-agent doc pages — one landing page per supported agent"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0010, SPEC-0018, SPEC-0050]
 ---
@@ -70,8 +70,8 @@ Maintainer-directed (2026-07-05).
 
 ## Success criteria
 
-- [ ] R1–R4 implemented; guard test green.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] R1–R4 implemented; guard test green.
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`,
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked.

--- a/specs/SPEC-0060-subagent-rollup-details.md
+++ b/specs/SPEC-0060-subagent-rollup-details.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0060
 title: "PR-comment subagent rollup — one aggregate row in the fence, the breakdown in details"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0026, SPEC-0044]
 ---
@@ -90,9 +90,9 @@ drawn-row granularity.
 
 ## Success criteria
 
-- [ ] R1–R5 implemented in `src/pr/body.ts` / `src/pr/index.ts`; `test/pr/body.test.ts` updated (no loosened assertions — the old per-row expectations are replaced by aggregate + details-table expectations).
-- [ ] `docs/pr-receipts.md` reflects the new fence/details split.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] R1–R5 implemented in `src/pr/body.ts` / `src/pr/index.ts`; `test/pr/body.test.ts` updated (no loosened assertions — the old per-row expectations are replaced by aggregate + details-table expectations).
+- [x] `docs/pr-receipts.md` reflects the new fence/details split.
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`,
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked.

--- a/specs/SPEC-0061-session-subagent-rollup.md
+++ b/specs/SPEC-0061-session-subagent-rollup.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0061
 title: "Session-surface subagent rollup — receipts and statusline stop undercounting background agents"
-status: building # PR open; shipped flips on merge
+status: shipped
 milestone: M5
 depends: [SPEC-0019, SPEC-0044, SPEC-0060]
 ---

--- a/specs/SPEC-0062-statusline-segments.md
+++ b/specs/SPEC-0062-statusline-segments.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0062
 title: "Statusline v2 — brand prefix, quota default-on, opt-in segments with a labeled quota ETA"
-status: building # PR open; shipped flips on merge
+status: shipped
 milestone: M5
 depends: [SPEC-0007, SPEC-0014, SPEC-0061]
 ---


### PR DESCRIPTION
## What this adds

The v0.3.0 release commit: version bump, changelog (with the 0.x output-change callouts), 13 spec-ledger flips to `shipped`, the `AGENTS.md` inventory update, the four-persona release-board verdict (`VERDICT: GO`), and three board-finding doc fixes.

## What changed

- `package.json` + `package-lock.json` → `0.3.0`
- `docs/CHANGELOG.md` → v0.3.0 section: Output changes / Added / Fixed / Docs
- 13 specs → `status: shipped` (+ success boxes); SPEC-0044 stays `building`
- `AGENTS.md` → v0.3.0 inventory, 35 shipped specs
- `docs/releases/0.3.0-verdict.md` → board SHA `8635a80`, 4× GO + mechanical checks (preflight RELEASE-READY ×2 — local quiet host and a clean-clone run on a 20-core Linux box; tarball smoke; gitleaks full-history clean locally + fresh CI dispatch; live cite-check)
- Board fixes: `docs/guide/01-getting-started.md` example now matches the golden (`(78% less)`); inspiration-source names genericized in `docs/internal/research/2026-07-05-receipt-details.md` + `docs/internal/readme-evidence.md` (originals archived to the research vault — flagging for maintainer eyes since one was a prepared launch-thread reply)

## What to review, in order

1. `docs/CHANGELOG.md` — the Output changes section is the user-facing contract for this minor.
2. `docs/releases/0.3.0-verdict.md` — panel findings + the three accepted open risks.
3. The two research-doc scrubs — confirm the genericized launch-thread reply still reads right to you.

## Evidence

Codex review of this commit: one real finding (changelog over-claimed byte-identity for childless sessions — SPEC-0054/0055 changed those bytes independently; wording fixed), everything else verified including spec-flip legitimacy and the 35-shipped count. Gates on this commit: tsc 0 · vitest 1535/1535 · goldens 102 · spec-lint 60 · hygiene OK · preflight RELEASE-READY (DGX, clean clone).

## Notes

After merge, publishing is button 4 (maintainer): `gh workflow run release-publish.yml --ref main` — the workflow re-runs preflight, publishes `aireceipts-cli@0.3.0` with OIDC provenance, then tags `v0.3.0` and creates the GitHub Release from the changelog section. Runbook: `docs/internal/releasing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
