### PR TITLE
feat: SPEC-0065 Phase 2 — pre-push hook auto-attaches the receipt

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,35 @@
+#!/bin/sh
+# SPEC-0065 R2 — pre-push hook: attach a receipt ref to every branch push, with
+# no extra step from the developer. Activated per clone via `core.hooksPath`
+# (run `npm run setup:hooks`; SPEC-0065 R3).
+#
+# RECURSION GUARD: this hook runs `aireceipts pr --store ref --push-ref`, which
+# does a nested `git push` of `refs/receipts/<slug>` (see `pushReceiptRef` in
+# src/pr/store.ts). That nested push re-invokes this same hook. We act only when
+# the ORIGINAL push targets a branch — a stdin line whose LOCAL or REMOTE ref is
+# `refs/heads/*` (a refspec like `HEAD^:refs/heads/main` names the branch only on
+# the remote side). A ref-only push (the nested receipts push, a tag push) names
+# no `refs/heads/*` on either side, so the guard below exits 0 and recursion stops.
+#
+# BEST-EFFORT: every failure path is silent (output redirected, exit ignored)
+# and this script always exits 0. It must never block `git push`.
+
+has_branch_push=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  case "$local_ref" in refs/heads/*) has_branch_push=1 ;; esac
+  case "$remote_ref" in refs/heads/*) has_branch_push=1 ;; esac
+done
+
+if [ "$has_branch_push" -ne 1 ]; then
+  exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+if [ -f "$repo_root/dist/cli.js" ]; then
+  node "$repo_root/dist/cli.js" pr --store ref --push-ref >/dev/null 2>&1 || true
+elif command -v aireceipts >/dev/null 2>&1; then
+  aireceipts pr --store ref --push-ref >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -56,6 +56,24 @@ git config alias.receipt '!npx aireceipts-cli pr --post'
 git receipt                  # after pushing your branch
 ```
 
+### Always-on: pre-push hook
+
+This is optional and not required for adoption — it's a convenience layer, not a
+replacement for the one command above. Enable it once per clone:
+
+```sh
+npm run setup:hooks
+```
+
+That points `core.hooksPath` at the committed `.githooks/` and builds the CLI (the hook
+runs the built `dist/`, or a global `aireceipts` if you have one). From then on, every
+`git push` of a branch runs `aireceipts pr --store ref --push-ref` for you: it writes the
+receipt to `refs/receipts/<slug>` and pushes that ref alongside your branch, with no extra
+step. It's best-effort and **never blocks the push** — a missing session, a repo without
+`gh`, an unbuilt CLI, or a push failure is swallowed silently and the push proceeds. (Git
+never runs a fetched hook automatically, so this one command is unavoidable; the CI check
+is the install-free layer that catches a missed receipt regardless.)
+
 ### Optional: publish a durable receipt page
 
 ```sh

--- a/goldens/cli/help.txt
+++ b/goldens/cli/help.txt
@@ -24,7 +24,7 @@ Usage:
   aireceipts week [--by-project] [--since <date>] [--json]
                                         trailing-7-day digest across sessions
   aireceipts pr [--post] [--session <id>] [--artifact] [--no-details] [--share]
-                [--store <comment|ref>]
+                [--store <comment|ref>] [--push-ref]
                                         attach the building session's receipt to
                                          the current PR (dry-run prints the body;
                                          --post upserts it via gh; --artifact also
@@ -34,7 +34,8 @@ Usage:
                                          intent URLs to stderr, requires --artifact;
                                          --store ref also writes the receipt to
                                          refs/receipts/<slug> (SPEC-0065); default
-                                         comment)
+                                         comment; --push-ref also pushes that ref to
+                                         origin, only meaningful with --store ref)
   aireceipts --check-budget             exit 1 if ~/.aireceipts/budget.json's cap is
                                          exceeded (advisory; see docs)
   aireceipts benchmark [--dry-run]      opt-in cost-per-turn benchmark (v1: client

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build": "tsup",
     "preflight": "node scripts/preflight-release.mjs",
     "prepublishOnly": "tsup",
+    "setup:hooks": "git config core.hooksPath .githooks && npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/scripts/hygiene.mjs
+++ b/scripts/hygiene.mjs
@@ -20,6 +20,7 @@ export const LINE_BUDGETS = Object.freeze([
 
 export const ROOT_ALLOWLIST = Object.freeze([
   ".claude",
+  ".githooks",
   ".github",
   ".gitleaksignore",
   ".gitignore",

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -13,6 +13,7 @@ async function run(ctx: CommandContext): Promise<number> {
     details: !ctx.options.noDetails,
     share: ctx.options.share,
     store: ctx.options.store,
+    pushRef: ctx.options.pushRef,
   });
   if (result.bodyRendered && result.receipt) {
     await ctx.telemetry.noteReceiptGenerated(
@@ -60,7 +61,7 @@ export const command: CommandDef = {
     order: 100,
     lines: [
       "  aireceipts pr [--post] [--session <id>] [--artifact] [--no-details] [--share]",
-      "                [--store <comment|ref>]",
+      "                [--store <comment|ref>] [--push-ref]",
       "                                        attach the building session's receipt to",
       "                                         the current PR (dry-run prints the body;",
       "                                         --post upserts it via gh; --artifact also",
@@ -70,7 +71,8 @@ export const command: CommandDef = {
       "                                         intent URLs to stderr, requires --artifact;",
       "                                         --store ref also writes the receipt to",
       "                                         refs/receipts/<slug> (SPEC-0065); default",
-      "                                         comment)",
+      "                                         comment; --push-ref also pushes that ref to",
+      "                                         origin, only meaningful with --store ref)",
     ],
   },
 };

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -43,6 +43,8 @@ export interface CliOptions {
   readonly share: boolean;
   /** SPEC-0065 R1: `aireceipts pr --store <comment|ref>` — where the receipt is persisted; default `comment`. */
   readonly store?: "comment" | "ref";
+  /** SPEC-0065 R2: `aireceipts pr --store ref --push-ref` also pushes the written ref to `origin`. */
+  readonly pushRef: boolean;
   /** SPEC-0056: `aireceipts backfill --limit N` caps the swept set to the N most recent matches. */
   readonly limit?: number;
   /** SPEC-0056: `aireceipts backfill --out <dir>` — distinct from `output` (SVG/PNG's `-o`/`--output`). */
@@ -94,6 +96,7 @@ export function parseOptions(argv: string[]): CliOptions {
   let noDetails = false;
   let share = false;
   let store: "comment" | "ref" | undefined;
+  let pushRef = false;
   let limit: number | undefined;
   let outDir: string | undefined;
   let format: string | undefined;
@@ -157,6 +160,8 @@ export function parseOptions(argv: string[]): CliOptions {
         throw new Error(`--store must be "comment" or "ref" (got ${JSON.stringify(value)})`);
       }
       store = value;
+    } else if (arg === "--push-ref") {
+      pushRef = true;
     } else if (arg === "--session") {
       prSession = argv[++i];
     } else if (arg.startsWith("--session=")) {
@@ -215,6 +220,7 @@ export function parseOptions(argv: string[]): CliOptions {
     noDetails,
     share,
     store,
+    pushRef,
     limit,
     outDir,
     help,

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -44,7 +44,7 @@ import type { ReceiptModel } from "../receipt/model.js";
 import type { ResultValue, StepResultValue } from "../telemetry/schemas.js";
 import { buildPrReceiptPayload, canonicalEndedAtMs, serializePrReceipt } from "./payload.js";
 import { receiptRefSlug } from "./payloadTypes.js";
-import { writeReceiptRef } from "./store.js";
+import { pushReceiptRef, writeReceiptRef } from "./store.js";
 
 export interface PrOptions {
   post: boolean;
@@ -57,6 +57,8 @@ export interface PrOptions {
   share?: boolean;
   /** SPEC-0065 R1: where the receipt is persisted. Precedence: flag > `AIRECEIPTS_STORE` env > default `"comment"`. */
   store?: "comment" | "ref";
+  /** SPEC-0065 R2: after a successful `store=ref` write, also push the ref to `origin`. Best-effort — never fails the command. */
+  pushRef?: boolean;
 }
 
 export interface PrDeps {
@@ -608,6 +610,16 @@ export async function runPrDetailed(opts: PrOptions, deps: PrDeps = defaultPrDep
       const outcome = writeReceiptRef(slug, branch, json, endedAtMs, deps.cwd);
       if (outcome.ok) {
         deps.err(`wrote receipt ref ${outcome.ref} (${outcome.commit})`);
+        // SPEC-0065 R2 — best-effort push of the ref itself, for the pre-push
+        // hook's `--push-ref` call. Never throws and never affects `code`: a
+        // push failure (no remote, no push rights, offline) prints one line
+        // and the branch push the hook is running inside of proceeds.
+        if (opts.pushRef) {
+          const pushed = pushReceiptRef(slug, "origin", deps.cwd);
+          if (!pushed) {
+            deps.err(`store=ref: push of ${outcome.ref} to origin failed (best-effort, continuing)`);
+          }
+        }
       } else {
         deps.err(`store=ref failed: ${outcome.reason}`);
       }

--- a/test/pr/prepush-hook.test.ts
+++ b/test/pr/prepush-hook.test.ts
@@ -1,0 +1,95 @@
+// SPEC-0065 R2 — the committed `.githooks/pre-push` hook: the branch-push
+// recursion guard, the exact CLI invocation it runs, and that every exit path
+// is `exit 0` (it must never block `git push`). Plus a unit test that the
+// `--push-ref` flag parses into `CliOptions.pushRef` (SPEC-0065 R2).
+import { fileURLToPath } from "node:url";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseOptions } from "../../src/cli/options.js";
+import { command as prCommand } from "../../src/cli/commands/pr.js";
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const HOOK_PATH = path.join(ROOT, ".githooks", "pre-push");
+const hook = readFileSync(HOOK_PATH, "utf8");
+
+/**
+ * Runs the real hook in a throwaway git repo with a fake `dist/cli.js` that drops a
+ * marker file, and returns whether the guard let the push through (marker written).
+ * Proves branch detection + recursion safety without invoking the real CLI.
+ */
+function hookActedOn(stdin: string): boolean {
+  const dir = mkdtempSync(path.join(tmpdir(), "aireceipts-hook-"));
+  try {
+    spawnSync("git", ["init", "-q"], { cwd: dir });
+    mkdirSync(path.join(dir, "dist"), { recursive: true });
+    const marker = path.join(dir, "RAN");
+    writeFileSync(path.join(dir, "dist", "cli.js"), `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "1");`);
+    spawnSync("sh", [HOOK_PATH], { cwd: dir, input: stdin });
+    return existsSync(marker);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("SPEC-0065 R2 .githooks/pre-push", () => {
+  it("is a POSIX sh script", () => {
+    expect(hook.startsWith("#!/bin/sh")).toBe(true);
+  });
+
+  it("guards on refs/heads/* from stdin before doing anything", () => {
+    expect(hook).toContain("refs/heads/*");
+  });
+
+  it("runs the CLI with --store ref --push-ref (no shell-side slug computation)", () => {
+    expect(hook).toContain("pr --store ref --push-ref");
+    // The hook must delegate slug derivation entirely to the CLI (which shares
+    // `receiptRefSlug` with CI, per SPEC-0066's seam contract) rather than
+    // deriving a branch-name-to-slug transform itself, which would drift.
+    expect(hook).not.toMatch(/\btr\b|\bsed\b|receiptRefSlug/);
+  });
+
+  it("every exit path is `exit 0` — the hook never blocks the push", () => {
+    const exits = hook.match(/exit\s+\d+/g) ?? [];
+    expect(exits.length).toBeGreaterThan(0);
+    expect(exits.every((e) => e === "exit 0")).toBe(true);
+  });
+
+  it("the CLI invocation is best-effort: output is discarded and failures are swallowed", () => {
+    expect(hook).toContain(">/dev/null 2>&1 || true");
+  });
+
+  it("falls back through node dist/cli.js, then a PATH-installed aireceipts, without ever failing hard", () => {
+    expect(hook).toContain("dist/cli.js");
+    expect(hook).toContain("command -v aireceipts");
+  });
+
+  it("acts on a branch push whether the branch is the local ref or only the remote ref", () => {
+    // normal push: branch named on both sides
+    expect(hookActedOn("refs/heads/feat 111 refs/heads/feat 111\n")).toBe(true);
+    // `git push origin HEAD^:refs/heads/main` — the branch is named only on the remote side
+    expect(hookActedOn("HEAD^ 111 refs/heads/main 111\n")).toBe(true);
+  });
+
+  it("does NOT act on a ref-only receipts push — the recursion guard holds", () => {
+    expect(hookActedOn("refs/receipts/feat 222 refs/receipts/feat 222\n")).toBe(false);
+  });
+});
+
+describe("SPEC-0065 R2 --push-ref CLI surface", () => {
+  it("parses aireceipts pr --store ref --push-ref", () => {
+    const opts = parseOptions(["pr", "--store", "ref", "--push-ref"]);
+    expect(opts.store).toBe("ref");
+    expect(opts.pushRef).toBe(true);
+  });
+
+  it("defaults to pushRef=false (opt-in, never implied by --store ref alone)", () => {
+    expect(parseOptions(["pr", "--store", "ref"]).pushRef).toBe(false);
+  });
+
+  it("lists --push-ref in the pr command's help text", () => {
+    expect(prCommand.help.lines.join("\n")).toContain("--push-ref");
+  });
+});


### PR DESCRIPTION
## What this adds

**Phase 2 of seamless receipts (SPEC-0065 R2/R3):** a committed pre-push git hook that auto-attaches the `store=ref` receipt on every branch push, so a developer runs nothing extra. Builds on Phase 1's `--store ref` producer (PR #165).

## Why it matters to users

- After a one-time `npm run setup:hooks`, a branch `git push` writes and pushes `refs/receipts/<slug>` for you — the receipt travels with the branch, no manual `pr --post`.
- Best-effort and **never blocks a push**; opt-in and additive (default `pr` behavior unchanged).

## See it

```
$ npm run setup:hooks          # once per clone: sets core.hooksPath + builds the CLI
$ git commit -m "…" && git push
# → the pre-push hook writes + pushes refs/receipts/<slug>, silently, in the background
```

## What changed

- `--push-ref` flag (`src/cli/options.ts`, `src/cli/commands/pr.ts`, `src/pr/index.ts`): `pr --store ref --push-ref` writes the local ref **and** pushes it via `pushReceiptRef`, using the CLI's own `receiptRefSlug` (no shell-side slug to drift from CI). Best-effort — a failed push emits one stderr line, never throws, never changes the exit code.
- `.githooks/pre-push`: on a branch push (guarded on `refs/heads/*` in **either** the local or remote ref, so `HEAD^:refs/heads/main`-style refspecs are covered) runs `pr --store ref --push-ref`. Recursion-safe; never blocks the push (all failures swallowed).
- `package.json` `setup:hooks` (a normal script, **not** a publish lifecycle hook): sets `core.hooksPath` + builds the CLI.
- `test/pr/prepush-hook.test.ts`: content invariants + an **execution test** that runs the real hook for normal / remote-only-branch / receipts-ref-only pushes.
- `docs/pr-receipts.md`, `goldens/cli/help.txt` (regenerated for `--push-ref`), `scripts/hygiene.mjs` (`.githooks` allowlisted).

## What to review, in order

1. `.githooks/pre-push` — the branch-detection guard (local **or** remote ref) + recursion safety + never-block. (riskiest)
2. `scripts/preflight-release.mjs` — **unchanged** (full `prepare`/`prepack` ban kept). Activation uses a normal `setup:hooks` script, not a lifecycle hook, so the supply-chain gate stays strict. (Codex's key concern.)
3. `src/pr/index.ts` — the `--push-ref` best-effort push (never alters exit code / default behavior).
4. `test/pr/prepush-hook.test.ts` — the execution test.

## Evidence

Gates green (unmasked, all `0`): `tsc`, `eslint --max-warnings 0`, `vitest` 1557, `verify-goldens`, `determinism-check` 10×, `spec-lint`, `hygiene`, `preflight --quick`.
Spec: SPEC-0065 (R2/R3).
Independent review: Codex (different family), deep effort, **three rounds** → **PASS, no findings**. It caught (and this PR fixed) a supply-chain gate weakening, a fresh-checkout no-op, a stale doc/comment, and a refspec edge case in the branch guard.

## Notes

- **Honest limit:** git never auto-runs a fetched hook, so seamless mode needs the one `npm run setup:hooks` per clone. The CI check (Phase 3 / SPEC-0066) is the install-free layer that catches a missed receipt regardless.
- Phase 3 (CI reads the ref → validates + sanitizes + renders + posts) is the next PR; its sanitizer is already hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
