### PR TITLE
feat: SPEC-0065 Phase 1 — store=ref PR-receipt producer

### DIFF
--- a/goldens/cli/help.txt
+++ b/goldens/cli/help.txt
@@ -24,13 +24,17 @@ Usage:
   aireceipts week [--by-project] [--since <date>] [--json]
                                         trailing-7-day digest across sessions
   aireceipts pr [--post] [--session <id>] [--artifact] [--no-details] [--share]
+                [--store <comment|ref>]
                                         attach the building session's receipt to
                                          the current PR (dry-run prints the body;
                                          --post upserts it via gh; --artifact also
                                          publishes pr-<n>.html to the
                                          aireceipts/artifacts branch and links it;
                                          --share prints ready-to-paste X/LinkedIn
-                                         intent URLs to stderr, requires --artifact)
+                                         intent URLs to stderr, requires --artifact;
+                                         --store ref also writes the receipt to
+                                         refs/receipts/<slug> (SPEC-0065); default
+                                         comment)
   aireceipts --check-budget             exit 1 if ~/.aireceipts/budget.json's cap is
                                          exceeded (advisory; see docs)
   aireceipts benchmark [--dry-run]      opt-in cost-per-turn benchmark (v1: client

--- a/specs/SPEC-0065-seamless-receipts.md
+++ b/specs/SPEC-0065-seamless-receipts.md
@@ -1,0 +1,139 @@
+---
+id: SPEC-0065
+title: Seamless PR receipts — pre-push hook, store=ref, CI posts from the ref
+status: approved
+milestone: M5
+depends: [SPEC-0019, SPEC-0037, SPEC-0064]
+---
+
+# SPEC-0065: Seamless PR receipts — pre-push hook, store=ref, CI posts from the ref
+
+## Purpose
+
+Today a receipt reaches a PR only if a human/agent remembers to run `npx aireceipts-cli
+pr --post` with local `gh` auth. If they forget, the PR has no receipt — the exact miss
+the org rollout can't tolerate. This spec makes the receipt **attach itself**: a
+committed pre-push git hook generates it locally and stores it as a git ref
+(`refs/receipts/<slug>`) that travels with the push; CI reads the ref and renders + posts
+the PR comment itself (no dev `gh` auth), enforcing presence when a repo opts in.
+
+The hard boundary is unchanged and load-bearing: **CI never generates a receipt** — the
+transcript lives only on the developer's machine (I1/I4). CI only transports and renders
+what the local hook already produced. The pattern is proven in a sibling internal build
+(`store=ref`); this ports it to aireceipts with byte-identical receipts (I1/I5): the
+ref's wrapping commit is dated from the session's own `endedAt`, never wall-clock, so the
+same transcript yields the same object SHA.
+
+## Requirements
+
+- **R1 — `store=ref` producer + stored payload schema.** `src/pr/store.ts` writes a
+  **schema-versioned PR-receipt payload** — NOT the single-session `toJsonModel()` export,
+  which carries no way to rebuild the comment (Codex plan-review, BLOCKER). The payload is
+  the exact renderer input, all already JSON-plain data:
+  `PrReceiptPayload = { schemaVersion: number; bodyInput: PrBodyInput; extras: PrBodyExtras }`
+  (`src/pr/body.ts`). `store.ts` owns `serializePrReceipt` (JSON) / `deserializePrReceipt`
+  (parse + schema-validate) as the round-trip; feeding the deserialized payload to the
+  existing `renderPrBody` must reproduce the comment byte-for-byte. **String fields inside
+  the payload stay untrusted across the CI trust boundary — sanitizing them at render time
+  is SPEC-0066's job, not the producer's.** It is written as a git object on `refs/receipts/<slug>` via pure plumbing
+  (`hash-object -w` → `mktree` with one `receipt.json` → `commit-tree` → `update-ref`),
+  touching no index or worktree, through a **dedicated fixed-env git invocation** (the
+  existing `CommandRunner` has no env seam): `GIT_AUTHOR_*`/`GIT_COMMITTER_*` pinned to a
+  fixed identity, date `<epochSeconds> +0000` (explicit UTC), fixed commit message, single
+  tree entry. The commit date is derived deterministically from the receipt model —
+  `max(startedAtMs + durationMs)` across contributing sessions — both are optional on
+  `ReceiptModel`, so the derivation skips any model missing either field and falls to `0`
+  (epoch, clamped ≥ 1) when none qualify; never wall-clock, so it stays deterministic. `slug` comes from a **new shared
+  `receiptRefSlug(branch)` helper** used identically by CLI, hook, and CI (there is no
+  existing branch-slug helper to reuse). Surfaced as `aireceipts pr --store ref` and
+  `AIRECEIPTS_STORE=ref`; default stays `comment` (opt-in first).
+- **R2 — pre-push hook.** `.githooks/pre-push` acts only on a branch push (guards on
+  `refs/heads/*` from stdin), runs `aireceipts pr --store ref`, then pushes the ref
+  (`git push <remote> +refs/receipts/<slug>:refs/receipts/<slug>`). The nested ref push
+  carries no `refs/heads/*`, so the same branch guard prevents recursion — **no
+  commit-then-re-push dance, no second `git push` for the user.** Every failure path is
+  best-effort: no session, not a repo, or push failure ⇒ one stderr line, the branch push
+  proceeds. It never blocks a push.
+- **R3 — repo-level activation, not per-user.** `package.json` `prepare` runs
+  `git config core.hooksPath .githooks` (activates on `npm install` for this repo's
+  contributors). The store default is repo-settable in a committed file
+  (`.claude/settings.json` env `AIRECEIPTS_STORE=ref`); precedence: flag > process env >
+  committed settings > default (`comment`). **Honest limit documented:** git never
+  auto-runs fetched hooks, so non-`npm install` adopters need a one-line
+  `git config core.hooksPath .githooks` (or the CI-only path) — CI (R4) is the only
+  universal, install-free layer.
+- **R4 — CI consumer: split to SPEC-0066 (the trust boundary).** The CI side — fetch
+  `refs/receipts/<slug>`, validate the **untrusted, fork-author-controlled** payload against
+  its `schemaVersion`, sanitize every string field (neutralize code fences, Markdown links,
+  HTML `<details>`; reject non-finite numbers, cap lengths, reject unknown fields), render
+  through the hardened renderer, upsert via `GITHUB_TOKEN` (workflow gains
+  `pull-requests: write`), and opt-in enforce — is specified and built in **SPEC-0066**,
+  which carries its own injection/security review. SPEC-0065 ships the producer, hook, and
+  local tooling (R1–R3, R5–R6); the ref R1 writes is SPEC-0066's input, and the payload
+  round-trip contract (`PrReceiptPayload`) is the seam both sides build to. The matrix rows
+  below state that seam contract; their CI-side verification lives in SPEC-0066.
+- **R5 — local tooling reads refs.** `aireceipts --list` / `week` / `stats` include
+  ref-stored receipts (`git for-each-ref refs/receipts`) alongside file/session discovery;
+  a prune deletes local+remote receipt refs for merged/gone branches.
+- **R6 — determinism + tests.** Same transcript ⇒ same object bytes (dated from
+  `endedAt`). Tests: plumbing round-trip (write ref → read back byte-identical); hook
+  branch-guard + recursion guard; store precedence chain; CI locate order (comment beats
+  ref; ref-only; neither); fork-fetch degrade; determinism-check stays green.
+
+## Scenarios
+
+- **Given** `AIRECEIPTS_STORE=ref` and a matching session, **when** the developer runs
+  `git push`, **then** the pre-push hook writes and pushes `refs/receipts/<slug>` and the
+  branch push completes with no second push.
+- **Given** a PR whose branch carries a receipt ref, **when** CI runs, **then** it fetches
+  the ref, renders the comment from it, upserts the marked comment via `GITHUB_TOKEN`, and
+  the check is green — the developer ran no `pr --post` and needed no `gh`.
+- **Given** an agent-built same-repo PR with no receipt (ref or comment) and enforcement
+  on, **when** CI runs, **then** it fails with a comment showing the one-time hook setup.
+- **Given** the same transcript on two machines, **when** each writes the ref, **then**
+  the `receipt.json` blob and wrapping-commit SHA are identical (I1/I5).
+
+## Non-goals
+
+- **Generating receipts in CI.** Impossible and unwanted — no transcript on the runner
+  (I1/I4). CI transports + renders only. Enforcement announces a miss; it can't fill it.
+- **Flipping the default to `ref`.** Ships opt-in; a default flip is a later spec after
+  dogfooding, so existing comment-based adopters are untouched.
+- **Sigstore signing / attestation.** The sibling build signs the ref bytes; that is a
+  separate provenance layer, out of scope here (the receipt's honesty rules stand alone).
+- **Zero-setup hooks for arbitrary repos.** Git won't auto-run fetched hooks; R3 states
+  the one-line activation for non-`npm` repos rather than pretending it's automatic.
+- **Replacing the PR comment as the human surface.** The comment stays; R4 only changes
+  who posts it (CI, from the ref) and removes the local-`gh` requirement.
+
+## Test matrix
+
+| Req | Case | Input | Expected |
+|---|---|---|---|
+| R1 | payload round-trip | `serialize` → `deserialize` → render | comment byte-identical to direct render |
+| R1 | ref round-trip | payload write → read | `readReceiptRef` returns byte-identical bytes |
+| R1 | deterministic SHA | same payload+derived date, pinned identity/tz | identical commit SHA across runs/machines |
+| R1 | derived date | model with startedAtMs+durationMs | date = `max(startedAtMs+durationMs)`, no wall-clock |
+| R1 | slug edges | branch names with `/`, spaces, unicode, empty | `receiptRefSlug` stable, matches CI's slug |
+| R2 | branch-push triggers | stdin has `refs/heads/x` | runs producer, pushes ref, exit 0 |
+| R2 | ref-push no recursion | stdin has only `refs/receipts/x` | guard exits 0, no regen |
+| R2 | multi-ref / `--all` push | stdin has heads + other refs | acts once on the branch, explicit refspec only |
+| R2 | no session | producer non-zero | push proceeds, one stderr line |
+| R3 | precedence | flag vs env vs settings | flag > env > settings > `comment` |
+| R4 | locate order | comment present + ref present | comment wins (back-compat) |
+| R4 | ref-only | no comment, ref present | CI validates + renders + upserts, check green |
+| R4 | untrusted payload | ref JSON with fences/links/`<details>`/NaN/unknown fields | schema-rejected or escaped; no raw injection posted |
+| R4 | write permission | reusable workflow | declares `pull-requests: write`; posts via `GITHUB_TOKEN` |
+| R4 | enforce miss | agent PR, no receipt, require on | check fails + fix comment |
+| R5 | list refs | `for-each-ref refs/receipts` | ref receipts appear in `--list` |
+| R6 | determinism gate | same transcript, 10 runs | `determinism-check` byte-identical; goldens green |
+
+## Success criteria
+
+- [ ] R1 ref store + `--store ref` shipped with round-trip + determinism tests; default
+      unchanged; `verify-goldens` and `determinism-check` green.
+- [ ] R2 pre-push hook + R3 activation land; recursion guard tested.
+- [ ] R4 CI renders + posts from the ref (no dev `gh`); enforcement opt-in; forks/hand-
+      written PRs never fail.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked.

--- a/specs/SPEC-0066-ci-post-from-ref.md
+++ b/specs/SPEC-0066-ci-post-from-ref.md
@@ -1,0 +1,110 @@
+---
+id: SPEC-0066
+title: CI renders and posts PR receipts from the ref (the trust boundary)
+status: approved
+milestone: M5
+depends: [SPEC-0019, SPEC-0064, SPEC-0065]
+---
+
+# SPEC-0066: CI renders and posts PR receipts from the ref (the trust boundary)
+
+## Purpose
+
+SPEC-0065 makes a receipt travel with the branch as `refs/receipts/<slug>`, generated
+locally. This spec is the other half: CI fetches that ref, and — instead of the developer
+running `pr --post` with local `gh` — **CI itself renders and posts the PR comment** via
+`GITHUB_TOKEN`, so a receipt lands with zero manual action. It is carved out of SPEC-0065
+because it crosses a new trust boundary: the ref payload is **fork/branch-author-controlled
+input**, and CI now posts derived content with a write token. That demands its own schema
+validation + Markdown-injection review, kept out of the low-risk local producer. Generation
+still never happens on the runner (I1/I4) — CI only validates, sanitizes, renders, and
+transports what the local hook produced.
+
+## Requirements
+
+- **R1 — locate + fetch order.** `pr-receipt-check.yml` / `scripts/check-pr-receipt.mjs`:
+  existing comment marker (back-compat, wins) → `git fetch <remote>
+  +refs/receipts/<slug>:refs/receipts/<slug>` then read `receipt.json`. Fork PRs fetch from
+  the head-repo clone URL; on failure, fall through to the current missing-receipt path.
+  `slug` comes from SPEC-0065's shared `receiptRefSlug`.
+- **R2 — validate the untrusted payload.** Parse the blob as `PrReceiptPayload`
+  (SPEC-0065), assert a known `schemaVersion`, reject unknown fields, non-finite numbers,
+  and over-cap strings. Any validation failure is treated exactly as **missing** (quiet or
+  enforced per R5) — CI never posts an unvalidated payload, never throws on hostile input.
+- **R3 — sanitize, then render (injection defense).** Every string reaching the comment
+  from the payload is untrusted (`DetailReceipt.text` is pre-rendered Markdown; `label`,
+  `row` cells, model names, waste lines are attacker-influenceable). Before render: guard
+  code fences (an injected ` ``` ` must not break out of the receipt fence — use a
+  length-adaptive fence or escape), neutralize raw HTML / `<details>` control tags, defang
+  Markdown links to plain text, and enforce the existing `COMMENT_SIZE_CAP`. Then feed the
+  sanitized payload to the unchanged `renderPrBody`. A golden pins the sanitizer against a
+  corpus of injection vectors. **Load-bearing render constraint (verified against
+  `body.ts`):** subagent names (`SubagentRow.name` = the prompt-derived subagent title,
+  attacker-controlled) reach the comment ONLY via the pre-rendered
+  `extras.details[].subagents` string. CI MUST render through `renderPrBody(sanitizedPayload)`
+  and rely on that sanitized string — it must NEVER regenerate the subagent table from
+  `bodyInput.contributors[].subagents` raw rows, or the raw `name` bypasses the sanitizer.
+  (`bodyInput.contributors[].subagents` legitimately feeds only count/cost math.)
+- **R4 — CI posts via `GITHUB_TOKEN`.** The reusable workflow `permissions` gains
+  `pull-requests: write`; CI upserts the marked comment (create/update the one marker
+  comment, no spam). The developer needs no local `gh`. `contents: read` and
+  `id-token`/`attestations` are NOT added (no signing here).
+- **R5 — enforcement, opt-in and honest.** With `AIRECEIPTS_REQUIRE_PR_RECEIPT=true`, an
+  **agent-built** (agent `Co-Authored-By` trailer or receipt-attach commit) **same-repo** PR
+  with a missing/invalid receipt fails the check with a 2-step fix comment. Hand-written PRs
+  (no agent evidence) and fork PRs never fail — there is no transcript to require.
+  Default stays notice-only.
+- **R6 — determinism + back-compat.** The comment-marker path is unchanged; the ref path is
+  additive. The same payload renders the same comment bytes; the sanitizer is golden-gated;
+  `verify-goldens` and existing `pr-receipt-check` tests stay green.
+
+## Scenarios
+
+- **Given** a branch carrying a valid receipt ref, **when** CI runs, **then** it fetches,
+  validates, sanitizes, renders, and upserts the marked comment via `GITHUB_TOKEN`; the
+  check is green and the developer ran no `pr --post`.
+- **Given** a hostile payload (injected fence / `<details>` / link / `NaN` / unknown
+  field), **when** CI processes it, **then** validation rejects or the sanitizer neutralizes
+  it — no comment breakout, no thrown job.
+- **Given** an agent-built same-repo PR with no receipt and enforcement on, **when** CI
+  runs, **then** it fails with the 2-step setup comment.
+- **Given** a hand-written PR (no agent evidence) with no receipt, **when** CI runs, **then**
+  it never fails, even with enforcement on.
+
+## Non-goals
+
+- **Generating a receipt in CI.** No transcript on the runner (I1/I4); CI validates +
+  transports only.
+- **Changing the producer or the ref layout.** Those are SPEC-0065; this spec consumes the
+  `PrReceiptPayload` seam unchanged.
+- **Sigstore signing / attestation.** A separate provenance layer, out of scope; no
+  signing permissions are added.
+- **Replacing the comment marker path.** The existing comment-presence check stays as the
+  back-compat/first-match; the ref path is additive.
+
+## Test matrix
+
+| Req | Case | Input | Expected |
+|---|---|---|---|
+| R1 | locate order | comment + ref both present | comment wins; no double-post |
+| R1 | ref fetch (same-repo) | ref on origin | fetched + read |
+| R1 | fork fetch fail | ref only on head repo, unreachable | degrades to missing path, no throw |
+| R2 | bad schemaVersion | payload with unknown version | treated as missing; nothing posted |
+| R2 | unknown field / NaN | malformed payload | rejected as missing; job green |
+| R3 | fence breakout | `DetailReceipt.text` with ` ``` ` | escaped/guarded; receipt fence intact |
+| R3 | HTML / details inject | payload string with `<details>`/`<script>` | neutralized in the posted comment |
+| R3 | valid render parity | clean payload | posted comment == `renderPrBody` byte-for-byte |
+| R4 | write permission | reusable workflow | declares `pull-requests: write`; upserts one marked comment |
+| R5 | enforce agent PR | agent trailer, no receipt, require on | fail + 2-step comment |
+| R5 | hand-written PR | no agent evidence, require on | never fails |
+| R6 | back-compat | comment-marker path unchanged | existing `pr-receipt-check` tests green; ref path additive |
+
+## Success criteria
+
+- [ ] CI fetches, validates, sanitizes, renders, and posts from the ref via `GITHUB_TOKEN`;
+      no local `gh` needed.
+- [ ] Injection corpus golden passes; hostile payloads never break the comment or fail the
+      job unexpectedly.
+- [ ] Enforcement is opt-in and skips hand-written/fork PRs.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked.

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -12,6 +12,7 @@ async function run(ctx: CommandContext): Promise<number> {
     artifact: ctx.options.artifact,
     details: !ctx.options.noDetails,
     share: ctx.options.share,
+    store: ctx.options.store,
   });
   if (result.bodyRendered && result.receipt) {
     await ctx.telemetry.noteReceiptGenerated(
@@ -59,13 +60,17 @@ export const command: CommandDef = {
     order: 100,
     lines: [
       "  aireceipts pr [--post] [--session <id>] [--artifact] [--no-details] [--share]",
+      "                [--store <comment|ref>]",
       "                                        attach the building session's receipt to",
       "                                         the current PR (dry-run prints the body;",
       "                                         --post upserts it via gh; --artifact also",
       "                                         publishes pr-<n>.html to the",
       "                                         aireceipts/artifacts branch and links it;",
       "                                         --share prints ready-to-paste X/LinkedIn",
-      "                                         intent URLs to stderr, requires --artifact)",
+      "                                         intent URLs to stderr, requires --artifact;",
+      "                                         --store ref also writes the receipt to",
+      "                                         refs/receipts/<slug> (SPEC-0065); default",
+      "                                         comment)",
     ],
   },
 };

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -41,6 +41,8 @@ export interface CliOptions {
   readonly noDetails: boolean;
   /** SPEC-0035 R5: `aireceipts pr --post --artifact --share` prints share intent URLs to stderr. */
   readonly share: boolean;
+  /** SPEC-0065 R1: `aireceipts pr --store <comment|ref>` — where the receipt is persisted; default `comment`. */
+  readonly store?: "comment" | "ref";
   /** SPEC-0056: `aireceipts backfill --limit N` caps the swept set to the N most recent matches. */
   readonly limit?: number;
   /** SPEC-0056: `aireceipts backfill --out <dir>` — distinct from `output` (SVG/PNG's `-o`/`--output`). */
@@ -91,6 +93,7 @@ export function parseOptions(argv: string[]): CliOptions {
   let artifact = false;
   let noDetails = false;
   let share = false;
+  let store: "comment" | "ref" | undefined;
   let limit: number | undefined;
   let outDir: string | undefined;
   let format: string | undefined;
@@ -142,6 +145,18 @@ export function parseOptions(argv: string[]): CliOptions {
       noDetails = true;
     } else if (arg === "--share") {
       share = true;
+    } else if (arg === "--store") {
+      const value = argv[++i];
+      if (value !== "comment" && value !== "ref") {
+        throw new Error(`--store must be "comment" or "ref" (got ${JSON.stringify(value)})`);
+      }
+      store = value;
+    } else if (arg.startsWith("--store=")) {
+      const value = arg.slice("--store=".length);
+      if (value !== "comment" && value !== "ref") {
+        throw new Error(`--store must be "comment" or "ref" (got ${JSON.stringify(value)})`);
+      }
+      store = value;
     } else if (arg === "--session") {
       prSession = argv[++i];
     } else if (arg.startsWith("--session=")) {
@@ -199,6 +214,7 @@ export function parseOptions(argv: string[]): CliOptions {
     artifact,
     noDetails,
     share,
+    store,
     limit,
     outDir,
     help,

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -32,6 +32,7 @@ import {
   type ContributorView,
   type HandoffSectionData,
   type HandoffSlipView,
+  type PrBodyExtras,
   type PrBodyInput,
 } from "./body.js";
 import { summarizeConfidence, type ConfidenceEvent } from "./confidence.js";
@@ -41,6 +42,9 @@ import { ARTIFACT_BRANCH, artifactViewUrl, publishArtifact } from "./publish.js"
 import { buildShareLines } from "./share.js";
 import type { ReceiptModel } from "../receipt/model.js";
 import type { ResultValue, StepResultValue } from "../telemetry/schemas.js";
+import { buildPrReceiptPayload, canonicalEndedAtMs, serializePrReceipt } from "./payload.js";
+import { receiptRefSlug } from "./payloadTypes.js";
+import { writeReceiptRef } from "./store.js";
 
 export interface PrOptions {
   post: boolean;
@@ -51,6 +55,8 @@ export interface PrOptions {
   details?: boolean;
   /** SPEC-0035 R5: print ready-to-paste share intent URLs to stderr (requires --artifact). */
   share?: boolean;
+  /** SPEC-0065 R1: where the receipt is persisted. Precedence: flag > `AIRECEIPTS_STORE` env > default `"comment"`. */
+  store?: "comment" | "ref";
 }
 
 export interface PrDeps {
@@ -572,11 +578,41 @@ export async function runPrDetailed(opts: PrOptions, deps: PrDeps = defaultPrDep
   // SPEC-0059 R5 — the comment's handoff section is a sibling of the details
   // section and shares its --no-details gate; R8's boolean is the assembler's
   // own decision, not a scan of the body.
-  const { body, handoffSectionIncluded } = renderPrBodyDetailed(bodyInput, {
-    artifactLink: link ?? undefined,
+  const extras: PrBodyExtras = {
+    // Project to the declared `{ fileName, url }` — `link` also carries a runtime
+    // `ownerRepo` (used for the share-hint check below, not by the renderer). Storing it
+    // in the payload would smuggle an unknown field past `PrBodyExtras.artifactLink` that
+    // SPEC-0066's strict CI validator rejects (Codex review).
+    artifactLink: link ? { fileName: link.fileName, url: link.url } : undefined,
     details,
     handoff: opts.details === false ? undefined : handoffData,
-  });
+  };
+  const { body, handoffSectionIncluded } = renderPrBodyDetailed(bodyInput, extras);
+
+  // SPEC-0065 R1 — `store=ref`: in addition to (never instead of) the comment
+  // path below, which stays the unconditional default, write the exact
+  // renderer input as a schema-versioned payload to `refs/receipts/<slug>`
+  // via pure git plumbing. Precedence: flag > `AIRECEIPTS_STORE` env >
+  // default `"comment"`; R3's committed-settings layer is out of scope here.
+  const store = opts.store ?? (process.env.AIRECEIPTS_STORE === "ref" ? "ref" : undefined) ?? "comment";
+  if (store === "ref") {
+    const branchResult = deps.runGit("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: deps.cwd });
+    const branch = branchResult.code === 0 ? branchResult.stdout.trim() : "";
+    if (!branch || branch === "HEAD") {
+      deps.err("store=ref skipped: could not resolve current branch");
+    } else {
+      const payload = buildPrReceiptPayload(bodyInput, extras);
+      const json = serializePrReceipt(payload);
+      const endedAtMs = canonicalEndedAtMs(receipt.models);
+      const slug = receiptRefSlug(branch);
+      const outcome = writeReceiptRef(slug, branch, json, endedAtMs, deps.cwd);
+      if (outcome.ok) {
+        deps.err(`wrote receipt ref ${outcome.ref} (${outcome.commit})`);
+      } else {
+        deps.err(`store=ref failed: ${outcome.reason}`);
+      }
+    }
+  }
 
   // R3 (SPEC-0019): render before the comment upsert, unconditionally.
   deps.out(body);

--- a/src/pr/payload.ts
+++ b/src/pr/payload.ts
@@ -1,0 +1,57 @@
+// SPEC-0065 R1 — assembly + serialization for the `PrReceiptPayload` stored
+// on a receipt ref. `payloadTypes.ts` is the shared seam (type, version,
+// slug helper) both this producer and SPEC-0066's CI consumer build
+// against; validation/deserialization of the untrusted ref bytes is CI's
+// job (payloadTypes.ts's own header comment), not this file's.
+import type { ReceiptModel } from "../receipt/model.js";
+import type { PrBodyExtras, PrBodyInput } from "./body.js";
+import { PR_RECEIPT_SCHEMA_VERSION, type PrReceiptPayload } from "./payloadTypes.js";
+
+/**
+ * Assemble the schema-versioned payload stored on the receipt ref — exactly
+ * the renderer's own input (`bodyInput`/`extras`), so reading it back and
+ * feeding it to `renderPrBody` reproduces the comment byte-for-byte.
+ */
+export function buildPrReceiptPayload(bodyInput: PrBodyInput, extras: PrBodyExtras): PrReceiptPayload {
+  return {
+    schemaVersion: PR_RECEIPT_SCHEMA_VERSION,
+    bodyInput,
+    extras,
+  };
+}
+
+/**
+ * Deterministic JSON for a `PrReceiptPayload` — the exact bytes written to
+ * `receipt.json` on the receipt ref. Rebuilds the object in a fixed key
+ * order (`schemaVersion`, `bodyInput`, `extras`) rather than trusting the
+ * caller's own insertion order, so the same payload always serializes to
+ * the same bytes (SPEC-0065 R1/R6).
+ */
+export function serializePrReceipt(payload: PrReceiptPayload): string {
+  return JSON.stringify({
+    schemaVersion: payload.schemaVersion,
+    bodyInput: payload.bodyInput,
+    extras: payload.extras,
+  });
+}
+
+/**
+ * The receipt ref's commit date: `max(startedAtMs + durationMs)` across
+ * every contributing session's model, never wall-clock, so the same
+ * transcript always yields the same date (and therefore the same commit
+ * SHA). A model missing either field doesn't contribute; if none carry
+ * both, returns 0 rather than falling back to `Date.now()`.
+ */
+export function canonicalEndedAtMs(models: readonly ReceiptModel[]): number {
+  let max = 0;
+  for (const model of models) {
+    if (model.startedAtMs === undefined || model.durationMs === undefined) {
+      continue;
+    }
+    const ended = model.startedAtMs + model.durationMs;
+    if (ended > max) {
+      max = ended;
+    }
+  }
+  return max;
+}

--- a/src/pr/payloadTypes.ts
+++ b/src/pr/payloadTypes.ts
@@ -1,0 +1,28 @@
+import type { PrBodyExtras, PrBodyInput } from "./body.js";
+
+/**
+ * SPEC-0065 / SPEC-0066 — the versioned, JSON-plain PR-receipt payload stored at
+ * `refs/receipts/<slug>` by the local producer and re-rendered by CI. It is exactly the
+ * renderer's input (`renderPrBody(bodyInput, extras)`), so a round-trip reproduces the
+ * comment byte-for-byte. Bump `PR_RECEIPT_SCHEMA_VERSION` on any shape change.
+ *
+ * This file is the SEAM the producer (SPEC-0065) and the CI consumer (SPEC-0066) both
+ * build against — it holds only the shared type, version, and slug so the two sides never
+ * drift. Serialization lives with the producer; validation/sanitization lives with CI.
+ */
+export const PR_RECEIPT_SCHEMA_VERSION = 1 as const;
+
+export interface PrReceiptPayload {
+  schemaVersion: number;
+  bodyInput: PrBodyInput;
+  extras: PrBodyExtras;
+}
+
+/**
+ * The ref slug for a branch (`refs/receipts/<slug>`). Shared verbatim by the producer's
+ * write path and CI's fetch path so they never diverge. Deterministic and ref-safe: every
+ * character outside `[A-Za-z0-9._-]` collapses to `-`.
+ */
+export function receiptRefSlug(branch: string): string {
+  return branch.replace(/[^A-Za-z0-9._-]/g, "-");
+}

--- a/src/pr/store.ts
+++ b/src/pr/store.ts
@@ -1,0 +1,144 @@
+// SPEC-0065 R1 — pure git-plumbing ref store for `store=ref` PR receipts.
+// Writes the schema-versioned `PrReceiptPayload` as a git object on
+// `refs/receipts/<slug>` via plumbing only (`hash-object` → `mktree` →
+// `commit-tree` → `update-ref`), touching no index or worktree. The wrapping
+// commit is dated from the receipt's own `endedAt` (never wall-clock) with a
+// fixed author/committer identity, so the same payload yields the same
+// commit SHA on every machine (I1/I5). Uses its own `spawnSync` wrapper
+// below — not `CommandRunner` from `./git.js` — because pinning
+// `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` needs an env-injection seam
+// `CommandRunner` doesn't have.
+import { spawnSync } from "node:child_process";
+
+/**
+ * Fixed identity for every receipt-ref commit, pinned via ENV — `GIT_AUTHOR_*` /
+ * `GIT_COMMITTER_*` override both `git config` and `-c user.*`, so setting them
+ * explicitly is what actually makes the commit deterministic on a machine that
+ * has its own identity env set (Codex review). Signing is disabled per-command
+ * (`-c commit.gpgsign=false`) so a global `commit.gpgsign=true` can't inject a
+ * nondeterministic signature into the object.
+ */
+const IDENT_ENV = {
+  GIT_AUTHOR_NAME: "aireceipts",
+  GIT_AUTHOR_EMAIL: "receipts@aireceipts.dev",
+  GIT_COMMITTER_NAME: "aireceipts",
+  GIT_COMMITTER_EMAIL: "receipts@aireceipts.dev",
+} as const;
+
+/** Prefix of every PR-receipt ref (SPEC-0065 R1). */
+export const RECEIPT_REF_PREFIX = "refs/receipts/";
+
+/** The full ref name for a slug (from `receiptRefSlug(branch)`), e.g. `refs/receipts/feat-x`. */
+export function receiptRef(slug: string): string {
+  return `${RECEIPT_REF_PREFIX}${slug}`;
+}
+
+interface GitResult {
+  out: string;
+  ok: boolean;
+  err: string;
+}
+
+interface GitOpts {
+  cwd?: string;
+  input?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * Dedicated fixed-env git invocation (SPEC-0065 R1). Deliberately separate
+ * from `CommandRunner` (`./git.js`), which has no env-injection seam — this
+ * one exists specifically to pin `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` for
+ * deterministic commit SHAs.
+ */
+function git(args: string[], opts: GitOpts = {}): GitResult {
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    cwd: opts.cwd,
+    input: opts.input,
+    env: opts.env ? { ...process.env, ...opts.env } : process.env,
+  });
+  return {
+    out: (result.stdout ?? "").trim(),
+    ok: result.status === 0,
+    err: (result.stderr ?? "").trim(),
+  };
+}
+
+export type WriteReceiptRefOutcome = { ok: true; ref: string; commit: string } | { ok: false; reason: string };
+
+/**
+ * Write `json` as `receipt.json` on `refs/receipts/<slug>`, wrapped in a
+ * commit dated `<epochSeconds> +0000` derived from `endedAtMs` (never
+ * wall-clock) under a fixed identity — so the same `(slug, branch, json,
+ * endedAtMs)` always produces the same commit SHA (SPEC-0065 R1/R6).
+ */
+export function writeReceiptRef(slug: string, branch: string, json: string, endedAtMs: number, cwd?: string): WriteReceiptRefOutcome {
+  const blob = git(["hash-object", "-w", "--stdin"], { cwd, input: json });
+  if (!blob.ok) {
+    return { ok: false, reason: `hash-object failed: ${blob.err}` };
+  }
+  const blobSha = blob.out;
+
+  const tree = git(["mktree"], { cwd, input: `100644 blob ${blobSha}\treceipt.json\n` });
+  if (!tree.ok) {
+    return { ok: false, reason: `mktree failed: ${tree.err}` };
+  }
+  const treeSha = tree.out;
+
+  // Explicit UTC epoch seconds — the deterministic date the whole write hinges on.
+  const epochSeconds = Math.max(1, Math.floor((endedAtMs ?? 0) / 1000));
+  const dateEnv = `@${epochSeconds} +0000`;
+  // Pin every config input to the commit object bytes: no signature, and UTF-8 encoding
+  // so a machine's `i18n.commitEncoding` can't write a differing `encoding` header (Codex
+  // review). Identity + dates are pinned via env below.
+  const commit = git(["-c", "commit.gpgsign=false", "-c", "i18n.commitEncoding=UTF-8", "commit-tree", treeSha, "-m", `receipt: ${branch}`], {
+    cwd,
+    env: {
+      ...IDENT_ENV,
+      GIT_AUTHOR_DATE: dateEnv,
+      GIT_COMMITTER_DATE: dateEnv,
+    },
+  });
+  if (!commit.ok) {
+    return { ok: false, reason: `commit-tree failed: ${commit.err}` };
+  }
+  const commitSha = commit.out;
+
+  const ref = receiptRef(slug);
+  const update = git(["update-ref", ref, commitSha], { cwd });
+  if (!update.ok) {
+    return { ok: false, reason: `update-ref failed: ${update.err}` };
+  }
+  return { ok: true, ref, commit: commitSha };
+}
+
+/** Read back `receipt.json` from `refs/receipts/<slug>`, or `null` when the ref or blob doesn't exist. */
+export function readReceiptRef(slug: string, cwd?: string): string | null {
+  const result = git(["cat-file", "blob", `${receiptRef(slug)}:receipt.json`], { cwd });
+  return result.ok ? result.out : null;
+}
+
+/** Best-effort push of one receipt ref to `remote` (force-updates the remote ref to match local). */
+export function pushReceiptRef(slug: string, remote = "origin", cwd?: string): boolean {
+  const ref = receiptRef(slug);
+  const result = git(["push", remote, `+${ref}:${ref}`], { cwd });
+  return result.ok;
+}
+
+export interface ReceiptRefEntry {
+  ref: string;
+  slug: string;
+}
+
+/** All local receipt refs (SPEC-0065 R5 — local tooling reads these alongside file/session discovery). */
+export function listReceiptRefs(cwd?: string): ReceiptRefEntry[] {
+  const result = git(["for-each-ref", RECEIPT_REF_PREFIX, "--format=%(refname)"], { cwd });
+  if (!result.ok || !result.out) {
+    return [];
+  }
+  return result.out
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((ref) => ({ ref, slug: ref.slice(RECEIPT_REF_PREFIX.length) }));
+}

--- a/test/pr/store.test.ts
+++ b/test/pr/store.test.ts
@@ -1,0 +1,156 @@
+// SPEC-0065 R1 — the pure git-plumbing ref store: write→read round-trip,
+// determinism (same payload+endedAt → identical commit SHA across a fresh
+// temp git repo), and `receiptRefSlug` edge cases.
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { listReceiptRefs, readReceiptRef, RECEIPT_REF_PREFIX, receiptRef, writeReceiptRef } from "../../src/pr/store.js";
+import { receiptRefSlug } from "../../src/pr/payloadTypes.js";
+
+const dirs: string[] = [];
+
+async function tempRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "aireceipts-store-"));
+  dirs.push(dir);
+  const init = spawnSync("git", ["init", "--quiet"], { cwd: dir, encoding: "utf8" });
+  if (init.status !== 0) {
+    throw new Error(`git init failed: ${init.stderr}`);
+  }
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("writeReceiptRef / readReceiptRef", () => {
+  it("round-trips byte-identical JSON", async () => {
+    const cwd = await tempRepo();
+    const json = JSON.stringify({ schemaVersion: 1, bodyInput: { a: 1 }, extras: { details: [] } });
+    const outcome = writeReceiptRef("feat-x", "feat/x", json, 1_750_000_000_000, cwd);
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) {
+      return;
+    }
+    expect(outcome.ref).toBe(`${RECEIPT_REF_PREFIX}feat-x`);
+    expect(outcome.commit).toMatch(/^[0-9a-f]{40}$/);
+
+    const readBack = readReceiptRef("feat-x", cwd);
+    expect(readBack).toBe(json);
+  });
+
+  it("returns null for a slug that was never written", async () => {
+    const cwd = await tempRepo();
+    expect(readReceiptRef("never-written", cwd)).toBeNull();
+  });
+
+  it("lists every written ref by slug", async () => {
+    const cwd = await tempRepo();
+    writeReceiptRef("feat-a", "feat/a", "{}", 1_000_000, cwd);
+    writeReceiptRef("feat-b", "feat/b", "{}", 1_000_000, cwd);
+
+    const refs = listReceiptRefs(cwd);
+    const slugs = refs.map((r) => r.slug).sort();
+    expect(slugs).toEqual(["feat-a", "feat-b"]);
+    expect(refs.every((r) => r.ref === receiptRef(r.slug))).toBe(true);
+  });
+});
+
+describe("writeReceiptRef determinism", () => {
+  it("same (slug, branch, json, endedAtMs) yields the same commit SHA in a fresh repo", async () => {
+    const json = JSON.stringify({ schemaVersion: 1, bodyInput: { x: "y" }, extras: {} });
+    const endedAtMs = 1_700_000_000_000;
+
+    const repoA = await tempRepo();
+    const outcomeA = writeReceiptRef("feat-det", "feat/det", json, endedAtMs, repoA);
+
+    const repoB = await tempRepo();
+    const outcomeB = writeReceiptRef("feat-det", "feat/det", json, endedAtMs, repoB);
+
+    expect(outcomeA.ok).toBe(true);
+    expect(outcomeB.ok).toBe(true);
+    if (!outcomeA.ok || !outcomeB.ok) {
+      return;
+    }
+    expect(outcomeA.commit).toBe(outcomeB.commit);
+  });
+
+  it("pins identity, signing, and encoding: hostile GIT_* env + gpgsign + i18n.commitEncoding config do not change the SHA", async () => {
+    const json = JSON.stringify({ schemaVersion: 1, bodyInput: {}, extras: {} });
+    const endedAtMs = 1_700_000_000_000;
+
+    const clean = await tempRepo();
+    const baseline = writeReceiptRef("feat-env", "feat/env", json, endedAtMs, clean);
+    expect(baseline.ok).toBe(true);
+
+    const keys = ["GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL"] as const;
+    const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+    for (const k of keys) {
+      process.env[k] = k.includes("EMAIL") ? "evil@example.com" : "evil";
+    }
+    try {
+      const hostile = await tempRepo();
+      spawnSync("git", ["config", "commit.gpgsign", "true"], { cwd: hostile });
+      spawnSync("git", ["config", "i18n.commitEncoding", "ISO-8859-1"], { cwd: hostile });
+      const outcome = writeReceiptRef("feat-env", "feat/env", json, endedAtMs, hostile);
+      expect(outcome.ok).toBe(true);
+      if (!outcome.ok || !baseline.ok) {
+        return;
+      }
+      expect(outcome.commit).toBe(baseline.commit);
+      const author = spawnSync("git", ["log", "-1", "--format=%an <%ae>", outcome.ref], { cwd: hostile, encoding: "utf8" }).stdout.trim();
+      expect(author).toBe("aireceipts <receipts@aireceipts.dev>");
+    } finally {
+      for (const k of keys) {
+        if (saved[k] === undefined) {
+          delete process.env[k];
+        } else {
+          process.env[k] = saved[k];
+        }
+      }
+    }
+  });
+
+  it("a different endedAtMs yields a different commit SHA", async () => {
+    const json = JSON.stringify({ schemaVersion: 1, bodyInput: {}, extras: {} });
+
+    const repoA = await tempRepo();
+    const outcomeA = writeReceiptRef("feat-det2", "feat/det2", json, 1_700_000_000_000, repoA);
+
+    const repoB = await tempRepo();
+    const outcomeB = writeReceiptRef("feat-det2", "feat/det2", json, 1_800_000_000_000, repoB);
+
+    expect(outcomeA.ok).toBe(true);
+    expect(outcomeB.ok).toBe(true);
+    if (!outcomeA.ok || !outcomeB.ok) {
+      return;
+    }
+    expect(outcomeA.commit).not.toBe(outcomeB.commit);
+  });
+});
+
+describe("receiptRefSlug edge cases", () => {
+  it("replaces path separators in a branch name", () => {
+    expect(receiptRefSlug("feat/my-feature")).toBe("feat-my-feature");
+  });
+
+  it("replaces spaces and unicode with hyphens", () => {
+    expect(receiptRefSlug("feat/héllo wörld")).toBe("feat-h-llo-w-rld");
+  });
+
+  it("collapses each disallowed character independently (no dedup)", () => {
+    expect(receiptRefSlug("a//b")).toBe("a--b");
+  });
+
+  it("leaves an already-safe branch name untouched", () => {
+    expect(receiptRefSlug("main")).toBe("main");
+    expect(receiptRefSlug("feat-0065_v2.1")).toBe("feat-0065_v2.1");
+  });
+
+  it("handles an empty string", () => {
+    expect(receiptRefSlug("")).toBe("");
+  });
+});


### PR DESCRIPTION
## What this adds

The local `store=ref` PR-receipt producer (SPEC-0065 Phase 1): `aireceipts pr --store ref` writes the receipt as a **deterministic git object** on `refs/receipts/<slug>` that travels with the branch — the first half of making PR receipts seamless (no manual `pr --post`, no local `gh`). Ships alongside the SPEC-0065 and SPEC-0066 plans.

## Why it matters to users

- **Foundation for auto-attaching receipts:** a pre-push hook (next slice) runs this so the receipt attaches on `git push`; CI (SPEC-0066) then reads the ref and posts the comment itself.
- **Opt-in and additive:** `--store ref` / `AIRECEIPTS_STORE=ref`; the default `comment` path is untouched.
- **Deterministic:** the same receipt yields the same commit SHA on every machine (I1/I5).

## See it

```
  aireceipts pr [--post] [--session <id>] [--artifact] [--no-details] [--share]
                [--store <comment|ref>]
                                         ... --store ref also writes the receipt to
                                         refs/receipts/<slug> (SPEC-0065); default
                                         comment)
```

## What changed

- `src/pr/store.ts` (new) — git-ref plumbing (`hash-object`→`mktree`→`commit-tree`→`update-ref`), deterministic commit via a dedicated fixed-env git call.
- `src/pr/payloadTypes.ts` + `src/pr/payload.ts` (new) — the versioned `PrReceiptPayload` seam, `serializePrReceipt`, canonical `endedAtMs`, shared `receiptRefSlug`.
- `src/cli/options.ts`, `src/cli/commands/pr.ts`, `src/pr/index.ts` — `--store ref` wiring; the comment path stays the default.
- `goldens/cli/help.txt` — regenerated for the new `--store` flag (intentional).
- `test/pr/store.test.ts` (new) — round-trip, determinism (incl. hostile `GIT_*` env + `gpgsign` + `i18n.commitEncoding` config), slug edges.
- `specs/SPEC-0065`, `specs/SPEC-0066` — both approved (the phased plan).

## What to review, in order

1. `src/pr/store.ts` — the determinism pinning: identity via `GIT_*` env (override-proof), `commit.gpgsign=false`, `i18n.commitEncoding=UTF-8`, `<endedAt> +0000` date, fixed tree/message. (riskiest — I1/I5)
2. `src/pr/index.ts` — the additive `store === "ref"` branch (default `comment` unchanged) and the `artifactLink` `{fileName,url}` projection (keeps `ownerRepo` out of the payload).
3. `src/pr/payload.ts` — `canonicalEndedAtMs` (`max(startedAtMs+durationMs)`, skips-missing→0) + serialize.
4. `specs/SPEC-0065` + `SPEC-0066` — the phased plan; SPEC-0066 (the CI trust-boundary consumer) is spec-only here.

## Evidence

Gates green (unmasked, all exit `0`): `tsc`, `eslint --max-warnings 0`, `vitest` 1546, `verify-goldens`, `determinism-check` 10× byte-identical, `spec-lint`, `hygiene`.
Specs: SPEC-0065 (approved), SPEC-0066 (approved).
Independent review: Codex (different model family), deep effort, iterated to **PASS, no findings** — it caught and I fixed 3 real determinism issues (identity-env override, `gpgsign`, `i18n.commitEncoding`) and 1 payload-schema leak (`artifactLink.ownerRepo`).

## Notes

- **SPEC-0066 sanitizer + CI wiring land in the follow-up PR.** Codex flagged trust-boundary gaps in the sanitizer (artifact-link URL rendered as a live link target, reference-style links) that are best fixed field-by-field against the real `renderPrBody` during wiring — so the sanitizer is held rather than landed unwired-and-leaky here.
- Next slices: Phase 2 (pre-push hook + `core.hooksPath` activation), Phase 3 / SPEC-0066 (CI validates + renders + posts from the ref, opt-in enforcement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
