### PR TITLE
feat: SPEC-0066 — CI posts the PR receipt from the branch ref

### DIFF
--- a/.github/workflows/pr-receipt-check.yml
+++ b/.github/workflows/pr-receipt-check.yml
@@ -1,36 +1,91 @@
-# SPEC-0019 R5 — presence check for the aireceipts PR receipt comment.
-# Generation runs on the developer's machine (transcripts aren't on the runner),
-# so this workflow is notice-only by default. Maintainers can opt into same-repo
-# enforcement with the repository variable AIRECEIPTS_REQUIRE_PR_RECEIPT=true.
+# SPEC-0019 R5 + SPEC-0066 — the PR receipt check. A receipt is GENERATED on the
+# developer's machine (transcripts never reach the runner, I1/I4). This workflow only
+# transports it: if the branch carries a git-ref receipt (refs/receipts/<slug>, written by
+# the local store=ref producer / pre-push hook), CI fetches + SANITIZES + renders it, then
+# posts the comment. A receipt posted locally (`pr --post`) is honored as-is. Notice-only
+# by default; opt into same-repo enforcement with AIRECEIPTS_REQUIRE_PR_RECEIPT=true.
+#
+# TRUST BOUNDARY (Codex review). The untrusted, mutable `@latest` npm package renders in a
+# SEPARATE JOB (`render`) that has NO write token and only `contents: read`; its output
+# crosses to the privileged `post` job as a DATA-ONLY artifact. The `post` job starts from a
+# fresh checkout + clean runner, so nothing the package did (workspace edits, $GITHUB_PATH)
+# can reach the write token. Nothing unvalidated is posted: the payload is schema-validated
+# + sanitized (src/pr/sanitize.ts) before render, and `post` re-verifies the receipt marker.
 name: pr-receipt-check
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  # SPEC-0030 R3 — reusable: other repos adopt with a 3-line caller
-  # (docs/adopt/pr-receipt-check-caller.yml). Callers must reference
-  # anandgupta42/receipts — GitHub does NOT redirect reusable-workflow
-  # references after a rename, so callers are created only post-rename.
+  # SPEC-0030 R3 — reusable: other repos adopt with a 3-line caller.
   workflow_call: {}
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
-  check:
+  # 1. RENDER — untrusted @latest, NO write token, isolated runner. Fetches the branch's
+  #    receipt ref from the PR head repo and renders the sanitized body; uploads it ONLY if
+  #    it is a genuine receipt (marker-prefixed), so an @latest predating pr-render-ref (it
+  #    would run its default command) can't smuggle a bogus artifact downstream.
+  render:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      AIRECEIPTS_TELEMETRY: "off"
+      DO_NOT_TRACK: "1"
     steps:
-      # Always check out THIS repo (the workflow's home) explicitly: when
-      # called from another repo, the default checkout would fetch the
-      # CALLER's repo, which does not carry scripts/check-pr-receipt.mjs.
-      # Same-repo runs get main's copy of the script — a PR cannot tamper
-      # with the verdict logic it is being checked by.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: anandgupta42/receipts
           ref: main
-      - name: Check for the aireceipts receipt comment
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+      - name: Render the receipt from the branch ref (no write token)
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+        run: |
+          set -uo pipefail
+          npx -y aireceipts-cli@latest pr-render-ref "$HEAD_REF" "$HEAD_REPO_URL" > "$RUNNER_TEMP/out.md" 2>/dev/null || true
+          if [ -s "$RUNNER_TEMP/out.md" ] && head -c 64 "$RUNNER_TEMP/out.md" | grep -qF '<!-- aireceipts-dogfood -->'; then
+            cp "$RUNNER_TEMP/out.md" receipt-body.md
+          fi
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ hashFiles('receipt-body.md') != '' }}
+        with:
+          name: receipt-body
+          path: receipt-body.md
+          retention-days: 1
+
+  # 2. POST + CHECK — fresh runner + fresh checkout of the audited source. Consumes the
+  #    render output only as a data artifact and posts it with the write token, but ONLY a
+  #    marker-verified body. Enforcement lives in the tested verdict, not shell.
+  post:
+    needs: render
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      AIRECEIPTS_TELEMETRY: "off"
+      DO_NOT_TRACK: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: anandgupta42/receipts
+          ref: main
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        continue-on-error: true
+        with:
+          name: receipt-body
+          path: incoming
+      - name: Post the rendered receipt (if any) and check
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -38,26 +93,47 @@ jobs:
           BASE_REPO: ${{ github.repository }}
           REQUIRE_PR_RECEIPT: ${{ vars.AIRECEIPTS_REQUIRE_PR_RECEIPT }}
         run: |
-          set -euo pipefail
-          gh api --paginate "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" > comments.json || echo "[]" > comments.json
-          args=(comments.json --head-repo "$HEAD_REPO" --base-repo "$BASE_REPO")
-          if [ "${REQUIRE_PR_RECEIPT:-}" = "true" ]; then
-            args+=(--require-same-repo)
+          set -uo pipefail
+          MARKER='<!-- aireceipts-dogfood -->'
+          BODY=incoming/receipt-body.md
+
+          receipt_verdict() {
+            gh api --paginate "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments" > comments.json || echo "[]" > comments.json
+            args=(comments.json --head-repo "$HEAD_REPO" --base-repo "$BASE_REPO")
+            if [ "${REQUIRE_PR_RECEIPT:-}" = "true" ]; then args+=(--require-same-repo); fi
+            node scripts/check-pr-receipt.mjs "${args[@]}"
+          }
+
+          # A receipt comment already present (posted locally, or by a prior run)? Done.
+          if [ "$(receipt_verdict)" = "found" ]; then
+            echo "aireceipts receipt comment present."
+            exit 0
           fi
-          verdict=$(node scripts/check-pr-receipt.mjs "${args[@]}")
-          case "$verdict" in
+
+          # Post the artifact body ONLY if it is genuinely a receipt (marker-prefixed).
+          if [ -s "$BODY" ] && head -c 64 "$BODY" | grep -qF "$MARKER"; then
+            existing=$(node -e 'const c=require("./comments.json");const m=process.argv[1];const f=Array.isArray(c)?c.find(x=>x&&typeof x.body==="string"&&x.body.startsWith(m)):null;process.stdout.write(f&&typeof f.id==="number"?String(f.id):"")' "$MARKER" 2>/dev/null || true)
+            jq -Rs '{body: .}' < "$BODY" > "$RUNNER_TEMP/comment.json"
+            if [ -n "$existing" ]; then
+              gh api "repos/${BASE_REPO}/issues/comments/${existing}" -X PATCH --input "$RUNNER_TEMP/comment.json" >/dev/null
+            else
+              gh api "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments" -X POST --input "$RUNNER_TEMP/comment.json" >/dev/null
+            fi
+          fi
+
+          case "$(receipt_verdict)" in
             found)
-              echo "aireceipts receipt comment present."
+              echo "aireceipts receipt posted from the branch's receipt ref."
               ;;
             missing-required)
-              echo "::error::No aireceipts receipt comment found. This repo has AIRECEIPTS_REQUIRE_PR_RECEIPT=true, so run \`npx aireceipts pr --post\` from your worktree and rerun this check."
+              echo "::error::No aireceipts receipt for this PR. Enable the pre-push hook (\`npm run setup:hooks\`) or run \`npx aireceipts-cli pr --post\`, then rerun."
               exit 1
               ;;
             missing-notice)
-              echo "::notice::No aireceipts receipt comment found. Run \`npx aireceipts pr --post\` from your worktree to attach one. Maintainers can opt into same-repo enforcement with AIRECEIPTS_REQUIRE_PR_RECEIPT=true."
+              echo "::notice::No aireceipts receipt for this PR yet. Enable the pre-push hook (\`npm run setup:hooks\`) to attach one on every push, or run \`npx aireceipts-cli pr --post\`."
               ;;
             *)
-              echo "::error::Unexpected pr receipt verdict: $verdict"
+              echo "::error::Unexpected pr receipt verdict."
               exit 1
               ;;
           esac

--- a/src/cli/commands/pr-render-ref.ts
+++ b/src/cli/commands/pr-render-ref.ts
@@ -1,0 +1,43 @@
+// SPEC-0066 R1/R3 — the CI render entrypoint (NO write token). Two modes:
+//   `pr-render-ref <branch> <head-repo-url>` — fetch the branch's receipt ref from the PR
+//       head repo, validate + sanitize, print the comment body (the CI path).
+//   `pr-render-ref`  (no args) — read a payload JSON on stdin and render it (local/debug).
+// Hidden (no help entry): the reusable workflow invokes it as
+// `npx aireceipts-cli@latest pr-render-ref <branch> <url>`, then posts the sanitized body
+// in a separate audited step with the token. Invalid/hostile input exits non-zero with
+// nothing on stdout (CI treats that as "no receipt"). Generation stays local (I1/I4).
+import { fetchReceiptRef, readReceiptRef } from "../../pr/store.js";
+import { fetchAndRenderReceipt, renderReceiptPayload } from "../../pr/postRef.js";
+import { readStdin } from "./statusline.js";
+import type { CommandContext, CommandDef } from "../types.js";
+
+async function run(ctx: CommandContext): Promise<number> {
+  const [, branch, remoteUrl] = ctx.options.positional;
+  if (branch && remoteUrl) {
+    const out = fetchAndRenderReceipt(
+      { branch, remoteUrl, cwd: ctx.cwd() },
+      { fetchRef: fetchReceiptRef, readRef: readReceiptRef },
+    );
+    if (out.code !== 0) {
+      ctx.stderr.write(`pr-render-ref: ${out.message}\n`);
+      return out.code;
+    }
+    ctx.stdout.write(`${out.body}\n`);
+    return 0;
+  }
+
+  const rendered = renderReceiptPayload(await readStdin(ctx.stdin));
+  if (!rendered.ok) {
+    ctx.stderr.write(`pr-render-ref: invalid receipt payload — ${rendered.reason}\n`);
+    return 1;
+  }
+  ctx.stdout.write(`${rendered.body}\n`);
+  return 0;
+}
+
+export const command: CommandDef = {
+  name: "pr-render-ref",
+  priority: 60,
+  matches: (options) => options.positional[0] === "pr-render-ref",
+  run,
+};

--- a/src/pr/postRef.ts
+++ b/src/pr/postRef.ts
@@ -1,0 +1,58 @@
+// SPEC-0066 R1/R3 — the CI RENDER path (no write token): fetch a branch's receipt ref
+// from the PR head repo, validate + sanitize the untrusted payload, and render the comment
+// body. The workflow runs this via `npx aireceipts-cli@latest pr-render-ref` WITHOUT
+// GITHUB_TOKEN, then posts the sanitized body in a separate audited step — so a mutable
+// npm package never holds the write token (Codex trust-boundary review). Generation stays
+// local (I1/I4); this only re-renders what the producer already computed.
+import { renderPrBody } from "./body.js";
+import { deserializePrReceipt, sanitizePrReceiptPayload } from "./sanitize.js";
+import { receiptRefSlug } from "./payloadTypes.js";
+
+/** Validate + sanitize an untrusted ref payload JSON, then render the PR comment body. */
+export function renderReceiptPayload(json: string): { ok: true; body: string } | { ok: false; reason: string } {
+  const parsed = deserializePrReceipt(json);
+  if (!parsed.ok) {
+    return { ok: false, reason: parsed.reason };
+  }
+  const sanitized = sanitizePrReceiptPayload(parsed.payload);
+  return { ok: true, body: renderPrBody(sanitized.bodyInput, sanitized.extras) };
+}
+
+export interface FetchRenderDeps {
+  fetchRef: (slug: string, remoteUrl: string, cwd?: string) => boolean;
+  readRef: (slug: string, cwd?: string) => string | null;
+}
+
+export interface FetchRenderArgs {
+  branch: string;
+  remoteUrl: string;
+  cwd?: string;
+}
+
+/** `code`: 0 rendered (body set) · 2 no/unreadable ref · 3 invalid payload. Never posts. */
+export interface FetchRenderOutcome {
+  code: number;
+  body?: string;
+  message: string;
+}
+
+/**
+ * Fetch the branch's receipt ref from `remoteUrl` (the PR head repo's clone URL) and render
+ * it. `slug` is derived by the CLI's own `receiptRefSlug`, so it always matches what the
+ * producer wrote (no shell-side drift). An unreadable/invalid ref renders nothing.
+ */
+export function fetchAndRenderReceipt(args: FetchRenderArgs, deps: FetchRenderDeps): FetchRenderOutcome {
+  const slug = receiptRefSlug(args.branch);
+  if (!deps.fetchRef(slug, args.remoteUrl, args.cwd)) {
+    return { code: 2, message: `no receipt ref refs/receipts/${slug} on the PR head repo` };
+  }
+  const json = deps.readRef(slug, args.cwd);
+  if (json === null) {
+    return { code: 2, message: `refs/receipts/${slug} present but receipt.json is unreadable` };
+  }
+  const rendered = renderReceiptPayload(json);
+  if (!rendered.ok) {
+    return { code: 3, message: `invalid receipt payload — ${rendered.reason}` };
+  }
+  return { code: 0, body: rendered.body, message: `rendered receipt for refs/receipts/${slug}` };
+}

--- a/src/pr/sanitize.ts
+++ b/src/pr/sanitize.ts
@@ -1,0 +1,379 @@
+// SPEC-0066 R2/R3 — validate + sanitize the untrusted `PrReceiptPayload` read
+// from `refs/receipts/<slug>` before it ever reaches `renderPrBody`. The ref is
+// fork/branch-author-controlled input crossing a new trust boundary: CI parses
+// it and posts the rendered result with a write token (`GITHUB_TOKEN`). Every
+// string the payload carries is therefore untrusted and could carry a
+// Markdown/HTML injection (`DetailReceipt.text` is pre-rendered Markdown;
+// `label`, `row` cells, contributor model names, and waste-line strings are
+// all attacker-influenceable).
+//
+// `deserializePrReceipt` never throws on hostile input — malformed JSON, an
+// unknown `schemaVersion`, unknown fields at any level, non-finite numbers
+// (reachable via a JSON literal like `1e400`, which parses to `Infinity`),
+// and over-cap strings/arrays all fall through to `{ ok: false }`. CI treats
+// that exactly like a missing receipt (R2) — it never posts an unvalidated
+// payload.
+//
+// `sanitizePrReceiptPayload` then returns a deep copy with every
+// attacker-influenceable string neutralized for safe embedding in a GitHub
+// Markdown comment: a code-fence guard (an injected ``` must not break out of
+// the receipt's own fence), raw-HTML neutralization (`<details>`, `<script>`,
+// `<img onerror=...>` become inert text), Markdown-link defanging (`[text](url)`
+// collapses to `text`, dropping the URL), and a length cap per field.
+//
+// Validation uses `zod` (already a dependency — see `src/telemetry/schemas.ts`
+// / `src/receipt/exportSchema.ts` for the same `.strict()` pattern used here)
+// rather than hand-rolled type guards: the payload's shape is deep (six levels
+// of nesting through `ContributorView`/`ModelMixEntry`/`SubagentRow`/`WasteLine`),
+// and `zod` gives unknown-key rejection (`.strict()`), non-finite rejection
+// (`.finite()`), and length caps (`.max()`) at every level for free, instead of
+// a few hundred lines of manual `typeof`/`Array.isArray` checks that would be
+// far easier to under-cover.
+import { z } from "zod";
+import { PR_RECEIPT_SCHEMA_VERSION, type PrReceiptPayload } from "./payloadTypes.js";
+
+/**
+ * R2 — a sane upper bound on any single string in the untrusted payload;
+ * anything longer is REJECTED outright (not sanitized) before any Markdown
+ * rendering is attempted. Deliberately generous relative to the per-field
+ * sanitize caps below — this is a "reject the absurd" ceiling, not the cap
+ * that shapes the final comment.
+ */
+export const MAX_PAYLOAD_STRING_LENGTH = 200_000;
+
+/**
+ * R2 — a sane upper bound on any array in the payload. Guards against a
+ * payload built to exhaust CI resources (e.g. a million-entry `contributors`
+ * array) rather than to inject Markdown.
+ */
+export const MAX_PAYLOAD_ARRAY_LENGTH = 2_000;
+
+/**
+ * R3 — the sanitize-time truncation length for short, single-line display
+ * fields (model names, labels, table cells, tool identifiers, artifact
+ * fileName/url). Generous for legitimate content, small enough that a
+ * hostile value can't dominate the rendered comment.
+ */
+export const SANITIZED_FIELD_CAP = 2_000;
+
+/**
+ * R3 — the sanitize-time truncation length for the largest free-text fields
+ * (`DetailReceipt.text`/`subagents`, the pre-rendered per-session blocks).
+ * Mirrors the value of `COMMENT_SIZE_CAP` in `body.ts` (module-private there,
+ * so redefined here) — these are the fields whose size actually dominates a
+ * rendered comment.
+ */
+export const SANITIZED_TEXT_CAP = 65_000;
+
+const str = () => z.string().max(MAX_PAYLOAD_STRING_LENGTH);
+const finiteNum = () => z.number().finite();
+const boundedArray = <T extends z.ZodTypeAny>(schema: T) => z.array(schema).max(MAX_PAYLOAD_ARRAY_LENGTH);
+
+const tokenUsageSchema = z
+  .object({
+    input: finiteNum(),
+    output: finiteNum(),
+    cacheRead: finiteNum(),
+    cacheCreation: finiteNum(),
+    cacheCreation5m: finiteNum().optional(),
+    cacheCreation1h: finiteNum().optional(),
+    total: finiteNum(),
+  })
+  .strict();
+
+const modelMixEntrySchema = z
+  .object({
+    model: str(),
+    tokens: tokenUsageSchema,
+    tokenShare: finiteNum(),
+    usd: finiteNum().nullable(),
+  })
+  .strict();
+
+const sliceResultSchema = z
+  .object({
+    kind: z.enum(["slice", "full"]),
+    startTurn: finiteNum(),
+    endTurn: finiteNum(),
+    turnCount: finiteNum(),
+    label: str().optional(),
+  })
+  .strict();
+
+const subagentRowSchema = z
+  .object({
+    name: str(),
+    model: str().optional(),
+    usd: finiteNum().nullable(),
+    tokens: tokenUsageSchema,
+    unreadable: z.boolean(),
+    droppedRecords: finiteNum().optional(),
+    filePath: str(),
+  })
+  .strict();
+
+const confidenceSummarySchema = z
+  .object({
+    unattributableAnchorPool: finiteNum(),
+    silencedGitWrite: finiteNum(),
+    unreadableSubagent: finiteNum(),
+    costLowerBoundCacheTier: finiteNum(),
+    unreadableSession: finiteNum(),
+    droppedTranscriptRecords: finiteNum(),
+  })
+  .strict();
+
+const contributorViewSchema = z
+  .object({
+    role: z.enum(["orchestrator", "builder", "codex"]),
+    sessionId: str(),
+    slice: sliceResultSchema,
+    modelMix: boundedArray(modelMixEntrySchema),
+    usd: finiteNum().nullable(),
+    tokens: tokenUsageSchema,
+    subagents: boundedArray(subagentRowSchema),
+    basis: z.enum(["anchor", "helper", "message"]).optional(),
+    durationMs: finiteNum().optional(),
+  })
+  .strict();
+
+const prBodyInputSchema = z
+  .object({
+    contributors: boundedArray(contributorViewSchema),
+    excludedCount: finiteNum(),
+    detailsBelow: z.boolean().optional(),
+    confidence: confidenceSummarySchema.optional(),
+  })
+  .strict();
+
+const detailReceiptSchema = z
+  .object({
+    label: str(),
+    row: boundedArray(str()),
+    text: str(),
+    subagents: str().optional(),
+  })
+  .strict();
+
+const stuckLoopWasteLineSchema = z
+  .object({
+    kind: z.literal("stuck-loop"),
+    tool: str(),
+    runLength: finiteNum(),
+    usd: finiteNum().nullable(),
+    tokens: tokenUsageSchema,
+    wallClockMs: finiteNum().nullable(),
+    turnIndices: boundedArray(finiteNum()),
+  })
+  .strict();
+
+const trivialSpansWasteLineSchema = z
+  .object({
+    kind: z.literal("trivial-spans"),
+    eligibleTurnCount: finiteNum(),
+    usd: finiteNum(),
+    tokens: tokenUsageSchema,
+    cheaperModel: str(),
+  })
+  .strict();
+
+const contextThrashWasteLineSchema = z
+  .object({
+    kind: z.literal("context-thrash"),
+    compactionCount: finiteNum(),
+    turnSpan: finiteNum(),
+    turnIndices: boundedArray(finiteNum()),
+    usd: finiteNum().nullable(),
+    tokens: tokenUsageSchema,
+  })
+  .strict();
+
+const wasteLineSchema = z.discriminatedUnion("kind", [
+  stuckLoopWasteLineSchema,
+  trivialSpansWasteLineSchema,
+  contextThrashWasteLineSchema,
+]);
+
+const handoffSectionDataSchema = z
+  .object({
+    wasteLines: boundedArray(wasteLineSchema),
+    sessionCount: finiteNum(),
+    turnCount: finiteNum(),
+  })
+  .strict();
+
+const artifactLinkSchema = z
+  .object({
+    fileName: str(),
+    url: str(),
+  })
+  .strict();
+
+const prBodyExtrasSchema = z
+  .object({
+    artifactLink: artifactLinkSchema.optional(),
+    details: boundedArray(detailReceiptSchema).optional(),
+    handoff: handoffSectionDataSchema.optional(),
+  })
+  .strict();
+
+const prReceiptPayloadSchema = z
+  .object({
+    schemaVersion: z.literal(PR_RECEIPT_SCHEMA_VERSION),
+    bodyInput: prBodyInputSchema,
+    extras: prBodyExtrasSchema,
+  })
+  .strict();
+
+export type DeserializeResult = { ok: true; payload: PrReceiptPayload } | { ok: false; reason: string };
+
+/**
+ * R2 — parse + structurally validate the untrusted ref blob. Never throws:
+ * a `JSON.parse` failure, a wrong/missing `schemaVersion`, an unknown field
+ * at any level (`.strict()` on every object schema), a non-finite number
+ * (`.finite()` on every number field — reachable from valid JSON via an
+ * extreme literal like `1e400`), or an over-cap string/array all resolve to
+ * `{ ok: false }` rather than an exception.
+ */
+export function deserializePrReceipt(json: string): DeserializeResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return { ok: false, reason: "invalid JSON" };
+  }
+
+  const result = prReceiptPayloadSchema.safeParse(parsed);
+  if (!result.success) {
+    const first = result.error.issues[0];
+    const path = first && first.path.length > 0 ? first.path.join(".") : "(root)";
+    return { ok: false, reason: `${path}: ${first?.message ?? "schema validation failed"}` };
+  }
+  return { ok: true, payload: result.data as PrReceiptPayload };
+}
+
+/** Zero-width space (U+200B) — invisible to a reader, but splits a run of fence characters so it can never match a fence-opening/closing line. Written as an escape (not a literal character) so it stays unambiguous in diffs/review. */
+const ZERO_WIDTH_SPACE = "\u200B";
+
+/** Breaks up any run of 3+ backtick or tilde characters (GFM's two fence delimiters) with a zero-width space between every character, so an injected fence run can never be parsed as a fence-opening/closing line — while remaining visually identical to a reader. */
+function guardCodeFences(value: string): string {
+  return value.replace(/[`~]{3,}/g, (run) => run.split("").join(ZERO_WIDTH_SPACE));
+}
+
+/** HTML-entity-encodes `<`/`>` so any raw tag (`<details>`, `<script>`, `<img onerror=...>`, HTML comments) becomes inert text instead of a parsed element. */
+function neutralizeHtml(value: string): string {
+  return value.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/** Collapses a Markdown link `[text](url)` to just `text`, dropping the URL entirely (a `javascript:`/`data:` URI or a phishing link never survives). */
+function defangMarkdownLinks(value: string): string {
+  // Allow one level of nested parens in the URL so `[t](javascript:alert(1))` fully
+  // collapses to `t` instead of leaving a stray `)`. The alternation branches are
+  // disjoint on the first char (non-paren vs `(`), so this can't backtrack (no ReDoS).
+  return value.replace(/\[([^\]]*)\]\((?:[^()]|\([^()]*\))*\)/g, "$1");
+}
+
+/** Truncates to `maxLength` code points (not UTF-16 code units, so multi-byte characters aren't split), appending an ellipsis when truncated. */
+function capString(value: string, maxLength: number): string {
+  const chars = [...value];
+  if (chars.length <= maxLength) {
+    return value;
+  }
+  if (maxLength <= 0) {
+    return "";
+  }
+  return chars.slice(0, maxLength - 1).join("") + "…";
+}
+
+/** Escapes Markdown link brackets so no link — inline `[t](u)`, reference `[t][r]`, or a `[r]: url` definition — can form from untrusted text. Runs AFTER inline-link defanging (which cleans the common `[t](u)` case), catching reference-style links and residual brackets that defanging leaves behind. */
+function escapeMarkdownBrackets(value: string): string {
+  return value.replace(/[[\]]/g, (bracket) => `\\${bracket}`);
+}
+
+/** Breaks GitHub's BARE autolinker (GFM turns a raw `https://…`, `http://…`, `ftp://…`, `www.…`, a bare email `a@b.tld`, or a `mailto:`/`xmpp:` form into a live link with no `[]()` syntax) by splicing a zero-width space into each trigger, so an attacker string in a live-markdown field can't become a clickable link. */
+function defangAutolinks(value: string): string {
+  return value
+    // protocol schemes (http/https/ftp autolinked; mailto/xmpp become mail links)
+    .replace(/(https?|ftp|mailto|xmpp):/gi, `$1:${ZERO_WIDTH_SPACE}`)
+    // bare `www.` autolink
+    .replace(/(www)\./gi, `$1${ZERO_WIDTH_SPACE}.`)
+    // bare email autolink (`local@domain.tld`) — split the `@`
+    .replace(/([\w.+-]+)@([\w-]+\.[\w.-]+)/g, `$1@${ZERO_WIDTH_SPACE}$2`);
+}
+
+/** A field rendered as LIVE Markdown (headings, table cells, the artifact link text): guard fences, neutralize raw HTML, defang inline + bare-autolink links, escape residual link brackets, then cap. */
+function sanitizeMarkdown(value: string, maxLength: number): string {
+  const guarded = guardCodeFences(value);
+  const htmlSafe = neutralizeHtml(guarded);
+  const linkless = escapeMarkdownBrackets(defangAutolinks(defangMarkdownLinks(htmlSafe)));
+  return capString(linkless, maxLength);
+}
+
+/** A field rendered INSIDE a code fence (the pre-rendered per-session receipt `text`): Markdown is inert there, so only a fence breakout matters — guard fences and cap, and deliberately DON'T HTML-encode or escape brackets, which would corrupt the literal receipt bytes. */
+function sanitizeFenced(value: string, maxLength: number): string {
+  return capString(guardCodeFences(value), maxLength);
+}
+
+/** An `artifactLink.url` is rendered raw into a Markdown link TARGET (`[text](url)`). Allow
+ * only `https://…` with NO character that could close the target early or open a new element
+ * — no whitespace, and no `( ) [ ] < > \`` (a url like `https://ok)![x](evil` would otherwise
+ * break out and render a second live link). Anything else returns null and the link is dropped.
+ * A legitimate artifact URL (a github.io viewer link with a percent-encoded `?src=`) has none
+ * of these raw. */
+function safeArtifactUrl(url: string): string | null {
+  return /^https:\/\/[^\s()[\]<>`]+$/i.test(url) ? url : null;
+}
+
+/**
+ * R3 — returns a deep copy of `payload` with every attacker-influenceable
+ * string neutralized for the exact position it renders into. Live-Markdown
+ * fields (`extras.details[].label/row[]/subagents`, contributor model names,
+ * `extras.handoff.wasteLines[]`, `extras.artifactLink.fileName`) get the full
+ * fence/HTML/link/bracket treatment; `extras.details[].text` renders inside a
+ * code fence and gets fence-guard + cap only; `extras.artifactLink.url` is a
+ * link target and is `https://`-allowlisted (the whole link is dropped if it
+ * isn't safe). Never mutates the input.
+ */
+export function sanitizePrReceiptPayload(payload: PrReceiptPayload): PrReceiptPayload {
+  const sanitized = JSON.parse(JSON.stringify(payload)) as PrReceiptPayload;
+
+  for (const contributor of sanitized.bodyInput.contributors) {
+    for (const entry of contributor.modelMix) {
+      entry.model = sanitizeMarkdown(entry.model, SANITIZED_FIELD_CAP);
+    }
+  }
+
+  if (sanitized.extras.details) {
+    for (const detail of sanitized.extras.details) {
+      detail.label = sanitizeMarkdown(detail.label, SANITIZED_FIELD_CAP);
+      detail.row = detail.row.map((cell) => sanitizeMarkdown(cell, SANITIZED_FIELD_CAP));
+      detail.text = sanitizeFenced(detail.text, SANITIZED_TEXT_CAP);
+      if (detail.subagents !== undefined) {
+        detail.subagents = sanitizeMarkdown(detail.subagents, SANITIZED_TEXT_CAP);
+      }
+    }
+  }
+
+  if (sanitized.extras.handoff) {
+    for (const line of sanitized.extras.handoff.wasteLines) {
+      if (line.kind === "stuck-loop") {
+        line.tool = sanitizeMarkdown(line.tool, SANITIZED_FIELD_CAP);
+      } else if (line.kind === "trivial-spans") {
+        line.cheaperModel = sanitizeMarkdown(line.cheaperModel, SANITIZED_FIELD_CAP);
+      }
+    }
+  }
+
+  if (sanitized.extras.artifactLink) {
+    const url = safeArtifactUrl(sanitized.extras.artifactLink.url);
+    if (url === null) {
+      // A non-https target can't be made safe in link-target position — drop the link.
+      sanitized.extras.artifactLink = undefined;
+    } else {
+      sanitized.extras.artifactLink.fileName = sanitizeMarkdown(sanitized.extras.artifactLink.fileName, SANITIZED_FIELD_CAP);
+      sanitized.extras.artifactLink.url = url;
+    }
+  }
+
+  return sanitized;
+}

--- a/src/pr/store.ts
+++ b/src/pr/store.ts
@@ -126,6 +126,21 @@ export function pushReceiptRef(slug: string, remote = "origin", cwd?: string): b
   return result.ok;
 }
 
+/**
+ * SPEC-0066 R1 — fetch one receipt ref from `remoteUrl` into the local ref namespace,
+ * for the CI side. `remoteUrl` is the PR head repo's clone URL (a fork's own URL), never
+ * a named remote. Returns whether the ref now exists locally. `--no-tags` keeps the fetch
+ * to exactly the one receipt ref.
+ */
+export function fetchReceiptRef(slug: string, remoteUrl: string, cwd?: string): boolean {
+  const ref = receiptRef(slug);
+  const fetched = git(["fetch", "--no-tags", remoteUrl, `+${ref}:${ref}`], { cwd });
+  if (!fetched.ok) {
+    return false;
+  }
+  return git(["cat-file", "-e", `${ref}:receipt.json`], { cwd }).ok;
+}
+
 export interface ReceiptRefEntry {
   ref: string;
   slug: string;

--- a/test/cli/pr-render-ref.test.ts
+++ b/test/cli/pr-render-ref.test.ts
@@ -1,0 +1,83 @@
+// SPEC-0066 R1/R3 — `pr-render-ref` is the CI render entrypoint: read an untrusted
+// PrReceiptPayload on stdin, validate + sanitize, print the comment body. A malformed
+// payload exits non-zero with nothing on stdout (CI treats it as "no receipt").
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { parseOptions } from "../../src/cli/options.js";
+import type { CommandContext } from "../../src/cli/types.js";
+import { command } from "../../src/cli/commands/pr-render-ref.js";
+import { PR_RECEIPT_SCHEMA_VERSION } from "../../src/pr/payloadTypes.js";
+
+function stdinStub(payload: string): NodeJS.ReadStream {
+  const stream = Readable.from(payload ? [Buffer.from(payload, "utf8")] : []) as unknown as NodeJS.ReadStream;
+  (stream as unknown as { isTTY: boolean }).isTTY = false;
+  return stream;
+}
+
+function fakeContext(argv: string[], stdin: NodeJS.ReadStream): { ctx: CommandContext; out: () => string; err: () => string } {
+  let out = "";
+  let err = "";
+  const stdout = { write: (s: string) => ((out += s), true) } as unknown as NodeJS.WriteStream;
+  const stderr = { write: (s: string) => ((err += s), true) } as unknown as NodeJS.WriteStream;
+  const ctx = {
+    options: parseOptions(argv),
+    stdin,
+    stdout,
+    stderr,
+    env: {},
+    cwd: () => process.cwd(),
+    now: () => 0,
+    fs: { writeFile: async () => {} },
+    prompt: async () => false,
+    telemetry: {
+      showPayload: () => ({ enabled: false, events: [] }),
+      noteReceiptGenerated: async () => {},
+      recordExportGenerated: () => {},
+      recordPrFlowCompleted: () => {},
+      recordHookConfigured: () => {},
+      recordIntegrationSurfaceRendered: () => {},
+      noteMilestone: async () => {},
+    },
+    renderHelp: () => "",
+  } as unknown as CommandContext;
+  return { ctx, out: () => out, err: () => err };
+}
+
+describe("SPEC-0066 pr-render-ref", () => {
+  it("matches the `pr-render-ref` positional only", () => {
+    expect(command.matches(parseOptions(["pr-render-ref"]))).toBe(true);
+    expect(command.matches(parseOptions(["pr"]))).toBe(false);
+  });
+
+  it("renders the comment body from a valid payload and exits 0", async () => {
+    const payload = JSON.stringify({
+      schemaVersion: PR_RECEIPT_SCHEMA_VERSION,
+      bodyInput: { contributors: [], excludedCount: 0 },
+      extras: { artifactLink: { fileName: "pr.html", url: "https://anandgupta42.github.io/receipts/view.html" } },
+    });
+    const { ctx, out } = fakeContext(["pr-render-ref"], stdinStub(payload));
+    expect(await command.run(ctx)).toBe(0);
+    expect(out()).toContain("full receipt:");
+    expect(out()).toContain("https://anandgupta42.github.io/receipts/view.html");
+  });
+
+  it("rejects an invalid payload: exit 1, nothing on stdout, reason on stderr", async () => {
+    const { ctx, out, err } = fakeContext(["pr-render-ref"], stdinStub("{not json"));
+    expect(await command.run(ctx)).toBe(1);
+    expect(out()).toBe("");
+    expect(err()).toContain("invalid receipt payload");
+  });
+
+  it("sanitizes a hostile payload before rendering — no live javascript link survives", async () => {
+    const hostile = JSON.stringify({
+      schemaVersion: PR_RECEIPT_SCHEMA_VERSION,
+      bodyInput: { contributors: [], excludedCount: 0 },
+      extras: { artifactLink: { fileName: "p.html", url: "javascript:alert(1)" } },
+    });
+    const { ctx, out } = fakeContext(["pr-render-ref"], stdinStub(hostile));
+    expect(await command.run(ctx)).toBe(0);
+    expect(out()).not.toMatch(/\]\(\s*javascript:/i);
+    // the javascript: artifact url is dropped, so no "full receipt:" link line renders
+    expect(out()).not.toContain("full receipt:");
+  });
+});

--- a/test/pr/postRef.test.ts
+++ b/test/pr/postRef.test.ts
@@ -1,0 +1,52 @@
+// SPEC-0066 R1/R3 — the CI render path (no write token): fetch the ref, validate +
+// sanitize + render. No ref → 2, unreadable → 2, invalid payload → 3 (no body), valid → 0
+// with the SANITIZED body. No `gh`/token is involved — posting is a separate audited step.
+import { describe, expect, it } from "vitest";
+import { fetchAndRenderReceipt, renderReceiptPayload, type FetchRenderDeps } from "../../src/pr/postRef.js";
+import { PR_RECEIPT_SCHEMA_VERSION } from "../../src/pr/payloadTypes.js";
+
+const ARGS = { branch: "feat/x", remoteUrl: "https://example.com/r.git" };
+
+describe("fetchAndRenderReceipt", () => {
+  it("returns code 2 when no ref is fetched", () => {
+    const deps: FetchRenderDeps = { fetchRef: () => false, readRef: () => null };
+    const out = fetchAndRenderReceipt(ARGS, deps);
+    expect(out.code).toBe(2);
+    expect(out.body).toBeUndefined();
+  });
+
+  it("returns code 2 when the ref is present but receipt.json is unreadable", () => {
+    const deps: FetchRenderDeps = { fetchRef: () => true, readRef: () => null };
+    expect(fetchAndRenderReceipt(ARGS, deps).code).toBe(2);
+  });
+
+  it("returns code 3 on an invalid payload and renders no body", () => {
+    const deps: FetchRenderDeps = { fetchRef: () => true, readRef: () => "{not json" };
+    const out = fetchAndRenderReceipt(ARGS, deps);
+    expect(out.code).toBe(3);
+    expect(out.body).toBeUndefined();
+  });
+
+  it("returns code 0 with the SANITIZED body on a valid payload", () => {
+    const hostile = JSON.stringify({
+      schemaVersion: PR_RECEIPT_SCHEMA_VERSION,
+      bodyInput: { contributors: [], excludedCount: 0 },
+      extras: { details: [{ label: "[x](javascript:alert(1))", row: [], text: "t" }], artifactLink: { fileName: "p.html", url: "javascript:alert(1)" } },
+    });
+    const deps: FetchRenderDeps = { fetchRef: () => true, readRef: () => hostile };
+    const out = fetchAndRenderReceipt(ARGS, deps);
+    expect(out.code).toBe(0);
+    expect(out.body ?? "").not.toMatch(/\]\(\s*javascript:/i);
+    expect(out.body ?? "").not.toContain("full receipt:"); // the javascript: artifact url was dropped
+  });
+});
+
+describe("renderReceiptPayload", () => {
+  it("rejects malformed JSON without throwing", () => {
+    expect(renderReceiptPayload("{not json").ok).toBe(false);
+  });
+  it("renders a valid payload", () => {
+    const json = JSON.stringify({ schemaVersion: PR_RECEIPT_SCHEMA_VERSION, bodyInput: { contributors: [], excludedCount: 0 }, extras: {} });
+    expect(renderReceiptPayload(json).ok).toBe(true);
+  });
+});

--- a/test/pr/sanitize.test.ts
+++ b/test/pr/sanitize.test.ts
@@ -1,0 +1,380 @@
+// SPEC-0066 R2/R3 — the injection corpus pinning `deserializePrReceipt`
+// (reject malformed/hostile payload shapes) and `sanitizePrReceiptPayload`
+// (neutralize every injection vector that DOES pass validation) against the
+// scenarios in SPEC-0066's test matrix: fence breakout, `<details>`/`<script>`
+// injection, `<img onerror>`, Markdown-link injection, `NaN`/`Infinity`,
+// unknown extra field, oversized string.
+import { describe, expect, it } from "vitest";
+import {
+  deserializePrReceipt,
+  sanitizePrReceiptPayload,
+  MAX_PAYLOAD_STRING_LENGTH,
+  SANITIZED_FIELD_CAP,
+} from "../../src/pr/sanitize.js";
+import { PR_RECEIPT_SCHEMA_VERSION, type PrReceiptPayload } from "../../src/pr/payloadTypes.js";
+import { renderPrBody } from "../../src/pr/body.js";
+import type { StuckLoopWasteLine, TrivialSpansWasteLine } from "../../src/receipt/model.js";
+
+const emptyTokens = () => ({ input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 });
+
+function basePayload(overrides: Partial<PrReceiptPayload> = {}): PrReceiptPayload {
+  return {
+    schemaVersion: PR_RECEIPT_SCHEMA_VERSION,
+    bodyInput: { contributors: [], excludedCount: 0 },
+    extras: {},
+    ...overrides,
+  };
+}
+
+describe("deserializePrReceipt", () => {
+  it("accepts a clean, minimal payload", () => {
+    const result = deserializePrReceipt(JSON.stringify(basePayload()));
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a clean, fully-populated payload", () => {
+    const payload = basePayload({
+      bodyInput: {
+        contributors: [
+          {
+            role: "builder",
+            sessionId: "abc123",
+            slice: { kind: "slice", startTurn: 0, endTurn: 3, turnCount: 4 },
+            modelMix: [{ model: "claude-opus-4-8", tokens: emptyTokens(), tokenShare: 1, usd: 1.5 }],
+            usd: 1.5,
+            tokens: emptyTokens(),
+            subagents: [],
+          },
+        ],
+        excludedCount: 0,
+      },
+      extras: {
+        details: [{ label: "builder — abc123", row: ["builder", "abc123", "full"], text: "receipt text" }],
+        handoff: {
+          wasteLines: [
+            {
+              kind: "stuck-loop",
+              tool: "Bash",
+              runLength: 3,
+              usd: 0.1,
+              tokens: emptyTokens(),
+              wallClockMs: 1000,
+              turnIndices: [1, 2, 3],
+            },
+          ],
+          sessionCount: 1,
+          turnCount: 4,
+        },
+        artifactLink: { fileName: "receipt.png", url: "https://example.com/receipt.png" },
+      },
+    });
+    const result = deserializePrReceipt(JSON.stringify(payload));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload).toEqual(payload);
+    }
+  });
+
+  it("rejects invalid JSON without throwing", () => {
+    expect(() => deserializePrReceipt("{not json")).not.toThrow();
+    const result = deserializePrReceipt("{not json");
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects an unknown schemaVersion", () => {
+    const raw = JSON.stringify({ ...basePayload(), schemaVersion: 999 });
+    expect(deserializePrReceipt(raw).ok).toBe(false);
+  });
+
+  it("rejects an unknown top-level field", () => {
+    const raw = JSON.stringify({ ...basePayload(), extraField: "smuggled" });
+    expect(deserializePrReceipt(raw).ok).toBe(false);
+  });
+
+  it("rejects an unknown nested field", () => {
+    const payload = basePayload({ extras: { details: [{ label: "x", row: [], text: "x", evilField: "smuggled" } as never] } });
+    expect(deserializePrReceipt(JSON.stringify(payload)).ok).toBe(false);
+  });
+
+  it("rejects a non-finite number reachable through a JSON literal (1e400 parses to Infinity)", () => {
+    const raw = `{"schemaVersion":1,"bodyInput":{"contributors":[],"excludedCount":1e400},"extras":{}}`;
+    expect(JSON.parse(raw).bodyInput.excludedCount).toBe(Infinity); // sanity: valid JSON syntax, non-finite value
+    const result = deserializePrReceipt(raw);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects an oversized string", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "x", row: [], text: "a".repeat(MAX_PAYLOAD_STRING_LENGTH + 1) }] },
+    });
+    expect(deserializePrReceipt(JSON.stringify(payload)).ok).toBe(false);
+  });
+
+  it("never throws regardless of input shape", () => {
+    const hostileInputs = ["null", "42", '"a string"', "[]", "{}", "", "   ", "{{{"];
+    for (const input of hostileInputs) {
+      expect(() => deserializePrReceipt(input)).not.toThrow();
+    }
+  });
+});
+
+describe("sanitizePrReceiptPayload", () => {
+  it("neutralizes a code-fence breakout in DetailReceipt.text", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "x", row: [], text: "before\n```\nmalicious content\n```\nafter" }] },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized.extras.details![0].text).not.toContain("```");
+    // the visible characters survive — only the fence's ability to parse is destroyed
+    expect(sanitized.extras.details![0].text.replace(/\u200B/g, "")).toContain("```");
+  });
+
+  it("neutralizes a tilde-fence breakout", () => {
+    const payload = basePayload({ extras: { details: [{ label: "x", row: [], text: "~~~\nbreakout\n~~~" }] } });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized.extras.details![0].text).not.toContain("~~~");
+  });
+
+  it("neutralizes a <details> injection", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "<details><summary>click</summary>hidden</details>", row: [], text: "x" }] },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized.extras.details![0].label).not.toContain("<details>");
+    expect(sanitized.extras.details![0].label).not.toContain("<");
+    expect(sanitized.extras.details![0].label).toContain("&lt;details&gt;");
+  });
+
+  it("neutralizes <script> in a live-markdown field, keeps it literal (inert) in fenced text", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "<script>alert(1)</script>", row: [], text: "<script>alert(1)</script>" }] },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    // label renders as a live heading → HTML neutralized
+    expect(sanitized.extras.details![0].label).not.toContain("<script>");
+    expect(sanitized.extras.details![0].label).toContain("&lt;script&gt;");
+    // text renders INSIDE a ``` fence (markdown inert) → kept literal, not corrupted
+    expect(sanitized.extras.details![0].text).toBe("<script>alert(1)</script>");
+  });
+
+  it("neutralizes an <img onerror> injection", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "x", row: ['<img src=x onerror="alert(1)">'], text: "x" }] },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized.extras.details![0].row[0]).not.toContain("<img");
+    expect(sanitized.extras.details![0].row[0]).toContain("&lt;img");
+  });
+
+  it("defangs a Markdown link, dropping the URL", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "[click me](javascript:alert(1))", row: [], text: "x" }] },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized.extras.details![0].label).not.toContain("javascript:");
+    expect(sanitized.extras.details![0].label).not.toContain("(");
+    expect(sanitized.extras.details![0].label).not.toContain("[");
+    expect(sanitized.extras.details![0].label).toBe("click me");
+  });
+
+  it("neutralizes a contributor model name carrying an injection", () => {
+    const payload = basePayload({
+      bodyInput: {
+        contributors: [
+          {
+            role: "builder",
+            sessionId: "abc123",
+            slice: { kind: "full", startTurn: 0, endTurn: 0, turnCount: 1, label: "full" },
+            modelMix: [{ model: "<script>alert(1)</script>", tokens: emptyTokens(), tokenShare: 1, usd: null }],
+            usd: null,
+            tokens: emptyTokens(),
+            subagents: [],
+          },
+        ],
+        excludedCount: 0,
+      },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized.bodyInput.contributors[0].modelMix[0].model).not.toContain("<script>");
+  });
+
+  it("neutralizes waste-line tool/cheaperModel strings", () => {
+    const payload = basePayload({
+      extras: {
+        handoff: {
+          wasteLines: [
+            {
+              kind: "stuck-loop",
+              tool: "<img src=x onerror=alert(1)>",
+              runLength: 2,
+              usd: null,
+              tokens: emptyTokens(),
+              wallClockMs: null,
+              turnIndices: [1, 2],
+            },
+            {
+              kind: "trivial-spans",
+              eligibleTurnCount: 2,
+              usd: 0.01,
+              tokens: emptyTokens(),
+              cheaperModel: "[cheap](javascript:alert(1))",
+            },
+          ],
+          sessionCount: 1,
+          turnCount: 2,
+        },
+      },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    const wasteLines = sanitized.extras.handoff!.wasteLines;
+    const stuckLoop = wasteLines[0] as StuckLoopWasteLine;
+    const trivialSpans = wasteLines[1] as TrivialSpansWasteLine;
+    expect(stuckLoop.tool).not.toContain("<img");
+    expect(trivialSpans.cheaperModel).not.toContain("javascript:");
+  });
+
+  it("drops the artifact link entirely when its url is not https (a link target can't be text-escaped)", () => {
+    const payload = basePayload({
+      extras: { artifactLink: { fileName: "pr-1.html", url: "javascript:alert(1)" } },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized.extras.artifactLink).toBeUndefined();
+  });
+
+  it("keeps a safe https artifact link and escapes a link-breakout in its fileName", () => {
+    const payload = basePayload({
+      extras: {
+        artifactLink: {
+          fileName: "x](https://evil.example) [ok",
+          url: "https://anandgupta42.github.io/receipts/view.html?x=1",
+        },
+      },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized.extras.artifactLink).toBeDefined();
+    expect(sanitized.extras.artifactLink!.url).toBe("https://anandgupta42.github.io/receipts/view.html?x=1");
+    // the fileName's brackets are escaped, so it can't close the link text and inject its own link
+    expect(sanitized.extras.artifactLink!.fileName).toContain("\\]");
+    expect(sanitized.extras.artifactLink!.fileName).toContain("\\[");
+  });
+
+  it("length-caps an oversized field", () => {
+    const payload = basePayload({
+      bodyInput: {
+        contributors: [
+          {
+            role: "builder",
+            sessionId: "abc123",
+            slice: { kind: "full", startTurn: 0, endTurn: 0, turnCount: 1, label: "full" },
+            modelMix: [{ model: "m".repeat(SANITIZED_FIELD_CAP * 2), tokens: emptyTokens(), tokenShare: 1, usd: null }],
+            usd: null,
+            tokens: emptyTokens(),
+            subagents: [],
+          },
+        ],
+        excludedCount: 0,
+      },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized.bodyInput.contributors[0].modelMix[0].model.length).toBeLessThanOrEqual(SANITIZED_FIELD_CAP);
+  });
+
+  it("does not mutate the input payload", () => {
+    const payload = basePayload({ extras: { details: [{ label: "<b>x</b>", row: [], text: "x" }] } });
+    const before = JSON.parse(JSON.stringify(payload));
+    sanitizePrReceiptPayload(payload);
+    expect(payload).toEqual(before);
+  });
+
+  it("round-trips a clean payload unchanged", () => {
+    const payload = basePayload({
+      bodyInput: {
+        contributors: [
+          {
+            role: "builder",
+            sessionId: "abc123",
+            slice: { kind: "slice", startTurn: 0, endTurn: 3, turnCount: 4 },
+            modelMix: [{ model: "claude-opus-4-8", tokens: emptyTokens(), tokenShare: 1, usd: 1.5 }],
+            usd: 1.5,
+            tokens: emptyTokens(),
+            subagents: [],
+          },
+        ],
+        excludedCount: 0,
+      },
+      extras: {
+        details: [{ label: "builder — abc123", row: ["builder", "abc123", "full"], text: "plain receipt text, no markup" }],
+      },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    expect(sanitized).toEqual(payload);
+  });
+});
+
+describe("sanitized payload renders safely through renderPrBody", () => {
+  it("drops a javascript: artifact link so no dangerous link reaches the comment", () => {
+    const payload = basePayload({
+      extras: { artifactLink: { fileName: "pr.html", url: "javascript:alert(1)" } },
+    });
+    const rendered = renderPrBody(payload.bodyInput, sanitizePrReceiptPayload(payload).extras);
+    expect(rendered).not.toMatch(/\]\(\s*javascript:/i);
+    expect(rendered).not.toContain("full receipt:");
+  });
+
+  it("keeps a safe https artifact link in the rendered comment", () => {
+    const url = "https://anandgupta42.github.io/receipts/view.html?x=1";
+    const payload = basePayload({ extras: { artifactLink: { fileName: "pr.html", url } } });
+    const rendered = renderPrBody(payload.bodyInput, sanitizePrReceiptPayload(payload).extras);
+    expect(rendered).toContain("full receipt:");
+    expect(rendered).toContain(url);
+  });
+
+  it("defangs a reference-style link definition in a live-markdown field", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "see [here][x]\n[x]: javascript:alert(1)", row: [], text: "t" }] },
+    });
+    const sanitized = sanitizePrReceiptPayload(payload);
+    // brackets escaped → neither the [here][x] use nor the [x]: definition can form a link
+    expect(sanitized.extras.details![0].label).not.toMatch(/\[x\]:/);
+    expect(sanitized.extras.details![0].label).toContain("\\[");
+  });
+});
+
+describe("SPEC-0066 sanitizer — link-target + autolink hardening (Codex)", () => {
+  it("drops an artifactLink whose url tries to break out of the link target", () => {
+    const payload = basePayload({
+      extras: { artifactLink: { fileName: "p.html", url: "https://ok.example)![x](https://evil.example/pixel" } },
+    });
+    expect(sanitizePrReceiptPayload(payload).extras.artifactLink).toBeUndefined();
+  });
+
+  it("defangs a bare autolink URL in a live-markdown field", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "see https://evil.example now", row: [], text: "t" }] },
+    });
+    const label = sanitizePrReceiptPayload(payload).extras.details![0].label;
+    // the raw https:// scheme is broken (zero-width space) → GitHub won't autolink it
+    expect(label).not.toContain("https://");
+    expect(label).toContain("evil.example");
+  });
+
+  it("leaves a bare URL literal inside fenced receipt text (inert there)", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "x", row: [], text: "ran https://example.com/api" }] },
+    });
+    expect(sanitizePrReceiptPayload(payload).extras.details![0].text).toBe("ran https://example.com/api");
+  });
+});
+
+describe("SPEC-0066 sanitizer — email/mailto autolink defang (Codex)", () => {
+  it("defangs bare email + mailto/xmpp autolinks in a live-markdown field", () => {
+    const payload = basePayload({
+      extras: { details: [{ label: "ping foo@evil.example or mailto:bar@evil.example or xmpp:baz@evil.example", row: [], text: "t" }] },
+    });
+    const label = sanitizePrReceiptPayload(payload).extras.details![0].label;
+    expect(label).not.toContain("foo@evil.example");
+    expect(label).not.toContain("mailto:bar");
+    expect(label).not.toContain("xmpp:baz");
+    expect(label).toContain("evil.example");
+  });
+});


### PR DESCRIPTION
## What this adds

**Phase 3 / SPEC-0066 — the CI trust boundary, and the last piece of seamless receipts.** CI fetches the branch's git-ref receipt (written by the Phase 2 pre-push hook), validates + **sanitizes** the untrusted payload, renders the comment, and **posts it with `GITHUB_TOKEN`** — so a receipt lands with zero local `gh`. Generation stays local (I1/I4); CI only transports and re-renders.

## Why it matters to users

With Phases 1–2 + this: a `git push` writes+pushes the receipt ref → CI renders and posts the comment automatically. No manual `pr --post`, no local `gh`. A locally-posted receipt is still honored as-is.

## See it

```
push branch → [render job: npx @latest pr-render-ref, no token]
            → [post job: fresh runner, gh api upsert marker-verified body]
            → PR comment appears
```

## What changed

- `src/pr/sanitize.ts` — field-aware hardening: live-markdown fields get bracket-escaping + inline-link + **bare-autolink** defanging (URLs, `www.`, bare email, `mailto:`/`xmpp:`); fenced receipt `text` keeps its literal bytes; `artifactLink.url` is `https://`-allowlisted **and** rejects markdown-breaking chars so it can't break out of the link target.
- `src/pr/postRef.ts` — `renderReceiptPayload` + `fetchAndRenderReceipt` (fetch → validate → sanitize → render). **No `gh`, no write token.**
- `src/cli/commands/pr-render-ref.ts` (hidden) — `pr-render-ref <branch> <head-repo-url>` (CI fetch mode) or stdin (debug).
- `src/pr/store.ts` — `fetchReceiptRef`; slug from the CLI's `receiptRefSlug` (never shell → no drift).
- `.github/workflows/pr-receipt-check.yml` — **two jobs**: `render` (untrusted `@latest`, `contents: read` only, `persist-credentials: false`, uploads a data-only marker-prefixed artifact) → `post` (fresh runner + checkout, `pull-requests: write`, posts a marker-verified body via `gh api`). Enforcement stays in the tested verdict; CI telemetry off.

## What to review, in order

1. `.github/workflows/pr-receipt-check.yml` — the **two-job trust boundary**: does the untrusted render job share any state with the token-holding post job? (It shouldn't — separate runners, data-only artifact.) (riskiest)
2. `src/pr/sanitize.ts` — every attacker-controlled string neutralized for its render position; the URL-target + autolink defangs.
3. `src/pr/postRef.ts` — render-only, never posts; invalid payloads never rendered.
4. `src/pr/store.ts` `fetchReceiptRef`; slug consistency with the producer.

## Evidence

Gates green (unmasked, all `0`): `tsc`, `eslint --max-warnings 0`, `vitest` 1585, `verify-goldens`, `determinism-check` 10×, `spec-lint`, `hygiene`.
Spec: `specs/SPEC-0066-ci-post-from-ref.md`.
Independent review: Codex (different family), deep effort, **three rounds** on the trust boundary → **PASS, no findings**. It caught (and this PR fixes) a URL-target breakout, incomplete autolink defang (email/`mailto:`), running `@latest` with the write token, and same-*job* state poisoning.

## Notes

- **Merge-order:** this and PR #164 (`@latest`) both touch `pr-receipt-check.yml` — expect a small conflict; resolve by keeping this two-job structure with the caller pinned `@latest`.
- Depends conceptually on Phase 1 (merged) for the payload/store; independent of Phase 2 (#166).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
