### PR TITLE
perf: drop Node 20 from CI matrix, cover sqlite3-CLI fallback directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        # Node 20 is EOL; CI runs a single supported version. `engines` still
+        # allows >=20, and the one path the dropped Node 20 job used to cover —
+        # the sqlite3-CLI fallback, exercised only when node:sqlite is absent —
+        # now has direct coverage in test/parse/sqlite.test.ts (forced-CLI +
+        # node:sqlite parity), so a single Node version loses no coverage.
+        node-version: [22]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/specs/SPEC-0063-fast-feedback.md
+++ b/specs/SPEC-0063-fast-feedback.md
@@ -34,9 +34,13 @@ I1/I5: determinism is proven more often per minute, not less).
   embeds the PID) never reaches stderr: a process-wide, idempotent `emitWarning` filter
   — installed once before the first import, never uninstalled, safe under concurrent
   adapter discovery — suppresses exactly that warning and nothing else.
-- **R3** — Receipt output stays byte-identical on both reader paths. The CI matrix
-  already proves this: Node 20 jobs exercise the CLI fallback, Node 22 jobs exercise
-  `node:sqlite`, and both must pass the same goldens + determinism gates.
+- **R3** — Receipt output stays byte-identical on both reader paths.
+  `test/parse/sqlite.test.ts` proves it end-to-end: it renders the full opencode
+  receipt (real adapter SQL — `json_extract`/`json_each` aggregates, message loading)
+  once through the sqlite3-CLI reader and once through `node:sqlite` and asserts the
+  two receipts are byte-identical, plus direct reader-level checks (real-data reads and
+  the `[]`-on-error contract). So the fallback stays covered even though CI runs a
+  single Node version (see the CI-matrix note under Non-goals).
 - **R4** — `verify-goldens.mjs` keeps its exact CLI contract (same invocation, same
   output, argv passthrough) but caches the compiled output under
   `node_modules/.cache/aireceipts-goldens/<hash>`, keyed by the content of every
@@ -63,8 +67,9 @@ I1/I5: determinism is proven more often per minute, not less).
 - **Given** Node ≥ 22.13 **When** any adapter opens a transcript DB **Then** queries run
   in-process via `node:sqlite`, stderr carries no ExperimentalWarning, and the rendered
   receipt is byte-identical to the sqlite3-CLI rendering of the same transcript.
-- **Given** Node 20 (no `node:sqlite`) **When** the same DB is opened **Then** the
-  sqlite3 CLI fallback is used and all goldens still pass.
+- **Given** a runtime without `node:sqlite` (Node 20, or Node 22 before it was
+  built in) **When** the same DB is opened **Then** the sqlite3 CLI fallback is used
+  and returns rows identical to the `node:sqlite` path.
 - **Given** two concurrent `verify-goldens.mjs` runs on a cold cache **When** both
   compile **Then** one entry wins the rename, both runs verify successfully, and no
   partially-written entry is ever read (sentinel).
@@ -76,8 +81,11 @@ I1/I5: determinism is proven more often per minute, not less).
 
 ## Non-goals
 
-- Dropping Node 20 from the support matrix or the CI matrix (EOL, but `engines` still
-  says `>=20`; a support-policy change is a separate maintainer decision).
+- Dropping Node 20 *support*: `engines` stays `>=20`, so Node 20 users still install
+  and run. The Node 20 **CI-matrix** job was removed as a follow-up (maintainer
+  decision, 2026-07-06) — it duplicated the Node 22 coverage except for the sqlite3-CLI
+  fallback path, which `test/parse/sqlite.test.ts` now covers directly. Bumping
+  `engines` to `>=22` (a user-facing breaking change) remains a separate future call.
 - Reducing determinism runs below 10, skipping tests, or weakening/removing any gate —
   the point is faster proof, not less proof.
 - Caching across CI jobs (actions/cache for the goldens build): each job compiles once
@@ -91,7 +99,7 @@ I1/I5: determinism is proven more often per minute, not less).
 |---|---|---|
 | R1 node:sqlite preferred | Node ≥ 22.13, fixture DB | in-process reads; probe cached; CLI used only when node:sqlite absent |
 | R2 warning suppressed | node:sqlite path active | no ExperimentalWarning on stderr; non-SQLite warnings pass through |
-| R3 both paths byte-equal | Node 20 (CLI) and Node 22 (node:sqlite) CI jobs | same goldens pass on both |
+| R3 both paths byte-equal | full opencode receipt rendered via CLI reader and node:sqlite (`test/parse/sqlite.test.ts`) | byte-identical receipts; CLI real-data + `[]`-on-error hold |
 | R4 cache hit | 2nd verify-goldens run, no edits | no tsc invocation; identical stdout; exit 0 |
 | R4 cache invalidation | edit a src file / a price table | key changes; recompile; exit reflects verification result |
 | R4 concurrent cold cache | two simultaneous runs | both exit 0; single valid (sentinel-complete) cache entry |

--- a/src/parse/sqlite.ts
+++ b/src/parse/sqlite.ts
@@ -110,6 +110,16 @@ function trySqlite3Cli(dbPath: string): SqliteReader | null {
   };
 }
 
+// Test-only: pin which backend openReadOnly uses. CI runs a single Node version
+// (node:sqlite present), so the sqlite3-CLI fallback is otherwise never reached;
+// pinning "cli" lets a test drive the full parse→render pipeline through it and
+// prove the receipt is byte-identical to the node:sqlite path. null = normal
+// auto-select; product code never sets this.
+let forcedReaderForTests: "cli" | "node" | null = null;
+export function __setForcedReaderForTests(reader: "cli" | "node" | null): void {
+  forcedReaderForTests = reader;
+}
+
 /**
  * Open a SQLite database read-only. Prefers node:sqlite for in-process reads and
  * falls back to the sqlite3 CLI on runtimes where node:sqlite is unavailable.
@@ -117,5 +127,15 @@ function trySqlite3Cli(dbPath: string): SqliteReader | null {
  * Cursor adapter reports not-detected).
  */
 export async function openReadOnly(dbPath: string): Promise<SqliteReader | null> {
+  if (forcedReaderForTests === "cli") return trySqlite3Cli(dbPath);
+  if (forcedReaderForTests === "node") return await tryNodeSqlite(dbPath);
   return (await tryNodeSqlite(dbPath)) ?? trySqlite3Cli(dbPath);
 }
+
+/**
+ * Test-only seam: each reader backend, exposed so the sqlite3-CLI fallback keeps
+ * direct unit coverage (real-data reads + the `[]`-on-error contract) alongside
+ * the end-to-end render parity that `__setForcedReaderForTests` enables. Not for
+ * product use.
+ */
+export const __sqliteReadersForTests = { tryNodeSqlite, trySqlite3Cli };

--- a/test/parse/sqlite.test.ts
+++ b/test/parse/sqlite.test.ts
@@ -1,0 +1,92 @@
+// The sqlite3-CLI fallback reader used to be covered only implicitly, by the
+// Node 20 CI job (no node:sqlite → fall back to the CLI). With CI down to a
+// single Node version that ships node:sqlite, that path would go dark. This
+// covers it directly at two levels:
+//   1. the reader itself — real-data reads + the []-on-error contract;
+//   2. end-to-end — the full opencode parse→render pipeline driven through the
+//      CLI reader must produce a receipt byte-identical to the node:sqlite path
+//      (the equivalence the Node 20-vs-22 CI split used to guarantee).
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { OpenCodeAdapter } from "../../src/parse/opencode.js";
+import { __setForcedReaderForTests, __sqliteReadersForTests } from "../../src/parse/sqlite.js";
+import { buildReceiptModel } from "../../src/receipt/model.js";
+import { renderReceipt } from "../../src/receipt/render.js";
+
+const { tryNodeSqlite, trySqlite3Cli } = __sqliteReadersForTests;
+
+const fixturesDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../fixtures/opencode");
+const dataDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../data/prices");
+const fixtures = [
+  { db: "clean-multi-vendor.db", sessionId: "ses_clean" },
+  { db: "loop-shell-3x.db", sessionId: "ses_loop" },
+] as const;
+
+const sqlite3Available = (() => {
+  const probe = spawnSync("sqlite3", ["-version"], { encoding: "utf8" });
+  return !probe.error && probe.status === 0;
+})();
+
+// The forks pool runs with --experimental-sqlite, so node:sqlite is normally
+// present — but detect rather than assume, so this file never hard-fails a
+// runtime that lacks it.
+const nodeSqliteReader = await tryNodeSqlite(path.join(fixturesDir, fixtures[0].db));
+const nodeSqliteAvailable = nodeSqliteReader !== null;
+nodeSqliteReader?.close();
+
+describe.skipIf(!sqlite3Available)("sqlite3 CLI fallback reader", () => {
+  for (const { db, sessionId } of fixtures) {
+    const dbPath = path.join(fixturesDir, db);
+
+    it(`reads real rows from ${db}`, () => {
+      const reader = trySqlite3Cli(dbPath);
+      expect(reader).not.toBeNull();
+      try {
+        expect(reader!.all("SELECT id FROM session ORDER BY id")).toEqual([{ id: sessionId }]);
+      } finally {
+        reader!.close();
+      }
+    });
+  }
+
+  it("returns [] for a failing query — same contract as node:sqlite", () => {
+    const reader = trySqlite3Cli(path.join(fixturesDir, fixtures[0].db));
+    try {
+      expect(reader!.all("SELECT * FROM does_not_exist")).toEqual([]);
+    } finally {
+      reader!.close();
+    }
+  });
+});
+
+// Renders the full opencode receipt through a pinned reader — exercises the real
+// adapter SQL (json_extract/json_each aggregates, message loading), not just a
+// bare row read.
+async function renderVia(reader: "cli" | "node", dbPath: string): Promise<string> {
+  __setForcedReaderForTests(reader);
+  try {
+    const adapter = new OpenCodeAdapter({ dbPath });
+    const session = await adapter.loadSession(dbPath);
+    if (!session) throw new Error(`loadSession returned null via ${reader} for ${dbPath}`);
+    return renderReceipt(await buildReceiptModel(session, dataDir), { color: false });
+  } finally {
+    __setForcedReaderForTests(null);
+  }
+}
+
+describe.skipIf(!sqlite3Available || !nodeSqliteAvailable)("receipt parity: sqlite3 CLI vs node:sqlite", () => {
+  afterEach(() => __setForcedReaderForTests(null));
+
+  for (const { db } of fixtures) {
+    const dbPath = path.join(fixturesDir, db);
+
+    it(`renders a byte-identical receipt from ${db} on both reader paths`, async () => {
+      const viaNode = await renderVia("node", dbPath);
+      const viaCli = await renderVia("cli", dbPath);
+      expect(viaCli).toBe(viaNode);
+      expect(viaCli.length).toBeGreaterThan(0);
+    });
+  }
+});


### PR DESCRIPTION
## What this adds

Follow-up to SPEC-0063: the CI `verify` job stops running twice. Node 20 is EOL, so the matrix drops to Node 22 only — one fewer full job (~58s) per CI run. **This is a CI-cost change, not a support drop:** `engines.node` stays `>=20`, so Node 20 users still install and run.

## What changed

- `.github/workflows/ci.yml` — `verify` matrix `[20, 22]` → `[22]` (kept as a one-entry matrix so the `verify (22)` check name stays stable for branch protection).
- `src/parse/sqlite.ts` — two test-only seams (matching the repo's `__resetQueueForTests` precedent): `__sqliteReadersForTests` (each reader backend) and `__setForcedReaderForTests` (pin the backend so the full pipeline can be driven through the CLI reader).
- `test/parse/sqlite.test.ts` — new; see below.
- `specs/SPEC-0063-fast-feedback.md` — R3, its scenario, test-matrix row, and the non-goal updated to record the decision and the real proof.

## What to review, in order

1. **The one real risk — lost coverage.** The dropped Node 20 job was the *only* thing exercising the sqlite3-CLI fallback in `src/parse/sqlite.ts` (Node 22 uses `node:sqlite`; the CLI is reached only when `node:sqlite` is absent). `test/parse/sqlite.test.ts:67-92` closes that gap: it renders the **full opencode receipt** — real adapter SQL, the `json_extract`/`json_each` aggregates at `src/parse/opencode.ts:346-389` — once through the CLI reader and once through `node:sqlite`, and asserts the two receipts are **byte-identical**. That's the equivalence the Node 20-vs-22 split used to guarantee implicitly. Plus reader-level checks: real-data reads and the `[]`-on-error contract.
2. **The seam**, `src/parse/sqlite.ts:117-137`: `__setForcedReaderForTests` adds one trivial branch to `openReadOnly`, is test-only (product never sets it), and is reset in `finally` + `afterEach`. Forcing `"cli"` returns `trySqlite3Cli` with no `node:sqlite` fallback, so the parity test can't pass vacuously.
3. **The SPEC edits** — confirm R3 (`specs/SPEC-0063-fast-feedback.md:37`) and the non-goal now tell the truth; the old R3 claimed the Node 20 CI job proved the fallback, which this change makes false.

## Evidence

Gates (unmasked): tsc 0 · eslint 0 · vitest 1540/1540 (121 files; the 5 new sqlite tests run, no skips) · goldens 102 byte-identical · determinism ×10 0 · spec-lint 0 · hygiene 0.

Spec: `specs/SPEC-0063-fast-feedback.md` (`building`).

Independent critic (Codex, deep effort, per `/review-pr`): first pass REJECT — R3 was an overclaim (the test then compared only one narrow query, not the aggregate-bearing receipt path); fixed by rendering the full receipt through both readers; re-review **APPROVE, no findings**, gates re-run independently.

## Notes

Same-author disclosure: built by Claude, deep review by Codex (different model family) per the maintainer directive in `/review-pr`. Not in scope: bumping `engines` to `>=22` (a user-facing breaking change) — left as a separate future decision in the spec's non-goals. CI wall-clock for the whole check suite drops by roughly one `verify` job.
