### PR TITLE
perf: SPEC-0063 in-process sqlite, goldens compile cache, parallel preflight

### DIFF
--- a/scripts/preflight-release.mjs
+++ b/scripts/preflight-release.mjs
@@ -14,10 +14,11 @@
 // case, which throttles badly on dev macOS under the full suite. CI (including
 // release-publish's own preflight, CI=true) runs everything, and CI-green-on-SHA
 // is a hard release precondition — so the release gate keeps full coverage.
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const r = (p) => join(ROOT, p);
@@ -98,80 +99,115 @@ export function checkTarball(manifest, requiredPaths) {
   return v;
 }
 
-const sh = (cmd, args, opts = {}) => execFileSync(cmd, args, { cwd: ROOT, stdio: "pipe", encoding: "utf8", ...opts });
+const execFileAsync = promisify(execFile);
+const MAX_EXEC_BUFFER = 64 * 1024 * 1024;
 
-function main() {
+async function sh(cmd, args, opts = {}) {
+  const { stdout } = await execFileAsync(cmd, args, { cwd: ROOT, encoding: "utf8", maxBuffer: MAX_EXEC_BUFFER, ...opts });
+  return stdout;
+}
+
+function failureMessage(error) {
+  const stdout = typeof error?.stdout === "string" ? error.stdout : "";
+  const stderr = typeof error?.stderr === "string" ? error.stderr : "";
+  const message = error instanceof Error ? error.message : String(error);
+  const out = (stdout + stderr).trim() || message;
+  return String(out).split("\n").slice(-20).join("\n");
+}
+
+async function record(results, name, fn) {
+  try {
+    await fn();
+    const result = { name, ok: true };
+    results.set(name, result);
+    console.log(`✓ ${name}`);
+    return result;
+  } catch (error) {
+    const result = { name, ok: false, msg: failureMessage(error) };
+    results.set(name, result);
+    console.log(`✗ ${name}`);
+    return result;
+  }
+}
+
+function recordSkipped(results, name, msg) {
+  const result = { name, ok: false, msg };
+  results.set(name, result);
+  console.log(`✗ ${name}`);
+  return result;
+}
+
+async function main() {
   const quick = process.argv.includes("--quick");
-  const results = [];
-  const record = (name, fn) => {
-    try {
-      fn();
-      results.push({ name, ok: true });
-      console.log(`✓ ${name}`);
-    } catch (e) {
-      const out = ((e.stdout || "") + (e.stderr || "")).trim() || e.message;
-      results.push({ name, ok: false, msg: String(out).split("\n").slice(-20).join("\n") });
-      console.log(`✗ ${name}`);
-    }
-  };
+  const results = new Map();
+  const gateOrder = [
+    "manifest: publish-shape contract",
+    "build → dist/cli.js + shebang",
+    "tarball: lean + complete",
+    "tsc --noEmit",
+    "eslint --max-warnings 0",
+    "cite-check (all price tables, liveness enforced)",
+    "verify-goldens",
+    "spec-lint",
+    "hygiene",
+    "vitest run (full suite, incl. install+run e2e)",
+    "determinism-check ×10",
+  ];
 
-  // 1. manifest shape (pure, fast)
-  record("manifest: publish-shape contract", () => {
+  await record(results, "manifest: publish-shape contract", () => {
     const pkg = JSON.parse(readFileSync(r("package.json"), "utf8"));
     const lock = existsSync(r("package-lock.json")) ? JSON.parse(readFileSync(r("package-lock.json"), "utf8")) : null;
     const viol = checkManifest(pkg, lock);
     if (viol.length) throw new Error(viol.join("\n"));
   });
 
-  // 2. types + lint
-  record("tsc --noEmit", () => sh("npx", ["tsc", "--noEmit"]));
-  record("eslint --max-warnings 0", () => sh("npx", ["eslint", ".", "--max-warnings", "0"]));
-
-  // 3. clean build → dist/cli.js with a node shebang (the bin must be executable)
-  record("build → dist/cli.js + shebang", () => {
-    sh("npm", ["run", "build"]);
+  // Build and pack are the only dist/ writer/readers besides the vitest e2e
+  // beforeAll rebuild, so they complete before anything else starts; after this
+  // point only vitest touches dist/.
+  await record(results, "build → dist/cli.js + shebang", async () => {
+    await sh("npm", ["run", "build"]);
     if (!existsSync(r("dist/cli.js"))) throw new Error("dist/cli.js missing after build");
     const first = readFileSync(r("dist/cli.js"), "utf8").split("\n", 1)[0];
     if (first !== "#!/usr/bin/env node") throw new Error(`dist/cli.js first line is not a node shebang: ${first}`);
   });
 
-  // 4. tarball shape (what npm would actually publish; build just ran so the
-  //    fresh dist is what --ignore-scripts packs — same output prepublishOnly
-  //    produces, enforced by the manifest prepublishOnly==build check)
-  record("tarball: lean + complete", () => {
-    const out = sh("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"]);
+  await record(results, "tarball: lean + complete", async () => {
+    const out = await sh("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"]);
     const viol = checkTarball(JSON.parse(out)[0], ["dist/cli.js", "README.md", "LICENSE", "NOTICE", ...priceTablePaths(), ...demoAssetPaths()]);
     if (viol.length) throw new Error(viol.join("\n"));
   });
 
-  // 5. price citations valid + LIVE (I3) — on every committed table, not a diff.
-  //    CI=1 makes cite-check enforce URL liveness (locally it only warns).
-  record("cite-check (all price tables, liveness enforced)", () =>
-    sh("node", ["--experimental-strip-types", "scripts/cite-check.ts", ...priceTablePaths()], { env: { ...process.env, CI: "1" } }),
-  );
-
-  // 6. byte-stability guarantees (I5)
-  record("verify-goldens", () => sh("node", ["scripts/verify-goldens.mjs"]));
-  record("spec-lint", () => sh("node", ["scripts/spec-lint.mjs"]));
-  record("hygiene", () => sh("node", ["scripts/hygiene.mjs"]));
-
-  // 7. the heavy, release-only gates: the FULL suite (incl. the packed-tarball
-  //    install-and-run e2e that proves a priced receipt) + determinism ×10.
-  //    --quick skips these, and therefore cannot declare RELEASE-READY.
-  //    On a LOCAL run only (not CI), skip the one spawn-heavy stress case — the
-  //    100-session built-CLI e2e — which throttles badly on dev macOS under the
-  //    full suite. CI (including release-publish's own preflight, which runs with
-  //    CI=true) leaves the env unset and runs the full suite, so the release gate
-  //    keeps full coverage; CI-green-on-SHA is a hard release precondition. The
-  //    tarball install-and-run proof is a separate test and always runs.
   const stressEnv = process.env.CI ? {} : { AIRECEIPTS_SKIP_STRESS: "1" };
+  const concurrent = [
+    record(results, "tsc --noEmit", () => sh("npx", ["tsc", "--noEmit"])),
+    record(results, "eslint --max-warnings 0", () => sh("npx", ["eslint", ".", "--max-warnings", "0"])),
+    record(results, "cite-check (all price tables, liveness enforced)", () =>
+      sh("node", ["--experimental-strip-types", "scripts/cite-check.ts", ...priceTablePaths()], { env: { ...process.env, CI: "1" } }),
+    ),
+    record(results, "spec-lint", () => sh("node", ["scripts/spec-lint.mjs"])),
+    record(results, "hygiene", () => sh("node", ["scripts/hygiene.mjs"])),
+  ];
+  const verify = record(results, "verify-goldens", () => sh("node", ["scripts/verify-goldens.mjs"]));
+  concurrent.push(verify);
+
   if (!quick) {
-    record("vitest run (full suite, incl. install+run e2e)", () =>
-      sh("npx", ["vitest", "run"], { stdio: "pipe", env: { ...process.env, ...stressEnv } }));
-    record("determinism-check ×10", () => sh("node", ["scripts/determinism-check.mjs", "--runs=10", "--", "node", "scripts/verify-goldens.mjs"]));
+    concurrent.push(
+      record(results, "vitest run (full suite, incl. install+run e2e)", () =>
+        sh("npx", ["vitest", "run"], { env: { ...process.env, ...stressEnv } })),
+    );
+    concurrent.push(
+      verify.then((result) => {
+        if (!result.ok) return recordSkipped(results, "determinism-check ×10", "skipped: verify-goldens failed");
+        return record(results, "determinism-check ×10", () =>
+          sh("node", ["scripts/determinism-check.mjs", "--runs=10", "--", "node", "scripts/verify-goldens.mjs"]));
+      }),
+    );
   }
 
-  const failed = results.filter((x) => !x.ok);
+  await Promise.all(concurrent);
+
+  const orderedResults = gateOrder.map((name) => results.get(name)).filter(Boolean);
+  const failed = orderedResults.filter((x) => !x.ok);
   console.log();
   if (failed.length) {
     console.error(`preflight: NOT RELEASABLE — ${failed.length} check(s) failed:`);
@@ -179,12 +215,12 @@ function main() {
     process.exit(1);
   }
   if (quick) {
-    console.log(`preflight: ${results.length} quick checks passed — NOT release-valid (skipped full suite + determinism; run without --quick before releasing).`);
+    console.log(`preflight: ${orderedResults.length} quick checks passed — NOT release-valid (skipped full suite + determinism; run without --quick before releasing).`);
     return;
   }
-  console.log(`preflight: RELEASE-READY — ${results.length} checks passed.`);
+  console.log(`preflight: RELEASE-READY — ${orderedResults.length} checks passed.`);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  main();
+  await main();
 }

--- a/scripts/verify-goldens.mjs
+++ b/scripts/verify-goldens.mjs
@@ -1,67 +1,219 @@
 // CI gate: byte-verifies golden receipts under a frozen env.
 // Compile to a temp dir first so this gate never depends on `npx` fetching tsx.
 import { spawnSync } from "node:child_process";
-import { cpSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
-function tsFiles(dir) {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) return tsFiles(path);
-    return entry.isFile() && path.endsWith(".ts") ? [path] : [];
-  });
+const root = process.cwd();
+const cacheRoot = join(root, "node_modules", ".cache", "aireceipts-goldens");
+const tscPath = join(root, "node_modules", "typescript", "bin", "tsc");
+const frozenEnv = { ...process.env, NO_COLOR: "1", TZ: "UTC", LANG: "C" };
+const compilerOptions = {
+  target: "ES2022",
+  module: "NodeNext",
+  moduleResolution: "NodeNext",
+  lib: ["ES2022"],
+  strict: true,
+  esModuleInterop: true,
+  skipLibCheck: true,
+  resolveJsonModule: true,
+  rootDir: root,
+  outDir: "out",
+};
+
+let sourceRelFilesCache;
+let dataRelFilesCache;
+
+function filesUnder(relDir, predicate) {
+  const absDir = join(root, relDir);
+  return readdirSync(absDir, { withFileTypes: true })
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+    .flatMap((entry) => {
+      const relPath = join(relDir, entry.name);
+      if (entry.isDirectory()) return filesUnder(relPath, predicate);
+      return entry.isFile() && predicate(relPath) ? [relPath] : [];
+    });
 }
 
-const root = process.cwd();
-const tmp = mkdtempSync(join(tmpdir(), "aireceipts-goldens-"));
-const outDir = join(tmp, "out");
-const configPath = join(tmp, "tsconfig.goldens.json");
-const tscPath = join(root, "node_modules", "typescript", "bin", "tsc");
-const files = [join(root, "scripts", "goldens.mts"), ...tsFiles(join(root, "src"))];
+function sourceRelFiles() {
+  sourceRelFilesCache ??= ["scripts/goldens.mts", ...filesUnder("src", (path) => path.endsWith(".ts"))].sort();
+  return sourceRelFilesCache;
+}
 
-writeFileSync(
-  configPath,
-  JSON.stringify(
-    {
-      compilerOptions: {
-        target: "ES2022",
-        module: "NodeNext",
-        moduleResolution: "NodeNext",
-        lib: ["ES2022"],
-        strict: true,
-        esModuleInterop: true,
-        skipLibCheck: true,
-        resolveJsonModule: true,
-        rootDir: root,
-        outDir,
+function dataRelFiles() {
+  dataRelFilesCache ??= filesUnder("data", () => true).sort();
+  return dataRelFilesCache;
+}
+
+function buildConfig(configPath) {
+  writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        compilerOptions,
+        files: sourceRelFiles().map((p) => join(root, p)),
       },
-      files,
-    },
-    null,
-    2,
-  ),
-);
+      null,
+      2,
+    ),
+  );
+}
+
+function hashString(hash, label, value) {
+  hash.update(`${label}\0${value}\0`);
+}
+
+function hashPathList(hash, label, paths) {
+  hash.update(`${label}\0`);
+  for (const path of paths) hash.update(`${path}\0`);
+}
+
+function hashFiles(hash, label, paths) {
+  hash.update(`${label}\0`);
+  for (const path of paths) {
+    hash.update(`${path}\0`);
+    hash.update(readFileSync(join(root, path)));
+    hash.update("\0");
+  }
+}
+
+function cacheKey() {
+  const tsVersion = JSON.parse(readFileSync(join(root, "node_modules", "typescript", "package.json"), "utf8")).version;
+  const packageType = JSON.parse(readFileSync(join(root, "package.json"), "utf8")).type ?? "";
+  const hash = createHash("sha256");
+  hashString(hash, "compilerOptions", JSON.stringify(compilerOptions));
+  hashString(hash, "typescriptVersion", tsVersion);
+  hashString(hash, "packageType", packageType);
+  hashPathList(hash, "sourcePaths", sourceRelFiles());
+  hashFiles(hash, "sourceFiles", sourceRelFiles());
+  hashPathList(hash, "dataPaths", dataRelFiles());
+  hashFiles(hash, "dataFiles", dataRelFiles());
+  return hash.digest("hex");
+}
+
+function compiledScript(outDir) {
+  return join(outDir, relative(root, join(root, "scripts", "goldens.mts"))).replace(/\.mts$/u, ".mjs");
+}
+
+function compileInto(tempDir) {
+  const outDir = join(tempDir, "out");
+  const configPath = join(tempDir, "tsconfig.goldens.json");
+  buildConfig(configPath);
+  const compile = spawnSync(process.execPath, [tscPath, "--project", configPath], {
+    stdio: "inherit",
+    env: frozenEnv,
+  });
+  const status = compile.status ?? 1;
+  if (status !== 0) return status;
+  cpSync(join(root, "data"), join(outDir, "data"), { recursive: true });
+  return 0;
+}
+
+function runGoldens(outDir) {
+  const verify = spawnSync(process.execPath, [compiledScript(outDir), ...process.argv.slice(2)], {
+    stdio: "inherit",
+    env: frozenEnv,
+  });
+  return verify.status ?? 1;
+}
+
+function runFresh() {
+  const tmp = mkdtempSync(join(tmpdir(), "aireceipts-goldens-"));
+  try {
+    const status = compileInto(tmp);
+    return status === 0 ? runGoldens(join(tmp, "out")) : status;
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function isComplete(entryDir) {
+  // Sentinel plus the compiled entrypoint: a corrupt entry (sentinel present,
+  // output missing) must read as a miss so the run falls back to compiling.
+  return existsSync(join(entryDir, ".complete")) && existsSync(compiledScript(join(entryDir, "out")));
+}
+
+function isRenameRace(error) {
+  return error && typeof error === "object" && "code" in error && ["EEXIST", "ENOTEMPTY", "EPERM"].includes(String(error.code));
+}
+
+function pruneCache(currentHash) {
+  const now = Date.now();
+  const entryTtlMs = 7 * 24 * 60 * 60 * 1000;
+  const tmpTtlMs = 24 * 60 * 60 * 1000;
+  try {
+    for (const entry of readdirSync(cacheRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const path = join(cacheRoot, entry.name);
+      const ageMs = now - statSync(path).mtimeMs;
+      if (entry.name.startsWith(".tmp-")) {
+        if (ageMs > tmpTtlMs) rmSync(path, { recursive: true, force: true });
+      } else if (entry.name !== currentHash && ageMs > entryTtlMs) {
+        rmSync(path, { recursive: true, force: true });
+      }
+    }
+  } catch {
+    // Best-effort pruning must never affect verification.
+  }
+}
+
+function runWithCache() {
+  const key = cacheKey();
+  mkdirSync(cacheRoot, { recursive: true });
+  pruneCache(key);
+
+  const entryDir = join(cacheRoot, key);
+  if (isComplete(entryDir)) return runGoldens(join(entryDir, "out"));
+
+  const tempDir = mkdtempSync(join(cacheRoot, `.tmp-${process.pid}-`));
+  let removeTemp = true;
+  try {
+    const status = compileInto(tempDir);
+    if (status !== 0) return status;
+
+    writeFileSync(join(tempDir, ".complete"), "");
+    try {
+      renameSync(tempDir, entryDir);
+      removeTemp = false;
+      return runGoldens(join(entryDir, "out"));
+    } catch (error) {
+      if (!isRenameRace(error)) throw error;
+      if (isComplete(entryDir)) return runGoldens(join(entryDir, "out"));
+      // An incomplete entry can never be live (rename is atomic and happens
+      // after the sentinel is written) — it is corrupt. Evict it so the next
+      // run gets a clean hit instead of recompiling forever.
+      try {
+        rmSync(entryDir, { recursive: true, force: true });
+        renameSync(tempDir, entryDir);
+        removeTemp = false;
+        return runGoldens(join(entryDir, "out"));
+      } catch {
+        return runGoldens(join(tempDir, "out"));
+      }
+    }
+  } finally {
+    if (removeTemp) rmSync(tempDir, { recursive: true, force: true });
+  }
+}
 
 let status = 1;
 try {
-  const compile = spawnSync(process.execPath, [tscPath, "--project", configPath], {
-    stdio: "inherit",
-    env: { ...process.env, NO_COLOR: "1", TZ: "UTC", LANG: "C" },
-  });
-  status = compile.status ?? 1;
-
-  if (status === 0) {
-    cpSync(join(root, "data"), join(outDir, "data"), { recursive: true });
-    const script = join(outDir, relative(root, join(root, "scripts", "goldens.mts"))).replace(/\.mts$/u, ".mjs");
-    const verify = spawnSync(process.execPath, [script, ...process.argv.slice(2)], {
-      stdio: "inherit",
-      env: { ...process.env, NO_COLOR: "1", TZ: "UTC", LANG: "C" },
-    });
-    status = verify.status ?? 1;
-  }
-} finally {
-  rmSync(tmp, { recursive: true, force: true });
+  status = runWithCache();
+} catch {
+  status = runFresh();
 }
 
 process.exit(status);

--- a/specs/SPEC-0063-fast-feedback.md
+++ b/specs/SPEC-0063-fast-feedback.md
@@ -1,0 +1,111 @@
+---
+id: SPEC-0063
+title: "Fast feedback — cut test, CI, and release wall-clock without weakening any gate"
+status: building # PR open; shipped flips on merge
+milestone: M5
+depends: []
+---
+
+# SPEC-0063: Fast feedback — cut test, CI, and release wall-clock without weakening any gate
+
+## Purpose
+
+The verification loop is the pacing item for every feature: the local suite runs ~58s
+(1,535 tests summing to ~247s of test time at ~58% CPU), the CI `verify` job ~85s, and
+the full release preflight ~90–110s — almost all of it waste, not coverage. Three root
+causes, all measured: (1) `src/parse/sqlite.ts` prefers the `sqlite3` CLI, so every
+query is a `spawnSync` — the slowest test file spends 24s at 15% CPU blocked on spawns,
+and the spawn storm slows every other fork; (2) `scripts/verify-goldens.mjs` recompiles
+all of `src/` with `tsc` on every invocation, and the determinism gate re-runs it 10× —
+ten identical compiles (36s of every CI run); (3) `preflight-release.mjs` runs its ~10
+independent gates strictly serially. This spec removes the waste while keeping every
+gate exactly as strong — same commands, same coverage, byte-identical output (serves
+I1/I5: determinism is proven more often per minute, not less).
+
+## Requirements
+
+- **R1** — `openReadOnly` prefers in-process `node:sqlite` and falls back to the
+  `sqlite3` CLI only when `node:sqlite` is unavailable (Node 20, or Node 22 before
+  22.13 without `--experimental-sqlite`). The `sqlite3 -version` probe result is cached
+  per process. Both readers keep the same error contract: a failing query (missing
+  table, schema drift) yields `[]`, never a throw — Node 20 and Node 22 behave
+  identically on malformed databases.
+- **R2** — When `node:sqlite` is used, Node's `ExperimentalWarning` for SQLite (which
+  embeds the PID) never reaches stderr: a process-wide, idempotent `emitWarning` filter
+  — installed once before the first import, never uninstalled, safe under concurrent
+  adapter discovery — suppresses exactly that warning and nothing else.
+- **R3** — Receipt output stays byte-identical on both reader paths. The CI matrix
+  already proves this: Node 20 jobs exercise the CLI fallback, Node 22 jobs exercise
+  `node:sqlite`, and both must pass the same goldens + determinism gates.
+- **R4** — `verify-goldens.mjs` keeps its exact CLI contract (same invocation, same
+  output, argv passthrough) but caches the compiled output under
+  `node_modules/.cache/aireceipts-goldens/<hash>`, keyed by the content of every
+  compiler input (sorted file list + contents of `src/**/*.ts` and `scripts/goldens.mts`,
+  the generated tsconfig, the TypeScript version, `package.json` `"type"`) plus
+  `data/**`. Cache entries are immutable once written (temp-dir build + atomic rename,
+  loser of a concurrent race adopts the winner's entry or runs from its own temp dir);
+  a missing sentinel or missing compiled entrypoint invalidates the entry (corrupt
+  entries are evicted); any cache failure falls back to today's fresh-compile
+  behavior. Entries not matching the current key are pruned after 7 days.
+- **R5** — `determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs` remains
+  the determinism gate, unchanged; with a warm cache the 10 runs byte-match trivially
+  and complete in seconds, not ~36s.
+- **R6** — `preflight-release.mjs` runs `build` → tarball-shape first (the only
+  `dist/` writer/reader pair outside vitest), then all remaining gates concurrently
+  (tsc, eslint, cite-check, spec-lint, hygiene, goldens → determinism, full vitest).
+  Per-gate output is buffered; the pass/fail summary prints in a fixed order. The set
+  of gates, their commands, and `--quick` semantics are unchanged.
+- **R7** — No gate is removed, no timeout raised, no test skipped, and AGENTS.md's
+  verification block still passes verbatim.
+
+## Scenarios
+
+- **Given** Node ≥ 22.13 **When** any adapter opens a transcript DB **Then** queries run
+  in-process via `node:sqlite`, stderr carries no ExperimentalWarning, and the rendered
+  receipt is byte-identical to the sqlite3-CLI rendering of the same transcript.
+- **Given** Node 20 (no `node:sqlite`) **When** the same DB is opened **Then** the
+  sqlite3 CLI fallback is used and all goldens still pass.
+- **Given** two concurrent `verify-goldens.mjs` runs on a cold cache **When** both
+  compile **Then** one entry wins the rename, both runs verify successfully, and no
+  partially-written entry is ever read (sentinel).
+- **Given** any edit to `src/`, `scripts/goldens.mts`, or `data/**` **When**
+  `verify-goldens.mjs` runs **Then** the key changes and a fresh compile occurs.
+- **Given** a red gate (e.g. a failing test) **When** `preflight-release.mjs` runs
+  **Then** it still reports NOT RELEASABLE with that gate's buffered output — the
+  parallelization changes scheduling, never outcomes.
+
+## Non-goals
+
+- Dropping Node 20 from the support matrix or the CI matrix (EOL, but `engines` still
+  says `>=20`; a support-policy change is a separate maintainer decision).
+- Reducing determinism runs below 10, skipping tests, or weakening/removing any gate —
+  the point is faster proof, not less proof.
+- Caching across CI jobs (actions/cache for the goldens build): each job compiles once
+  and reuse within the job already removes the waste; cross-job caching adds
+  invalidation risk for ~3s of savings.
+- New telemetry: no user-facing feature surface changes (SPEC-0043 events unaffected).
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 node:sqlite preferred | Node ≥ 22.13, fixture DB | in-process reads; probe cached; CLI used only when node:sqlite absent |
+| R2 warning suppressed | node:sqlite path active | no ExperimentalWarning on stderr; non-SQLite warnings pass through |
+| R3 both paths byte-equal | Node 20 (CLI) and Node 22 (node:sqlite) CI jobs | same goldens pass on both |
+| R4 cache hit | 2nd verify-goldens run, no edits | no tsc invocation; identical stdout; exit 0 |
+| R4 cache invalidation | edit a src file / a price table | key changes; recompile; exit reflects verification result |
+| R4 concurrent cold cache | two simultaneous runs | both exit 0; single valid (sentinel-complete) cache entry |
+| R5 determinism gate | `determinism-check --runs=10 -- node scripts/verify-goldens.mjs` | 10 byte-identical outputs, seconds not ~36s |
+| R6 preflight red path | failing gate injected | NOT RELEASABLE, gate's buffered output in fixed-order summary |
+| R7 verification block | AGENTS.md commands, unmasked | all exit 0 verbatim, no gate removed or weakened |
+
+## Success criteria
+
+- [ ] Local `npx vitest run` wall-clock materially reduced (target ≥ 2× vs the 58s
+      baseline on the same machine).
+- [ ] CI `verify` job time materially reduced (determinism step ~36s → seconds).
+- [ ] Full preflight wall-clock ≈ its longest single gate, not the sum.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs` all pass unmasked (`echo $?`).
+- [ ] `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
+      `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked.

--- a/src/parse/sqlite.ts
+++ b/src/parse/sqlite.ts
@@ -6,13 +6,58 @@ export interface SqliteReader {
   close(): void;
 }
 
+let sqliteWarningFilterInstalled = false;
+let sqlite3ProbeUsable: boolean | undefined;
+
+type WarningConstructor = (...args: never[]) => unknown;
+type EmitWarningArgs =
+  | [warning: string | Error]
+  | [warning: string | Error, type: string]
+  | [warning: string | Error, type: string, code: string]
+  | [warning: string | Error, type: string, code: string, ctor: WarningConstructor]
+  | [warning: string | Error, options: NodeJS.EmitWarningOptions];
+type EmitWarningDelegate = (...args: EmitWarningArgs) => void;
+
+function warningMessage(warning: string | Error): string {
+  return warning instanceof Error ? warning.message : warning;
+}
+
+function warningType(warning: string | Error, typeOrOptions?: string | NodeJS.EmitWarningOptions): string | undefined {
+  if (warning instanceof Error) return warning.name;
+  if (typeof typeOrOptions === "string") return typeOrOptions;
+  return typeOrOptions?.type;
+}
+
+function isNodeSqliteExperimentalWarning(
+  warning: string | Error,
+  typeOrOptions?: string | NodeJS.EmitWarningOptions,
+): boolean {
+  return warningType(warning, typeOrOptions) === "ExperimentalWarning" && warningMessage(warning).includes("SQLite");
+}
+
+function installNodeSqliteWarningFilter(): void {
+  if (sqliteWarningFilterInstalled) return;
+  sqliteWarningFilterInstalled = true;
+
+  const emitWarning = process.emitWarning.bind(process) as unknown as EmitWarningDelegate;
+  process.emitWarning = ((...args: EmitWarningArgs): void => {
+    const [warning, typeOrOptions] = args;
+    if (isNodeSqliteExperimentalWarning(warning, typeOrOptions)) return;
+    emitWarning(...args);
+  }) as typeof process.emitWarning;
+}
+
 /**
- * Node's built-in SQLite (Node ≥ 22.5). Available only when started with
- * `--experimental-sqlite`; otherwise the import/construct throws and we fall back
- * to the CLI. Opened read-only — we never write to the agent's DB.
+ * Node's built-in SQLite is preferred when present: in-process reads avoid a
+ * spawn per query. Node ≥22.13 loads it unflagged but emits an ExperimentalWarning
+ * that embeds the PID; suppressing only that SQLite warning preserves I1/I5
+ * byte-determinism and keeps user stderr clean. The sqlite3 CLI remains the
+ * portable fallback for Node without node:sqlite. Opened read-only — we never
+ * write to the agent's DB.
  */
 async function tryNodeSqlite(dbPath: string): Promise<SqliteReader | null> {
   try {
+    installNodeSqliteWarningFilter();
     const { DatabaseSync } = (await import("node:sqlite")) as {
       DatabaseSync: new (
         path: string,
@@ -21,7 +66,15 @@ async function tryNodeSqlite(dbPath: string): Promise<SqliteReader | null> {
     };
     const db = new DatabaseSync(dbPath, { readOnly: true });
     return {
-      all: (sql) => db.prepare(sql).all() as Record<string, unknown>[],
+      // Same error contract as the CLI fallback: a failing query (missing
+      // table, schema drift) yields [] on every runtime, never a throw.
+      all: (sql) => {
+        try {
+          return db.prepare(sql).all() as Record<string, unknown>[];
+        } catch {
+          return [];
+        }
+      },
       close: () => db.close(),
     };
   } catch {
@@ -31,8 +84,11 @@ async function tryNodeSqlite(dbPath: string): Promise<SqliteReader | null> {
 
 /** The `sqlite3` CLI in read-only JSON mode — the portable fallback (no npm dep). */
 function trySqlite3Cli(dbPath: string): SqliteReader | null {
-  const probe = spawnSync("sqlite3", ["-version"], { encoding: "utf8" });
-  if (probe.error || probe.status !== 0) {
+  if (sqlite3ProbeUsable === undefined) {
+    const probe = spawnSync("sqlite3", ["-version"], { encoding: "utf8" });
+    sqlite3ProbeUsable = !probe.error && probe.status === 0;
+  }
+  if (!sqlite3ProbeUsable) {
     return null;
   }
   return {
@@ -55,12 +111,11 @@ function trySqlite3Cli(dbPath: string): SqliteReader | null {
 }
 
 /**
- * Open a SQLite database read-only. Prefers the stable `sqlite3` CLI so normal
- * CLI/golden runs do not emit Node's process-specific experimental
- * `node:sqlite` warning; falls back to `node:sqlite` when the CLI is absent.
+ * Open a SQLite database read-only. Prefers node:sqlite for in-process reads and
+ * falls back to the sqlite3 CLI on runtimes where node:sqlite is unavailable.
  * Returns null when neither is usable — callers degrade gracefully (e.g. the
  * Cursor adapter reports not-detected).
  */
 export async function openReadOnly(dbPath: string): Promise<SqliteReader | null> {
-  return trySqlite3Cli(dbPath) ?? (await tryNodeSqlite(dbPath));
+  return (await tryNodeSqlite(dbPath)) ?? trySqlite3Cli(dbPath);
 }


### PR DESCRIPTION
## What this adds

SPEC-0063: the verification loop gets ~2–3× faster at every tier — local suite, CI verify job, and the full release preflight — without removing, weakening, or skipping a single gate. Same commands, same coverage, byte-identical output.

## What changed

- `src/parse/sqlite.ts` — `openReadOnly` prefers in-process `node:sqlite`; the `sqlite3` CLI (previously a subprocess **per query**) becomes the fallback for runtimes without it, with its `-version` probe cached. A scoped, idempotent `emitWarning` filter suppresses only the SQLite `ExperimentalWarning` (it embeds the PID — a determinism hazard). Both readers share one error contract: failing queries yield `[]`, never a throw.
- `scripts/verify-goldens.mjs` — content-hash compile cache under `node_modules/.cache/aireceipts-goldens/` (key: compiler options, TS version, `package.json` `type`, all source + `data/` contents). Immutable entries with sentinel + entrypoint validation, rename-race handling, corrupt-entry eviction, and fresh-compile fallback on any cache failure. CLI contract unchanged — the determinism gate stops paying for 10 identical tsc compiles.
- `scripts/preflight-release.mjs` — the `dist/` writers (manifest → build → tarball) run serially first, then every remaining gate runs concurrently; determinism starts once verify-goldens warms the cache. Exports, gate commands, `--quick` semantics, and the fixed-order failure summary are unchanged.
- `specs/SPEC-0063-fast-feedback.md` — the spec (R1–R7, `building`).

## What to review, in order

1. **The riskiest decision — reader preference swap**, `src/parse/sqlite.ts:106-113`: Node ≥22.13 now parses transcripts via `node:sqlite` while Node 20 keeps the CLI path. Mitigations: identical `[]`-on-error contract (`src/parse/sqlite.ts:69-77`), warning filter installed before the import (`src/parse/sqlite.ts:38-48`), and the CI matrix itself is the proof — the node 20 job exercises the fallback, node 22 the new path, both against the same goldens + determinism ×10.
2. **Cache correctness**, `scripts/verify-goldens.mjs:93-105` (key completeness) and `:171-210` (hit/miss, race, eviction). A wrong key silently verifies stale code; the key covers every compiler input plus `data/`.
3. **Preflight scheduling**, `scripts/preflight-release.mjs:164-207`: confirm nothing that touches `dist/` runs concurrently with the build/pack pair.

## Evidence

Gates (unmasked): tsc 0 · eslint 0 · vitest 0 (120 files, 1535/1535) · goldens 0 (102 artifacts byte-identical) · determinism ×10 0 · spec-lint 0 (61 specs) · hygiene 0. Full `preflight-release.mjs`: RELEASE-READY, 11/11.

Spec: `specs/SPEC-0063-fast-feedback.md`.

Measured on one machine (before → after):

| Path | Before | After |
|---|---|---|
| `npx vitest run` wall | 58s | 20–25s |
| summed per-file test time | 282s | 34.5s |
| slowest file (`test/parse/opencode.test.ts`) | 56.7s | off the top-10 (<1s) |
| `verify-goldens` warm | 1.45s | 0.15s |
| determinism ×10 | 14.5s | 1.9s |
| full release preflight | ~95s | 33s |

CI verify job's `determinism` step (36s of every run) drops to seconds; the `test` step shrinks with the spawn storm gone.

Independent critic (Codex, deep effort, per `/review-pr`): first pass REJECT with two findings — the `node:sqlite` error-contract divergence and the corrupt-cache sentinel hole — both fixed in this diff; re-review PASS on all sections with gates re-run independently. Receipt comment: posted via `pr --post` (see below).

## Notes

Same-author disclosure: built and orchestrated by Claude; the recorded deep review is Codex (different model family) per the maintainer directive in `/review-pr`. Remaining long pole is `test/cli-e2e/built-cli.test.ts` (~18s) — genuine packaging proof (build + pack + install + ~20 real CLI runs), intentionally untouched. Not in scope: dropping Node 20 (EOL) from the matrix — flagged as a separate maintainer decision in the spec's non-goals.
