### PR TITLE
feat: SPEC-0064 pin PR-receipt check at @latest; draft npm-native pr-check

### DIFF
--- a/.github/workflows/pr-receipt-check.yml
+++ b/.github/workflows/pr-receipt-check.yml
@@ -7,10 +7,12 @@ name: pr-receipt-check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  # SPEC-0030 R3 — reusable: other repos adopt with a 3-line caller
-  # (docs/adopt/pr-receipt-check-caller.yml). Callers must reference
-  # anandgupta42/receipts — GitHub does NOT redirect reusable-workflow
-  # references after a rename, so callers are created only post-rename.
+  # SPEC-0030 R3 / SPEC-0064 R1 — reusable: other repos adopt with a 3-line
+  # caller (docs/adopt/pr-receipt-check-caller.yml) that pins `@latest`, a moving
+  # tag tracking the newest published release (advanced by release-publish.yml).
+  # Callers must reference anandgupta42/receipts — GitHub does NOT redirect
+  # reusable-workflow references after a rename, so callers are created only
+  # post-rename.
   workflow_call: {}
 
 permissions:
@@ -26,6 +28,12 @@ jobs:
       # CALLER's repo, which does not carry scripts/check-pr-receipt.mjs.
       # Same-repo runs get main's copy of the script — a PR cannot tamper
       # with the verdict logic it is being checked by.
+      #
+      # The internal ref stays `main` even though callers pin the workflow at
+      # `@latest` (SPEC-0064 R1): this repo's own dogfood CI checks against the
+      # freshest verdict script, and the presence-grep is backward-compatible by
+      # design. Version-coherent packaging — the script frozen to the pinned ref
+      # — is the composite action's job (SPEC-0057), not the reusable workflow's.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: anandgupta42/receipts

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -161,6 +161,18 @@ jobs:
             git push origin "refs/tags/${TAG}"
           fi
 
+      - name: advance the `latest` moving tag to this release
+        # SPEC-0064 R1 — external adopters pin the reusable workflow at
+        # `@latest`; this tag tracks the newest published release so `@latest`
+        # always resolves to a release-gated commit. Unlike the immutable `v*`
+        # tags above, `latest` is intentionally FORCE-MOVED on every publish.
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f latest "${GITHUB_SHA}"
+          git push -f origin refs/tags/latest
+
       - name: create GitHub Release v${{ env.VERSION }}
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/adopt/pr-receipt-check-caller.yml
+++ b/docs/adopt/pr-receipt-check-caller.yml
@@ -2,8 +2,10 @@
 # .github/workflows/pr-receipt-check.yml. It is notice-only by default; set
 # AIRECEIPTS_REQUIRE_PR_RECEIPT=true to enforce same-repo PRs. Generation is
 # local; see https://github.com/anandgupta42/receipts/blob/main/docs/pr-receipts.md.
+# `@latest` is a moving tag that tracks the newest published release and is
+# advanced on every publish (SPEC-0064 R1); pin a `v*` tag instead for a frozen ref.
 name: pr-receipt-check
 on: [pull_request]
 jobs:
   check:
-    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@main
+    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest

--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -95,7 +95,7 @@ who viewed which receipt.
    on: [pull_request]
    jobs:
      check:
-       uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@main
+       uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest
    ```
 
 2. Add one line to `CONTRIBUTING.md`:

--- a/scripts/rollout-dogfood.mts
+++ b/scripts/rollout-dogfood.mts
@@ -19,7 +19,7 @@ export const CALLER_YAML = `name: pr-receipt-check
 on: [pull_request]
 jobs:
   check:
-    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@main
+    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest
 `;
 export const CONTRIBUTING_LINE =
   "Before opening a PR, run `npx aireceipts-cli pr --post` to attach your build receipt.";

--- a/specs/SPEC-0030-release-readiness.md
+++ b/specs/SPEC-0030-release-readiness.md
@@ -121,6 +121,11 @@ jobs:
     uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@main
 ```
 
+> **Superseded (SPEC-0064 R1):** callers now pin `@latest` — a moving tag that
+> tracks the newest published release, advanced by `release-publish.yml` on every
+> publish — instead of `@main`. The template above records what R3 originally
+> shipped; the live template is `docs/adopt/pr-receipt-check-caller.yml`.
+
 R1 sequencing checklist (maintainer + agent interleaved, executed as one
 continuous window):
 1. URL-cutover PR opened, CI green, held unmerged.

--- a/specs/SPEC-0064-check-distribution.md
+++ b/specs/SPEC-0064-check-distribution.md
@@ -1,0 +1,98 @@
+---
+id: SPEC-0064
+title: PR-receipt check — release-pinned distribution and an npm-native pr-check
+status: draft
+milestone: M5
+depends: [SPEC-0019, SPEC-0030, SPEC-0057]
+---
+
+# SPEC-0064: PR-receipt check — release-pinned distribution and an npm-native pr-check
+
+## Purpose
+
+Adopters wire the CI presence check by pinning the reusable workflow at `@main` — a
+moving branch on a personal repo, with no release gate. This spec does two things. **R1
+(ship now):** move the adopter pin to `@latest`, a moving tag that tracks the newest
+*published* release and is advanced automatically on every publish, so an org rollout
+pins a release-gated ref instead of raw `main`. **R2–R4 (follow-up):** publish the
+verdict as an `aireceipts pr-check` command so CI can run `npx aireceipts-cli@latest
+pr-check` with no GitHub-repo `uses:` reference at all — the only packaging that removes
+the personal-repo dependency entirely.
+
+The check only ever *reads a PR's comments* for the marked receipt; generation stays on
+the developer's machine (`npx aireceipts-cli pr --post`). This serves **I1/I4**
+(local-first; zero transcript exposure on the runner) and the "one verdict, N packagings"
+principle established with SPEC-0057: the verdict logic in `scripts/check-pr-receipt.mjs`
+is the single source of truth behind the reusable workflow, the composite action
+(SPEC-0057), and — with R2 — the published CLI.
+
+## Requirements
+
+- **R1** — A moving `latest` git tag tracks the newest published release. Caller
+  templates (`docs/adopt/pr-receipt-check-caller.yml`, the `rollout-dogfood` generator,
+  `docs/pr-receipts.md`, `aireceipts integrations`) pin the reusable workflow at
+  `@latest`. `release-publish.yml`'s `tag-and-release` job force-moves `latest` to the
+  published commit on every publish. The reusable workflow's *internal* self-checkout
+  stays `ref: main` (freshest verdict script for this repo's own dogfood CI; the grep is
+  backward-compatible by design).
+- **R2** — An `aireceipts pr-check` command exposes the `check-pr-receipt.mjs` verdict
+  (`found` / `missing-notice` / `missing-required`) through the published package. It
+  accepts a comments JSON on stdin/path (CI passes the `gh api` output) with
+  `--head-repo`, `--base-repo`, and `--require-same-repo` flags, mirroring the script's
+  interface. Exit code is `0` for `found`/`missing-notice` and `1` for `missing-required`
+  — the CLI never fails a build unless enforcement is opted in.
+- **R3** — The render/native path (`@resvg/resvg-js`) is lazily imported so `pr-check`
+  runs without loading it. A cold `npx aireceipts-cli@latest pr-check` in CI must not
+  download or build native bindings it does not use.
+- **R4** — A documented npm-native caller (`docs/adopt/`) runs the check via
+  `npx aireceipts-cli@latest pr-check` with no `uses:` reference. `pr-check` also runs
+  locally (a developer checks whether their PR carries a receipt before pushing).
+
+## Scenarios
+
+- **Given** an adopter repo pins `@latest`, **when** a new release publishes, **then**
+  `release-publish.yml` moves `latest` to that commit and the adopter's next run resolves
+  the release-gated workflow with no edit on their side.
+- **Given** a PR carries the marked receipt comment, **when** `aireceipts pr-check` reads
+  the comments JSON, **then** it prints `found` and exits `0`.
+- **Given** a same-repo PR with no receipt and `--require-same-repo`, **when** `pr-check`
+  runs, **then** it prints `missing-required` and exits `1`; a fork PR under the same flag
+  stays `missing-notice`, exit `0`.
+- **Given** a cold CI runner, **when** it runs `npx aireceipts-cli@latest pr-check`,
+  **then** no `@resvg/resvg-js` native binary is fetched or built.
+
+## Non-goals
+
+- **Generating receipts in CI.** Generation stays local (I1/I4); the runner has no
+  transcripts and does no pricing work. `pr-check` is a presence checker, never a renderer.
+- **Replacing the reusable workflow or the SPEC-0057 composite action.** Three packagings
+  of one verdict coexist; the adopter picks (reusable workflow / composite action for a
+  GitHub-native `uses:` pin, npm CLI for a GitHub-repo-free pin). Reason: each fits a
+  different adopter constraint and they share `check-pr-receipt.mjs`.
+- **Changing the receipt marker or verdict semantics.** `DOGFOOD_MARKER` and the three
+  verdicts are unchanged; R2 only re-packages them. The marker-parity test stays the gate.
+- **SHA-pinning policy for adopters.** `@latest` is the documented default; adopters who
+  want a frozen ref pin a `v*` tag. This spec does not mandate one over the other.
+
+## Test matrix
+
+| Req | Case | Input | Expected |
+|---|---|---|---|
+| R1 | Caller templates pinned | all live caller snippets | reference `@latest`, not `@main` |
+| R1 | Release moves tag | `release-publish.yml` | a step force-moves `latest` to `${GITHUB_SHA}` |
+| R1 | Internal ref unchanged | `pr-receipt-check.yml` | self-checkout stays `ref: main` |
+| R2 | pr-check found | comments JSON with marker | stdout `found`, exit 0 |
+| R2 | pr-check missing-notice | comments JSON, no marker, no enforce | stdout `missing-notice`, exit 0 |
+| R2 | pr-check missing-required | no marker, `--require-same-repo`, same-repo | stdout `missing-required`, exit 1 |
+| R3 | Lean check path | `pr-check` invocation | no `@resvg/resvg-js` import on the code path |
+| R4 | npm-native caller | `npx aireceipts-cli@latest pr-check` | resolves with no `uses:` reference; same command runs locally |
+
+## Success criteria
+
+- [ ] R1 landed: every live caller template pins `@latest`; `release-publish.yml` advances
+      the tag; a bootstrap `latest` tag exists at the current release.
+- [ ] R2–R4: `aireceipts pr-check` ships in `dist/`, verdict parity with
+      `check-pr-receipt.mjs` is asserted by a test, and the render path stays lazy.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked
+      (`echo $?`).

--- a/src/setup/integrations.ts
+++ b/src/setup/integrations.ts
@@ -139,7 +139,7 @@ export const INTEGRATION_RECIPES: readonly IntegrationRecipe[] = [
       "on: [pull_request]",
       "jobs:",
       "  check:",
-      "    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@main",
+      "    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest",
       "```",
     ].join("\n"),
     notes: [


### PR DESCRIPTION
## What this adds

Pins the PR-receipt CI check at a release-gated `@latest` moving tag instead of `@main`, and drafts SPEC-0064 for an npm-native `aireceipts pr-check` command. This unblocks rolling the check out across the org without pinning adopters to raw `main`.

## Why it matters to users

- Adopters (and the AltimateAI org rollout) pin `uses: …@latest`, a tag that tracks the newest **published** release, instead of the moving `@main` branch.
- `@latest` advances automatically on every publish — no adopter edits on release.
- A frozen pin is still one line away (`@v0.3.0`).

## See it

The caller template adopters copy (`docs/adopt/pr-receipt-check-caller.yml`):

```yaml
name: pr-receipt-check
on: [pull_request]
jobs:
  check:
    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest
```

The rollout generator now emits `@latest` per repo:

```
    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest
```

## What changed

- `docs/adopt/pr-receipt-check-caller.yml`, `scripts/rollout-dogfood.mts` (`CALLER_YAML`), `docs/pr-receipts.md`, `src/setup/integrations.ts` → caller ref `@main` → `@latest`.
- `.github/workflows/release-publish.yml` → the `tag-and-release` job force-moves `latest` to the published commit on each publish (the immutable `v*` tags are untouched).
- `.github/workflows/pr-receipt-check.yml` → comments document the `@latest` pin; the internal self-checkout deliberately stays `ref: main`.
- `specs/SPEC-0030-release-readiness.md` → superseding note on R3's verbatim template.
- `specs/SPEC-0064-check-distribution.md` (new) → the whole arc: R1 `@latest` pin (this PR), R2–R4 npm `pr-check` (draft).
- Bootstrap `latest` tag pushed → `55198e0` (the v0.3.0 commit, = npm `latest`).

## What to review, in order

1. `.github/workflows/release-publish.yml` — the force-move step: moving `latest` on every publish, scoped so it never touches `v*`. (riskiest decision)
2. `.github/workflows/pr-receipt-check.yml` — keeping internal `ref: main` while callers pin `@latest` (documented tradeoff; version-coherent packaging is SPEC-0057's composite-action job).
3. `specs/SPEC-0064-check-distribution.md` — R1 (shipped here) vs draft R2–R4; reconciliation with in-flight SPEC-0057.
4. The 4 caller-template edits — `@latest` consistent across every live template.

## Evidence

Gates (unmasked, all exit `0`): `tsc`, `eslint --max-warnings 0`, `vitest` 1535/1535, `verify-goldens`, `determinism-check` 10× byte-identical, `spec-lint` (62 OK), `hygiene`.
Spec: `specs/SPEC-0064-check-distribution.md` (draft — needs maintainer approval).
Independent review: Codex (different model family), deep effort — **PASS, no findings** (verdict pasted as a comment).

## Notes

- `site/docs/*.html` deliberately **not** regenerated here: the committed site HTML is systematically stale on `main` (the site build isn't in CI, so it rots — 8 pages drift). Recommend a follow-up "regen site + add a CI freshness check" PR.
- Follow-up (Codex non-blocking suggestion): a drift-guard test asserting live caller snippets stay `@latest`.
- R2–R4 (the npm `pr-check` command) are draft; implementation is the follow-up step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
