### PR TITLE
chore: release v0.4.0 — seamless PR receipts, @latest pin, perf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.3.0):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.4.0):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,
@@ -93,12 +93,28 @@ after each release — don't hand-edit it elsewhere.*
   (day-1 kit), per-agent docs pages, PR receipts (multi-session, SHA-anchored,
   artifact/share), SVG/PNG export, receipt templates, the landing + docs sites,
   adoption telemetry + a local `stats` counter command (SPEC-0043), and disclosed
-  opt-out diagnostics telemetry. 35 specs at `status: shipped`.
+  opt-out diagnostics telemetry; **seamless PR receipts** — a deterministic `store=ref`
+  producer writing `refs/receipts/<slug>`, a pre-push auto-attach hook, and CI rendering +
+  posting the receipt from the ref via `GITHUB_TOKEN` behind a hardened trust-boundary
+  sanitizer with opt-in **same-repo** enforcement (SPEC-0065/0066 — the capability ships in
+  v0.4.0; both specs stay `building` for their final slices, listed below), the adopter pin
+  moved to `@latest` (SPEC-0064 R1); and a faster parse/preflight path — in-process
+  sqlite, goldens compile cache, parallel preflight (SPEC-0063). 36 specs at
+  `status: shipped`.
 - **In progress (`building`):** SPEC-0044 cost-attribution confidence — its
   implemented slices ship in v0.2.0 (ConfidenceEvent contract + no-silent-drop,
   cost matrix, rows-sum-to-total, cache-write caveat, parse-skip/load-failure
   drops, subagent double-count fix, mutation-gated PR path); the spec stays
   `building` until its `--self-check` kill-criterion and cost-model docs land.
+  SPEC-0064 (PR-check distribution) — R1 (`@latest` pin + release tag-move) shipped in
+  v0.4.0; R2–R4 (the npm-native `aireceipts pr-check` command) remain, so it stays
+  `building`. SPEC-0065 (seamless producer + hook) — R1–R3/R6 (`store=ref` producer,
+  pre-push auto-attach hook, determinism) shipped in v0.4.0; R5 (local `--list`/`week`/
+  `stats` reads of `refs/receipts` + prune) is not wired, so it stays `building`.
+  SPEC-0066 (CI posts from the ref) — R1–R4/R6 (fetch, validate, sanitize, render, post via
+  `GITHUB_TOKEN`, two-job trust boundary) shipped in v0.4.0; R5's agent-built vs
+  hand-written enforcement discrimination is not built (opt-in enforcement is coarse —
+  same-repo vs fork only), so it stays `building`.
 - **Approved, not yet shipped:** the opt-in benchmark (SPEC-0015) client contract only —
   actual send disabled; `benchmark` is otherwise reachable from `--help`.
 - **Draft:** SPEC-0039 (human-authored PRs).

--- a/README.md
+++ b/README.md
@@ -25,20 +25,22 @@ turns them into receipts: what a session cost, tool by tool; what a PR cost, acr
 every supported agent session it can attribute; where tokens were wasted. This repo
 runs on it — every pull request here carries the receipt of the agent sessions that
 built it ([how](docs/pr-receipts.md)). Local, with no accounts and no servers: your
-transcripts and code never leave your machine, and rendering a receipt makes zero
-network calls.
+transcripts and code never leave your machine, and pricing a receipt needs no network —
+it uses cited, bundled price tables. (aireceipts does send anonymous, opt-out usage
+[telemetry](#telemetry-disclosed) — turn it off with `AIRECEIPTS_TELEMETRY=off` or
+`DO_NOT_TRACK=1`; it is auto-off in CI.)
 
 ## Install — four steps, first receipt in under a minute
 
-1. **See a receipt.** `npx aireceipts-cli` — your newest session, no install, no
-   account (`npx aireceipts-cli --demo` shows a bundled example if you have no
-   sessions yet).
+1. **See a receipt.** `npx aireceipts-cli` — renders your newest agent session found
+   anywhere on your machine (not scoped to the current folder), no install, no account
+   (`npx aireceipts-cli --demo` shows a bundled example if you have no sessions yet).
 2. **Get your bearings.** `npx aireceipts-cli setup` — found sessions, latest cost,
    week total, and the integrations that fit your machine
    ([guide](docs/guide/01-getting-started.md)).
-3. **Make it always-on.** `aireceipts install-hook` ends every Claude Code session
-   with a mini-receipt; `aireceipts statusline` puts the live cost in the status bar.
-4. **Put receipts on your PRs.** `aireceipts pr --post` posts the comment shown above.
+3. **Make it always-on.** `npx aireceipts-cli install-hook` ends every Claude Code session
+   with a mini-receipt; `npx aireceipts-cli statusline` puts the live cost in the status bar.
+4. **Put receipts on your PRs.** `npx aireceipts-cli pr --post` posts the comment shown above.
    Generation stays local; a drop-in [CI check](docs/adopt/pr-receipt-check-caller.yml)
    can then verify every PR carries one ([guide](docs/pr-receipts.md)).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,55 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.4.0 — 2026-07-07
+
+Minor: PR receipts can now **attach and post themselves**. A receipt travels with the
+branch as a sibling git ref and CI renders + posts the comment, so a receipt lands even
+when no one runs `pr --post`. Rendered receipt output is unchanged from v0.3.0 (goldens
+byte-identical); the new surface is opt-in.
+
+### Added
+
+- **Seamless PR receipts — `store=ref` + pre-push hook** (SPEC-0065): `aireceipts pr
+  --store ref` (or `AIRECEIPTS_STORE=ref`) writes the receipt as a **deterministic** git
+  object on `refs/receipts/<slug>` — invisible in the tree and PR diff, byte-identical
+  across machines (dated from the session's own `endedAt`, never wall-clock). A committed
+  `.githooks/pre-push` hook generates and pushes that ref on `git push` (best-effort;
+  never blocks a push, no second push). `npm run setup:hooks` activates the hook for a
+  clone of this repo; the default store stays `comment`.
+- **CI posts the receipt from the ref** (SPEC-0066): a two-job `pr-receipt-check.yml`
+  fetches the branch ref, validates and sanitizes the **untrusted, fork-author-controlled**
+  payload, renders it through the existing renderer, and upserts one marker comment via
+  `GITHUB_TOKEN` — no local `gh` required. Opt-in enforcement
+  (`AIRECEIPTS_REQUIRE_PR_RECEIPT=true`) makes **same-repo** PRs require a receipt; **fork**
+  PRs always stay notice-only (their transcripts live on the contributor's machine, so CI
+  can't generate one). Enforcement is currently coarse — it does not yet distinguish
+  agent-built from hand-written PRs.
+- **`@latest` distribution pin** (SPEC-0064 R1): the PR-receipt-check caller installs the
+  reusable workflow at `@latest`; the moving `latest` git tag is advanced by the release
+  workflow on each publish. (SPEC-0064 R2–R4, the npm-native `pr-check` command, remain in
+  progress.)
+
+### Performance
+
+- **Faster feedback** (SPEC-0063): in-process sqlite parsing, a goldens compile cache, and
+  parallel preflight reduce CLI and preflight wall-clock.
+
+### Security
+
+- The receipt payload that rides on the branch ref is treated as untrusted input — anyone
+  who can push a branch, including a fork author, controls its bytes. The CI post path is a
+  hardened trust boundary: a field-aware sanitizer (bracket-escape +
+  autolink defang for live-markdown fields, fence-guard for fenced `text`, an
+  https-allowlist that rejects markdown-breaking characters for artifact URLs), rendered in
+  a **token-less** `render` job whose data-only artifact is posted by a separate `post`
+  job — golden-gated against an injection corpus.
+
+### Docs
+
+- Adopter kit: a minimally-invasive default plus opt-in tiers for repos that want to turn
+  enforcement up (`docs/pr-receipts.md`, `docs/adopt/`).
+
 ## v0.3.0 — 2026-07-06
 
 Minor: background-agent (subagent) spend becomes visible on every surface, the

--- a/docs/adopt/org-rollout.md
+++ b/docs/adopt/org-rollout.md
@@ -22,9 +22,11 @@ PR, and the script refuses to run until `aireceipts` is actually on npm
 optionally, a one-line CONTRIBUTING note). The packet adds only the notice-only caller: it
 never fails a build, and aireceipts never commits receipt files (a receipt is a PR comment
 or a git ref, invisible in the tree and PR diffs). So a fleet rollout doesn't dirty anyone's
-repo or gate anyone's CI. Enforcement (`AIRECEIPTS_REQUIRE_PR_RECEIPT`) is opt-in; the fully
-seamless auto-attach + CI-post layers are landing with the seamless-receipts work, each
-opt-in and off by default. See the tiers in [docs/pr-receipts.md](../pr-receipts.md).
+repo or gate anyone's CI. Enforcement (`AIRECEIPTS_REQUIRE_PR_RECEIPT`) is opt-in and coarse — it makes same-repo PRs
+require a receipt (fork PRs always stay notice-only). The seamless CI-post layer (CI renders
++ posts the receipt from a branch ref, no contributor `gh`) shipped in v0.4.0, opt-in and
+off by default; auto-attach on push ships as a committed hook for this repo's contributors,
+which an adopter repo wires itself. See the tiers in [docs/pr-receipts.md](../pr-receipts.md).
 
 Two constraints inherited from GitHub:
 

--- a/docs/agents/claude-code.md
+++ b/docs/agents/claude-code.md
@@ -46,5 +46,6 @@ sessions (and their subagents) to the branch and posts the receipt comment —
 
 ## Privacy
 
-Read-only, local. Transcripts never leave your machine; rendering a receipt
-makes zero network calls ([what a receipt proves](../trust.md)).
+Read-only, local. Transcripts never leave your machine; pricing a receipt needs no
+network — it uses bundled, cited price tables ([what a receipt proves](../trust.md)).
+Anonymous, opt-out usage telemetry is the one exception (`AIRECEIPTS_TELEMETRY=off`).

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -43,5 +43,6 @@ worktree + time window, committing sessions by branch SHA —
 
 ## Privacy
 
-Read-only, local. Transcripts never leave your machine; rendering a receipt
-makes zero network calls ([what a receipt proves](../trust.md)).
+Read-only, local. Transcripts never leave your machine; pricing a receipt needs no
+network — it uses bundled, cited price tables ([what a receipt proves](../trust.md)).
+Anonymous, opt-out usage telemetry is the one exception (`AIRECEIPTS_TELEMETRY=off`).

--- a/docs/agents/gemini.md
+++ b/docs/agents/gemini.md
@@ -38,5 +38,6 @@ conservative branch rules as every agent — [how](../pr-receipts.md).
 
 ## Privacy
 
-Read-only, local. Transcripts never leave your machine; rendering a receipt
-makes zero network calls ([what a receipt proves](../trust.md)).
+Read-only, local. Transcripts never leave your machine; pricing a receipt needs no
+network — it uses bundled, cited price tables ([what a receipt proves](../trust.md)).
+Anonymous, opt-out usage telemetry is the one exception (`AIRECEIPTS_TELEMETRY=off`).

--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -65,6 +65,12 @@ replacement for the one command above. Enable it once per clone:
 npm run setup:hooks
 ```
 
+> **Scope:** `npm run setup:hooks` and the committed `.githooks/` live in **this repo's
+> own source tree** — they are not part of the published npm package, so this exact wiring
+> is for aireceipts' own contributors. The underlying flags (`aireceipts pr --store ref
+> --push-ref`) work in any repo; a repo that has adopted aireceipts can point
+> `core.hooksPath` at its own hook that calls them.
+
 That points `core.hooksPath` at the committed `.githooks/` and builds the CLI (the hook
 runs the built `dist/`, or a global `aireceipts` if you have one). From then on, every
 `git push` of a branch runs `aireceipts pr --store ref --push-ref` for you: it writes the
@@ -134,11 +140,14 @@ by deleting the file.
 - **Enforce** — set the repo variable `AIRECEIPTS_REQUIRE_PR_RECEIPT=true` to make same-repo
   PRs require a receipt. Fork PRs always stay notice-only (source transcripts live on the
   contributor's machine, so CI can't generate one).
-- **Fully seamless (in progress)** — the `store=ref` receipt producer is shipped; a pre-push
-  hook that auto-attaches the receipt on every push, and a CI step that posts it for you (so
-  contributors need no local `gh`), are landing next — each opt-in, each notice-only until
-  turned on. Until then, a contributor attaches a receipt with the one shipped command:
-  `npx aireceipts-cli pr --post`.
+- **Fully seamless (v0.4.0)** — two opt-in layers now exist. **CI posts for you:** when a
+  branch carries a `refs/receipts/<slug>` ref, the check renders and posts the receipt
+  comment itself via `GITHUB_TOKEN`, so a contributor needs no local `gh`. **Auto-attach on
+  push:** a committed pre-push hook writes and pushes that ref on `git push` — shipped for
+  *this* repo's own contributors (`npm run setup:hooks`); an adopter repo wires an equivalent
+  hook calling `npx aireceipts-cli pr --store ref --push-ref` (the flags ship in the npm
+  package; the hook file does not). Either way a contributor can still just run
+  `npx aireceipts-cli pr --post`. Each layer is opt-in and notice-only until turned on.
 
 CI still never generates a receipt itself: the source transcripts stay local (I1/I4).
 Rolling out across a whole org: [docs/adopt/org-rollout.md](adopt/org-rollout.md).

--- a/docs/releases/0.4.0-verdict.md
+++ b/docs/releases/0.4.0-verdict.md
@@ -1,0 +1,147 @@
+# Release verdict — v0.4.0
+
+- **Candidate version:** 0.4.0
+- **Judged content SHA:** `dadcdd8` (HEAD of `main` at review time; `git rev-parse` = `dadcdd83660648fa66265acba5635ef0b1f68522`)
+- **Changelog range:** `55198e0..dadcdd8` (`v0.3.0..HEAD`)
+- **Bump rationale:** MINOR — new capability (seamless PR receipts), fully additive, no rendered-output/format break (I5 holds).
+- **Date:** 2026-07-07 (UTC)
+
+## Scope (what ships)
+
+Commits since `v0.3.0`:
+
+- SPEC-0063 — perf: in-process sqlite, goldens compile cache, parallel preflight (#162)
+- SPEC-0064 — feat: pin PR-receipt check at `@latest`; draft npm-native pr-check (#164)
+- SPEC-0065 — feat: seamless `store=ref` producer + pre-push hook (#165, #166)
+- SPEC-0066 — feat: CI renders + posts the PR receipt from the branch ref (#168)
+- docs — adopter kit: minimally-invasive default + opt-in tiers (#169)
+
+SPEC-0044 has **no** commit in this window and stays `building`.
+
+## Tagged-SHA note (read before dispatch)
+
+The persona panel and mechanical gates judged the **content** SHA `dadcdd8`. The release
+commit that follows adds **no code and changes no golden** — it is purely: `package.json`
+version bump, `docs/CHANGELOG.md` v0.4.0 section, spec-status updates (SPEC-0063 →
+`shipped`; SPEC-0064/0065/0066 → `building` with per-requirement shipped/deferred notes),
+`AGENTS.md` inventory refresh, the docs-panel fixes (below), and this verdict file. `release-publish.yml` re-runs the full `preflight-release.mjs` on the
+exact SHA it publishes as the final mechanical gate, so the tagged artifact is
+re-verified byte-for-byte at dispatch time. This verdict is valid for that release commit
+provided no further **code/spec-behavior** commit lands on top of it.
+
+## Mechanical checks (lead, unmasked, on `dadcdd8`)
+
+- `node scripts/preflight-release.mjs` → **11/11 passed** — RELEASE-READY. Includes: publish-shape manifest, `dist/cli.js` + shebang build, lean+complete tarball, spec-lint, hygiene, verify-goldens, `tsc --noEmit`, cite-check (all price tables, liveness enforced), `eslint --max-warnings 0`, determinism-check ×10, and `vitest run` full suite **incl. the packed-tarball install+run e2e**.
+- `node scripts/verify-goldens.mjs` → **102 artifacts byte-identical** (terminal, SVG light+dark, compare cards, hostile-fixture battery). I5 holds.
+- `npx vitest run` → **125 files / 1596 tests passed**, single run, no flake (EM + independent panel runs).
+- Dependency delta: **none** — only a `setup:hooks` npm *script* added; `dependencies` and `package-lock.json` diffs empty.
+- `npm audit --production` → **0 vulnerabilities** (one dev-only `esbuild` low advisory GHSA-g7r4-m6w7-qqqr, not shipped).
+- CI on the exact SHA `dadcdd8` → **success** (CI, scorecard, CodeQL), verified via `gh run view`, not a cousin.
+
+## Persona panel (isolated contexts)
+
+### Product Manager — GO (conditional on release mechanics)
+
+Quickstart works literally as written (`npm ci && npm run build`, `--demo`, `setup`, bare
+receipt, `pr` dry-run, hidden `pr-render-ref`). The seamless CI-post arc is **honestly
+framed as "in progress"**: verified `git rev-parse latest` = `55198e0` (v0.3.0), so
+existing `@latest` adopters still run the old notice-only workflow — the docs do not
+over-claim. README makes zero seamless/`--store ref` claims. Findings: (1) release not
+cut at this SHA yet — `package.json` still `0.3.0`, no `## v0.4.0` changelog (the release
+step); (2) `docs/pr-receipts.md` "Always-on: pre-push hook" reads as universal but is
+aireceipts-repo-only (`setup:hooks`/`.githooks/` not in the npm `files` array) — needs a
+one-line caveat. Both are release housekeeping, not shipped-feature honesty problems.
+
+### Engineering Manager — GO
+
+I5 intact (102/102 goldens byte-identical). MINOR bump correct — every change additive,
+no rendered-output break. Zero new runtime deps (package.json + package-lock both
+confirm). Zero production advisories. Rollback to 0.3.0 clean — the only new persistent
+artifacts (`.githooks/`, `refs/receipts/*` schema behind `PR_RECEIPT_SCHEMA_VERSION`) are
+unpublished to npm or silently ignored by the old version. Full 1596-test suite green in
+one run, no flake. CI verified green on exact SHA `dadcdd8`. Open issue #161 (abnormal
+on-disk state under-count) is pre-existing, low-severity, unrelated to this diff.
+
+### Designer — GO
+
+Plumbing release touches nothing in the render path. `verify-goldens` → 102 artifacts
+byte-identical. Independent fresh renders of priced/unpriced fixtures, all three
+templates, `--details`, PNG rasterization, compare-SVG, and README's four image
+references all check out — no truncation, misalignment, or broken links. Product's face
+confirmed unchanged.
+
+### QA / adversarial — GO
+
+**No I2 violation reproducible** — every hostile path lacking real priced data prints
+`0 tok` / `no price table matched` / an explicit unreadable-record caveat rather than
+inventing a number. Empty dir, Turkish-I locale, no-git, malformed `budget.json`
+(all variants → `ignored: <reason>`, exit 0), truncated/30k-line transcripts, piped vs
+TTY (zero ANSI leak), hostile fixtures, `gh`-absent — all degrade cleanly. The
+highest-risk new surface (pre-push hook + `pr --store ref --push-ref`) proved genuinely
+non-blocking even against an unreachable remote (exit 0, best-effort stderr line). One
+real defect: `--csv` does not neutralize leading `=`/`+`/`-`/`@` in agent-controlled
+fields (spreadsheet formula injection) — medium, pre-existing, **not** I2; QA recommends a
+follow-up patch, not a hold.
+
+## Open risks (non-blocking)
+
+1. **#170 (new)** — CSV formula injection: `--csv` doesn't guard leading `=`/`+`/`-`/`@`.
+   Pre-existing (present in v0.3.0), not a regression, not I2. Follow-up patch (own
+   spec+PR). Filed this pass.
+2. **#161 (carried from v0.3.0)** — missing `subagents/` dir silently under-counts the
+   session total; requires abnormal on-disk state (partial backup/rsync). Accepted risk
+   at v0.3.0, unchanged here.
+3. `esbuild` dev-only low advisory — not shipped in the tarball.
+
+## Conditions folded into the release commit
+
+- Version bump `0.3.0 → 0.4.0` + `docs/CHANGELOG.md` v0.4.0 section (PM/EM release-mechanics condition).
+- `docs/pr-receipts.md` pre-push-hook caveat (PM doc finding).
+- Spec statuses: SPEC-0063 → `shipped`; SPEC-0064 (R1 only), SPEC-0065 (R5 local tooling
+  deferred), SPEC-0066 (R5 agent-built enforcement deferred) → `building`, each with a
+  shipped/deferred note. `AGENTS.md` inventory refresh (36 specs shipped).
+
+None of these alter code or goldens; the workflow's preflight re-gates the tagged SHA.
+
+## Docs panel (`/review-docs`, blocking)
+
+Two independent reviewers in separate contexts: **Reviewer A — cold reader** (Sonnet, README
+only) and **Reviewer B — correctness auditor** (Codex, claims-vs-code). Both ran against the
+release branch.
+
+First pass: **DOCS-NO-GO** — three correctness findings, all verified against code and fixed:
+
+1. **Enforcement over-claim.** The draft changelog + SPEC-0065/0066 said opt-in enforcement
+   "fails only agent-built same-repo PRs; hand-written PRs never fail." `check-pr-receipt.mjs`
+   has no agent-built signal — it fails any same-repo PR missing a receipt when opted in.
+   Fixed: changelog reworded to the honest coarse behavior; **SPEC-0066 downgraded to
+   `building`** (R5 enforcement discrimination not built); the "hand-written never fail" reach
+   removed from SPEC-0065's R4 box.
+2. **"zero network calls" over-claim.** Telemetry is on-by-default (anonymous, opt-out,
+   auto-off in CI) and POSTs to App Insights. README hero + three agent docs claimed
+   rendering makes zero network calls unconditionally. Fixed: scoped to "pricing needs no
+   network" + inline opt-out telemetry disclosure. Conditioned mentions ("zero calls when
+   disabled") left intact — they were already correct.
+3. **Stale "seamless in progress"** in `docs/pr-receipts.md` + `docs/adopt/org-rollout.md`.
+   Fixed to "CI-post shipped in v0.4.0 (opt-in)" while honestly scoping the pre-push hook as
+   this-repo's-contributors (the `.githooks` file is not in the npm package).
+
+Cold-reader (simplicity) fixes: README Install steps 3–4 switched to `npx aireceipts-cli`
+(bare `aireceipts` fails without a global install); step 1 notes it scans the whole machine.
+Changelog Security bullet given a plain lead. Filed **#170** (CSV formula-injection, QA
+finding, pre-existing, follow-up).
+
+Second pass: all four findings **PASS**; two self-introduced inconsistencies (stale verdict
+text; SPEC-0065 shipped-vs-deferred contradiction) then resolved — **SPEC-0065 also
+downgraded to `building`** with an explicit R5 acceptance box, `AGENTS.md` count → 36. Net
+spec outcome: **SPEC-0063 `shipped`; SPEC-0064/0065/0066 `building`** with precise
+shipped/deferred notes.
+
+## Verdict
+
+All four personas GO; the blocking docs panel is GO after the correctness fixes above. All
+remaining conditions are release-mechanics or documented non-blocking follow-ups (#170, #161,
+the three `building` specs' deferred slices). Mechanical gates green on the exact content SHA
+and re-green after the doc/spec edits (preflight 11/11).
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",

--- a/specs/SPEC-0063-fast-feedback.md
+++ b/specs/SPEC-0063-fast-feedback.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0063
 title: "Fast feedback — cut test, CI, and release wall-clock without weakening any gate"
-status: building # PR open; shipped flips on merge
+status: shipped
 milestone: M5
 depends: []
 ---
@@ -101,11 +101,11 @@ I1/I5: determinism is proven more often per minute, not less).
 
 ## Success criteria
 
-- [ ] Local `npx vitest run` wall-clock materially reduced (target ≥ 2× vs the 58s
+- [x] Local `npx vitest run` wall-clock materially reduced (target ≥ 2× vs the 58s
       baseline on the same machine).
-- [ ] CI `verify` job time materially reduced (determinism step ~36s → seconds).
-- [ ] Full preflight wall-clock ≈ its longest single gate, not the sum.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] CI `verify` job time materially reduced (determinism step ~36s → seconds).
+- [x] Full preflight wall-clock ≈ its longest single gate, not the sum.
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs` all pass unmasked (`echo $?`).
-- [ ] `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
+- [x] `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked.

--- a/specs/SPEC-0064-check-distribution.md
+++ b/specs/SPEC-0064-check-distribution.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0064
 title: PR-receipt check — release-pinned distribution and an npm-native pr-check
-status: draft
+status: building
 milestone: M5
 depends: [SPEC-0019, SPEC-0030, SPEC-0057]
 ---
@@ -89,10 +89,14 @@ is the single source of truth behind the reusable workflow, the composite action
 
 ## Success criteria
 
-- [ ] R1 landed: every live caller template pins `@latest`; `release-publish.yml` advances
+- [x] R1 landed: every live caller template pins `@latest`; `release-publish.yml` advances
       the tag; a bootstrap `latest` tag exists at the current release.
 - [ ] R2–R4: `aireceipts pr-check` ships in `dist/`, verdict parity with
       `check-pr-receipt.mjs` is asserted by a test, and the render path stays lazy.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked
       (`echo $?`).
+
+**Shipped in v0.4.0:** R1 only (`@latest` pin + tag-move, #164). R2–R4 (the npm-native
+`aireceipts pr-check` command) are not built; the spec stays `status: building` until they
+land.

--- a/specs/SPEC-0065-seamless-receipts.md
+++ b/specs/SPEC-0065-seamless-receipts.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0065
 title: Seamless PR receipts — pre-push hook, store=ref, CI posts from the ref
-status: approved
+status: building
 milestone: M5
 depends: [SPEC-0019, SPEC-0037, SPEC-0064]
 ---
@@ -69,7 +69,8 @@ same transcript yields the same object SHA.
   through the hardened renderer, upsert via `GITHUB_TOKEN` (workflow gains
   `pull-requests: write`), and opt-in enforce — is specified and built in **SPEC-0066**,
   which carries its own injection/security review. SPEC-0065 ships the producer, hook, and
-  local tooling (R1–R3, R5–R6); the ref R1 writes is SPEC-0066's input, and the payload
+  local tooling (R1–R3, R6; R5 is deferred — see the shipped/deferred note under Success
+  criteria); the ref R1 writes is SPEC-0066's input, and the payload
   round-trip contract (`PrReceiptPayload`) is the seam both sides build to. The matrix rows
   below state that seam contract; their CI-side verification lives in SPEC-0066.
 - **R5 — local tooling reads refs.** `aireceipts --list` / `week` / `stats` include
@@ -130,10 +131,21 @@ same transcript yields the same object SHA.
 
 ## Success criteria
 
-- [ ] R1 ref store + `--store ref` shipped with round-trip + determinism tests; default
+- [x] R1 ref store + `--store ref` shipped with round-trip + determinism tests; default
       unchanged; `verify-goldens` and `determinism-check` green.
-- [ ] R2 pre-push hook + R3 activation land; recursion guard tested.
-- [ ] R4 CI renders + posts from the ref (no dev `gh`); enforcement opt-in; forks/hand-
-      written PRs never fail.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] R2 pre-push hook + R3 activation land; recursion guard tested.
+- [x] R4 CI renders + posts from the ref (no dev `gh`); enforcement opt-in; fork PRs stay
+      notice-only. (The agent-built vs hand-written enforcement refinement is deferred with
+      SPEC-0066 — see its note.)
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked.
+- [ ] R5 local tooling reads ref receipts (`--list`/`week`/`stats`) + a prune for merged
+      branches — **not yet wired** (the spec stays `building` for this); the seamless
+      push→CI-post arc (R1–R4/R6) does not depend on it.
+
+**Shipped in v0.4.0:** the push→CI-post arc — R1 (`store=ref` producer), R2 (pre-push
+hook), R3 (activation), R6 (determinism), and R4 via SPEC-0066. **Deferred:** R5 (local
+`--list`/`week`/`stats` reading `refs/receipts` + a prune for merged branches) is not yet
+wired — `listReceiptRefs` has no CLI caller. Also deferred with SPEC-0066: enforcement's
+agent-built vs hand-written discrimination (opt-in enforcement is currently coarse —
+same-repo vs fork only). Both are follow-ups; neither gates the seamless push→CI-post arc.

--- a/specs/SPEC-0066-ci-post-from-ref.md
+++ b/specs/SPEC-0066-ci-post-from-ref.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0066
 title: CI renders and posts PR receipts from the ref (the trust boundary)
-status: approved
+status: building
 milestone: M5
 depends: [SPEC-0019, SPEC-0064, SPEC-0065]
 ---
@@ -101,10 +101,19 @@ transports what the local hook produced.
 
 ## Success criteria
 
-- [ ] CI fetches, validates, sanitizes, renders, and posts from the ref via `GITHUB_TOKEN`;
+- [x] CI fetches, validates, sanitizes, renders, and posts from the ref via `GITHUB_TOKEN`;
       no local `gh` needed.
-- [ ] Injection corpus golden passes; hostile payloads never break the comment or fail the
+- [x] Injection corpus golden passes; hostile payloads never break the comment or fail the
       job unexpectedly.
 - [ ] Enforcement is opt-in and skips hand-written/fork PRs.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked.
+
+**Shipped in v0.4.0:** R1–R4, R6 — CI fetches the ref, validates + sanitizes the untrusted
+payload (injection-corpus golden), renders via `renderPrBody`, and upserts via
+`GITHUB_TOKEN` from a separate `post` job; the comment-marker back-compat path is unchanged.
+**Deferred (spec stays `building`):** R5's agent-built vs hand-written discrimination is not
+implemented. `scripts/check-pr-receipt.mjs` distinguishes only same-repo vs fork, so opt-in
+enforcement currently fails **any** same-repo PR missing a receipt — it does not yet skip a
+hand-written PR. Enforcement is opt-in and default-off, so this is a refinement, not a
+regression; the spec flips to `shipped` when the agent-evidence gate lands.


### PR DESCRIPTION
## Release v0.4.0 — ready to dispatch

Prepares the `0.4.0` cut. **Publishing stays the maintainer's button** — merge this, then
run `release-publish.yml` (Actions → Run workflow on `main`, OIDC, no token). This PR does
not publish.

### What ships (verified against code)

- **Seamless PR receipts** — `aireceipts pr --store ref` writes the receipt as a
  deterministic git object on `refs/receipts/<slug>` (invisible in the tree/diff); a
  committed pre-push hook auto-attaches it on `git push`; a two-job CI workflow renders +
  posts the receipt from the ref via `GITHUB_TOKEN` behind a hardened trust-boundary
  sanitizer — no local `gh`. Opt-in, off by default. (SPEC-0065 / SPEC-0066)
- **`@latest` distribution pin** for the PR-receipt-check caller (SPEC-0064 R1).
- **Faster parse/preflight** — in-process sqlite, goldens compile cache, parallel preflight
  (SPEC-0063).

### Spec statuses (honest partial-ship)

Only the fully-complete spec flips to `shipped`; the rest carry per-requirement notes.

| Spec | Status | Note |
|---|---|---|
| SPEC-0063 | `shipped` | perf, fully done |
| SPEC-0064 | `building` | R1 (`@latest`) shipped; R2–R4 (`pr-check` cmd) pending |
| SPEC-0065 | `building` | R1–R3/R6 shipped; R5 (local ref tooling) pending |
| SPEC-0066 | `building` | R1–R4/R6 shipped; R5 (agent-built enforcement) pending |

`AGENTS.md`: 36 specs at `status: shipped`.

### Gates

- **Release-manager verdict: GO** — 4-persona panel (PM/EM/Designer/QA), all GO;
  `docs/releases/0.4.0-verdict.md`.
- **Docs panel (`/review-docs`): GO after fixes** — cold-reader + Codex correctness auditor.
  Caught and fixed two honesty over-claims before ship:
  - enforcement is coarse (same-repo require; forks notice-only) — *not* agent-aware as the
    draft claimed → changelog + SPEC-0065/0066 corrected, SPEC-0066 kept `building`;
  - "zero network calls" was false by default (opt-out telemetry) → README hero + agent docs
    scoped to pricing, with the opt-out disclosed inline.
- **Preflight: 11/11** — tarball install+run e2e, determinism ×10, full vitest, goldens,
  spec-lint, hygiene, cite-check, eslint, tsc. Green on the exact SHA.

### Follow-ups filed

- #170 — CSV formula-injection guard (pre-existing, QA finding).
- The three `building` specs' deferred slices (npm-native `pr-check`; local ref tooling;
  agent-built enforcement discrimination).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
