### PR TITLE
docs: adopter kit — minimally-invasive default + opt-in tiers

### DIFF
--- a/docs/adopt/org-rollout.md
+++ b/docs/adopt/org-rollout.md
@@ -18,6 +18,14 @@ PR. **It performs no repo or GitHub mutations** — each repo's owners review an
 PR, and the script refuses to run until `aireceipts` is actually on npm
 (a packet telling developers to run an unpublished command helps nobody).
 
+**The default footprint is deliberately minimal — one non-blocking file per repo** (plus,
+optionally, a one-line CONTRIBUTING note). The packet adds only the notice-only caller: it
+never fails a build, and aireceipts never commits receipt files (a receipt is a PR comment
+or a git ref, invisible in the tree and PR diffs). So a fleet rollout doesn't dirty anyone's
+repo or gate anyone's CI. Enforcement (`AIRECEIPTS_REQUIRE_PR_RECEIPT`) is opt-in; the fully
+seamless auto-attach + CI-post layers are landing with the seamless-receipts work, each
+opt-in and off by default. See the tiers in [docs/pr-receipts.md](../pr-receipts.md).
+
 Two constraints inherited from GitHub:
 
 - The caller references the receipts repo by name; reusable-workflow

--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -102,12 +102,28 @@ who viewed which receipt.
 
    > Before opening a PR, run `npx aireceipts-cli pr --post` to attach your build receipt.
 
-That's it. By default, the workflow emits a neutral `::notice` when a PR has no receipt
-comment and never fails the build. To enforce receipts for same-repo PRs, set the repo
-variable `AIRECEIPTS_REQUIRE_PR_RECEIPT=true`; fork PRs stay notice-only because source
-transcripts remain on the contributor's machine. CI still never generates a receipt
-itself: the source transcripts stay local. Rolling out across a whole org:
-[docs/adopt/org-rollout.md](adopt/org-rollout.md).
+That's it — and by design it stays out of your way.
+
+**Footprint (what this actually adds to your repo).** One workflow file (plus, optionally, a
+one-line note in `CONTRIBUTING.md`). The check **never fails a build** — a neutral `::notice`
+when a receipt is missing, and nothing otherwise. aireceipts **never commits receipt files**
+to your tree: a receipt is a PR comment or a git ref (`refs/receipts/…`), both invisible in
+your source and your PR diffs. Nothing runs on any contributor's machine. Remove it anytime
+by deleting the file.
+
+**Turn it up when you want — opt-in and escapable:**
+
+- **Enforce** — set the repo variable `AIRECEIPTS_REQUIRE_PR_RECEIPT=true` to make same-repo
+  PRs require a receipt. Fork PRs always stay notice-only (source transcripts live on the
+  contributor's machine, so CI can't generate one).
+- **Fully seamless (in progress)** — the `store=ref` receipt producer is shipped; a pre-push
+  hook that auto-attaches the receipt on every push, and a CI step that posts it for you (so
+  contributors need no local `gh`), are landing next — each opt-in, each notice-only until
+  turned on. Until then, a contributor attaches a receipt with the one shipped command:
+  `npx aireceipts-cli pr --post`.
+
+CI still never generates a receipt itself: the source transcripts stay local (I1/I4).
+Rolling out across a whole org: [docs/adopt/org-rollout.md](adopt/org-rollout.md).
 
 There is no aireceipts GitHub App or bot: receipts are generated and posted locally by
 design, and a hosted App could never see the transcripts they're built from — the


### PR DESCRIPTION
## What this adds

Frames adopter integration as a **minimally-invasive default with opt-in seamless tiers** — directly answering the "we like to keep our repos clean" concern. Docs-only.

## Why it matters

Adoption should never dirty a repo or gate CI by default. This makes the footprint explicit:
- **Default:** one workflow file (plus, optionally, a one-line CONTRIBUTING note). Never fails a build. **aireceipts never commits receipt files** — a receipt is a PR comment or a git ref (`refs/receipts/…`), invisible in the tree and PR diffs. (Unlike a committed `.receipts/*.json` file-store, which we deliberately never built.)
- **Opt-in, off by default:** enforcement (`AIRECEIPTS_REQUIRE_PR_RECEIPT`, shipped), and the fully-seamless auto-attach hook + CI auto-post (landing with the seamless-receipts work).

## What changed

- `docs/pr-receipts.md` — maintainer section gains a "Footprint" note + a "Turn it up" opt-in tier list.
- `docs/adopt/org-rollout.md` — minimal-default footprint note for fleet rollouts.

## Evidence

Gates green: `wiring-docs` test, `hygiene`, `spec-lint`.
Independent review: Codex (different family) — caught that an earlier draft over-claimed the not-yet-merged seamless tiers as available; fixed to state only shipped behavior with the seamless layers marked in-progress. Final: **PASS, no findings.**

## Notes

Accuracy is pinned to `main`: enforcement is shipped; the pre-push hook (PR #166) and CI auto-post (PR #168) are described as in-progress, and the shipped attach path today is `npx aireceipts-cli pr --post`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
