### PR TITLE
feat: SPEC-0068 same-file re-reads — low-confidence diagnostic (corpus-gated)

### DIFF
--- a/docs/json-schema.md
+++ b/docs/json-schema.md
@@ -57,6 +57,7 @@ JSON export.
 | `methodology` | string | The attribution methodology string (I3). |
 | `priceRowsUsed` | array | Every dated price row consulted; see PriceRowUsed. |
 | `costShape` | CostShape | SPEC-0067 — cost-shape facts (standalone, never in savings math): `preEdit` (pre-edit cost/token share), `topTurns` (expensive-turn concentration, or null), `lateTurn` (neutral late-half/early-half cost ratio, low confidence, or null). |
+| `sameFileReReads` | SameFileReReads \| null | SPEC-0068 — same-file re-reads diagnostic (standalone, low confidence, NEVER a waste row or savings claim); null when none. |
 | `subagents` | Subagents (optional) | SPEC-0061 — the session's subagent (child-transcript) rollup; present only when children were discovered. Aggregate only — never child ids, titles, or paths. |
 
 ### Subagents object
@@ -87,6 +88,18 @@ SPEC-0067 cost-shape facts — standalone, never in savings math. `preEdit` alwa
 | `indices` | array | 1-based turn numbers of the top-3 turns, ascending. |
 | `lateTurn` | object \| null | `lateRatio`: a neutral late-half/early-half average-cost ratio (low confidence; never a "context growth" cause). |
 | `lateRatio` | number | Second-half average turn cost / first-half average. |
+
+### SameFileReReads object
+
+SPEC-0068 — same-FILE re-reads (same normalized path, any range) with no recorded edit, compaction, or matching shell command between them. A neutral low-confidence diagnostic; it is not a waste row and never contributes to a "could have saved" figure.
+
+| Field | Type | Notes |
+|---|---|---|
+| `count` | number | No-recorded-cause re-reads (2nd..Nth reads of a path). |
+| `turnIndices` | array | 1-/0-based transcript turn indices of the counted re-reads, ascending. |
+| `tokens` | TokenUsage | Per-call token share of the counted re-reads. |
+| `usd` | number \| null | Priced share; null if any counted re-read is unpriced (I2). |
+| `confidence` | string | Always `low` — the transcript cannot prove a re-read was unnecessary. |
 
 ### TokenUsage object
 

--- a/specs/SPEC-0068-same-file-rereads.md
+++ b/specs/SPEC-0068-same-file-rereads.md
@@ -68,6 +68,13 @@ tokens-only or stays draft.
   low confidence) — no recorded edit, compaction, or matching shell command between; may include
   legitimate re-grounding.` Never "wasted"/"avoidable". A test asserts no savings `$` AND no `%` is
   attributed on **both** the handoff and the PR body.
+  **Implementation note (2026-07-07):** realized as a **standalone diagnostic block** (R5's
+  `sameFileReReads` field on `ReceiptModel`, mirroring `costShape`), NOT a `WasteLine`. It is
+  therefore structurally never in `handoff.ts`'s `WasteLine.usd` sum or `pr/body.ts`'s savings line,
+  achieving the Net above **by construction** — the (i)/(ii) WasteLine-confidence-exclusion mechanism
+  is unnecessary. The `confidence: "low"` field lives on the standalone block, and a test asserts the
+  signal is never a `same-file-rereads` waste-row kind. Rendered in `--details` + `--json` only (a
+  low-confidence, corpus-gated line stays off the default receipt until R6 is met).
 - **R5 — Surfaces (minimal).** Text receipt: the R4 diagnostic line (marked low confidence). `--json`:
   `sameFileReReads: { count, turnIndices, tokens, usd: number | null, confidence: "low" }`. No
   `--handoff` action suggestion in this spec (deferred until the corpus gate proves the signal — S2).

--- a/src/pricing/waste.ts
+++ b/src/pricing/waste.ts
@@ -1,4 +1,5 @@
-import type { Compaction, Session, TokenUsage, Turn } from "../parse/types.js";
+import { posix as posixPath } from "node:path";
+import type { Compaction, Session, TokenUsage, ToolCallStatus, Turn } from "../parse/types.js";
 import { addUsage, emptyUsage, scaleUsage, withTotal } from "../parse/util.js";
 import { defaultDataDir } from "./priceTable.js";
 import { cheapestCurrentRow, costOf, isoDateOf, priceTurn, resolvePrice, vendorForSource, vendorForTurn } from "./resolve.js";
@@ -42,6 +43,12 @@ export interface StuckLoopFinding {
 interface FlatCall {
   tool: string;
   normalizedInput: string;
+  /** SPEC-0068 — raw call input (for read `file_path` / shell `command` extraction). */
+  input?: unknown;
+  /** SPEC-0068 — a real shell execution (may mutate files). */
+  shell?: boolean;
+  /** SPEC-0068 — a failed read is a retry, not a re-read. */
+  status?: ToolCallStatus;
   usd: number | null;
   tokens: TokenUsage;
   turnIndex: number;
@@ -65,6 +72,9 @@ async function flattenCalls(session: Session, dataDir: string): Promise<FlatCall
       out.push({
         tool: call.name,
         normalizedInput: normalizedInput(call.input),
+        input: call.input,
+        shell: call.shell,
+        status: call.status,
         usd: priced !== null ? priced.usd * share : null,
         tokens: tokenShare,
         turnIndex: turn.index,
@@ -114,6 +124,120 @@ export async function detectStuckLoops(session: Session, dataDir: string = defau
   }
 
   return findings;
+}
+
+// --- SPEC-0068 same-file re-reads (a LOW-confidence neutral diagnostic) ---------
+
+const READ_TOOL_NAMES = new Set(["Read"]);
+const REREAD_EDIT_TOOL_NAMES = new Set(["Edit", "Write", "NotebookEdit"]);
+/**
+ * Whole-tree shell mutators that can change files WITHOUT naming a basename the
+ * substring check would catch. Deliberately narrow: a path-specific `git checkout
+ * README.md` is NOT whole-tree (the substring check suppresses only that file);
+ * only `.`-targeted / `--hard` / stash / apply / whole-tree formatters qualify.
+ */
+const WHOLE_TREE_MUTATOR = /\bgit\s+reset\s+--hard\b|\bgit\s+stash\b|\bgit\s+apply\b|\bgit\s+(?:checkout|restore)\s+(?:--\s+)?\.(?:\s|$)|\bprettier\b[^|]*--write|\beslint\b[^|]*--fix|\bfind\b[^|]*-exec/u;
+
+/** Normalize a read/edit path (`file_path`, or `NotebookEdit`'s `notebook_path`): resolve `.`/`..`, collapse separators, strip a trailing slash. Absolute vs relative and different dirs stay distinct — `src/a.ts` !== `test/a.ts` (SPEC-0068 R1). */
+function normReadPath(input: unknown): string | undefined {
+  if (input && typeof input === "object") {
+    const o = input as { file_path?: unknown; notebook_path?: unknown };
+    const raw = typeof o.file_path === "string" ? o.file_path : typeof o.notebook_path === "string" ? o.notebook_path : undefined;
+    if (raw && raw.length > 0) {
+      return posixPath.normalize(raw).replace(/(?!^)\/+$/u, "");
+    }
+  }
+  return undefined;
+}
+
+function shellCommandOf(input: unknown): string {
+  if (input && typeof input === "object" && "command" in input) {
+    const c = (input as { command?: unknown }).command;
+    return typeof c === "string" ? c : "";
+  }
+  return "";
+}
+
+export interface SameFileReReadsFinding {
+  /** No-recorded-cause re-reads (2nd..Nth reads of a path with no edit/compaction/shell-touch between). */
+  count: number;
+  /** `null` when any counted re-read is unpriced (I2). */
+  usd: number | null;
+  tokens: TokenUsage;
+  turnIndices: number[];
+  /** Always low — the transcript cannot prove the re-read was unnecessary (SPEC-0068 R4). */
+  confidence: "low";
+}
+
+/**
+ * SPEC-0068 R1-R3 — same-FILE re-reads (same normalized path, any range) with no
+ * RECORDED edit to that path, compaction, or shell command touching it between the
+ * reads. A neutral diagnostic FACT, never a waste verdict (R4) and never a savings
+ * claim. `usd` is `null` if any counted re-read is unpriced (I2). Fires only where a
+ * `Read` tool with a `file_path` exists (Claude Code) — silent elsewhere (I6).
+ */
+export async function detectSameFileReReads(session: Session, dataDir: string = defaultDataDir()): Promise<SameFileReReadsFinding | null> {
+  const flat = await flattenCalls(session, dataDir);
+  const compactionTurns = (session.compactions ?? []).map((c) => c.turnIndex);
+
+  const lastRead = new Map<string, { ord: number; turn: number }>();
+  const lastEditOrd = new Map<string, number>();
+  // Shell calls in order — a re-read is "shell-touched" if a later-than-prior-read
+  // shell command is whole-tree OR mentions the file's basename (substring, so it
+  // catches multi-dot/no-extension/dotfile names the regex would miss — Codex #1).
+  const shellCalls: { ord: number; cmd: string; wholeTree: boolean }[] = [];
+
+  let count = 0;
+  let tokens = emptyUsage();
+  let usd: number | null = 0;
+  const turnIndices = new Set<number>();
+
+  flat.forEach((f, ord) => {
+    if (REREAD_EDIT_TOOL_NAMES.has(f.tool)) {
+      const p = normReadPath(f.input);
+      if (p) {
+        lastEditOrd.set(p, ord);
+      }
+      return;
+    }
+    if (f.shell === true || f.tool === "Bash") {
+      const cmd = shellCommandOf(f.input);
+      shellCalls.push({ ord, cmd, wholeTree: WHOLE_TREE_MUTATOR.test(cmd) });
+      return;
+    }
+    if (!READ_TOOL_NAMES.has(f.tool) || f.status === "error") {
+      return; // non-read, or a failed read (a retry, not a re-read)
+    }
+    const p = normReadPath(f.input);
+    if (!p) {
+      return;
+    }
+    const prev = lastRead.get(p);
+    if (prev === undefined) {
+      lastRead.set(p, { ord, turn: f.turnIndex });
+      return;
+    }
+    const editBetween = (lastEditOrd.get(p) ?? -1) > prev.ord;
+    const base = posixPath.basename(p);
+    const bashBetween = shellCalls.some((s) => s.ord > prev.ord && (s.wholeTree || s.cmd.includes(base)));
+    const compactionBetween = compactionTurns.some((t) => t > prev.turn && t <= f.turnIndex);
+    if (!editBetween && !bashBetween && !compactionBetween) {
+      count += 1;
+      tokens = addUsage(tokens, f.tokens);
+      if (f.usd === null) {
+        usd = null;
+      } else if (usd !== null) {
+        usd += f.usd;
+      }
+      turnIndices.add(f.turnIndex);
+    }
+    lastRead.set(p, { ord, turn: f.turnIndex });
+  });
+
+  if (count === 0) {
+    return null;
+  }
+  return { count, usd, tokens, turnIndices: [...turnIndices].sort((a, b) => a - b), confidence: "low" };
 }
 
 const TRIVIAL_SPAN_MAX_OUTPUT_TOKENS = 120;

--- a/src/receipt/exportSchema.ts
+++ b/src/receipt/exportSchema.ts
@@ -149,6 +149,17 @@ const receiptBodyShape = {
       lateTurn: z.object({ lateRatio: z.number(), confidence: z.literal("low") }).strict().nullable(),
     })
     .strict(),
+  /** SPEC-0068 — same-file re-reads diagnostic (standalone, never in savings math); null when none. */
+  sameFileReReads: z
+    .object({
+      count: z.number().int().nonnegative(),
+      turnIndices: z.array(z.number().int()),
+      tokens: tokenUsageSchema,
+      usd: z.number().nullable(),
+      confidence: z.literal("low"),
+    })
+    .strict()
+    .nullable(),
   /** SPEC-0061 R5 — subagent rollup aggregate; present only when the session has children. Counts and sums only — never child ids, titles, or paths. */
   subagents: z
     .object({

--- a/src/receipt/json.ts
+++ b/src/receipt/json.ts
@@ -132,6 +132,16 @@ function receiptBody(model: ReceiptModel) {
       topTurns: model.costShape.topTurns,
       lateTurn: model.costShape.lateTurn,
     },
+    // SPEC-0068 — same-file re-reads diagnostic (standalone; NEVER a waste[] row or savings claim).
+    sameFileReReads: model.sameFileReReads
+      ? {
+          count: model.sameFileReReads.count,
+          turnIndices: model.sameFileReReads.turnIndices,
+          tokens: tokenUsageJson(model.sameFileReReads.tokens),
+          usd: model.sameFileReReads.usd,
+          confidence: model.sameFileReReads.confidence,
+        }
+      : null,
     // SPEC-0061 R5 — aggregate only (counts + sums); child ids/titles/paths never export.
     ...(model.subagents ? { subagents: { ...model.subagents } } : {}),
   };

--- a/src/receipt/model.ts
+++ b/src/receipt/model.ts
@@ -10,9 +10,9 @@ import { computeCostShape, type CostShape } from "../pricing/costShape.js";
 import { defaultDataDir } from "../pricing/priceTable.js";
 import { isoDateOf, resolvePrice, vendorForTurn } from "../pricing/resolve.js";
 import type { ResolvedPrice } from "../pricing/types.js";
-import { detectContextThrash, detectStuckLoops, detectTrivialSpans, priceDeltaFootnote } from "../pricing/waste.js";
+import { detectContextThrash, detectSameFileReReads, detectStuckLoops, detectTrivialSpans, priceDeltaFootnote } from "../pricing/waste.js";
 import { detectTimeCaveats, type CaveatFinding } from "./caveats.js";
-import type { PriceDeltaFootnote } from "../pricing/waste.js";
+import type { PriceDeltaFootnote, SameFileReReadsFinding } from "../pricing/waste.js";
 
 export interface ModelMixEntry {
   model: string;
@@ -118,6 +118,8 @@ export interface ReceiptModel {
   cacheReadAtInputRateUsd: number | null;
   /** SPEC-0067 — cost-shape facts (pre-edit share + JSON/details expensive-turn & late-turn). Standalone facts, not WasteLines; never enter savings math. */
   costShape: CostShape;
+  /** SPEC-0068 — same-file re-reads, a LOW-confidence neutral diagnostic. A standalone field, NOT a WasteLine, so it is structurally never in the handoff/PR "could have saved" savings math (R4 satisfied by construction). Absent on mocks; `null` when no re-reads. */
+  sameFileReReads?: SameFileReReadsFinding | null;
   /** SPEC-0061 — subagent rollup, composed after build by session surfaces; absent ⇒ no children discovered (or the surface didn't compose it) and output stays byte-identical (I5). */
   subagents?: SubagentAggregate;
 }
@@ -265,6 +267,7 @@ export async function buildReceiptModel(session: Session, dataDir: string = defa
   const modelMix = await buildModelMix(session, attribution.byModelUsd);
   const toolRows = sortToolRows(attribution.byTool);
   const costShape = await computeCostShape(session, dataDir);
+  const sameFileReReads = await detectSameFileReReads(session, dataDir);
 
   const wasteLines: WasteLine[] = [
     ...stuckLoops.map(
@@ -372,5 +375,6 @@ export async function buildReceiptModel(session: Session, dataDir: string = defa
     peakTurn: findPeakTurn(session),
     cacheReadAtInputRateUsd: attribution.cacheReadAtInputRateUsd,
     costShape,
+    sameFileReReads,
   };
 }

--- a/src/receipt/present.ts
+++ b/src/receipt/present.ts
@@ -400,6 +400,14 @@ export function detailsBlocks(model: ReceiptModel): Block[] {
     // cache-write, and model switches, so it is not a context-growth measure (Codex #4).
     blocks.push({ kind: "note", text: "(ratio only — mixes output/cache/model)", indent: 2, muted: true });
   }
+  // SPEC-0068 — same-file re-reads: a LOW-confidence neutral diagnostic (never a
+  // "wasted"/savings claim; it is not a WasteLine and never enters savings math).
+  if (model.sameFileReReads) {
+    const r = model.sameFileReReads;
+    blocks.push({ kind: "row", label: "same-file re-reads", value: `${formatInt(r.count)} · ${formatShortTokens(r.tokens.total)} tok` });
+    blocks.push({ kind: "note", text: "(no recorded edit/shell/compaction between)", indent: 2, muted: true });
+    blocks.push({ kind: "note", text: "(low conf — may be legitimate re-grounding)", indent: 2, muted: true });
+  }
   if (model.cacheReadAtInputRateUsd !== null) {
     blocks.push({ kind: "row", label: "same reads at uncached input rate", value: `$${formatUsd(model.cacheReadAtInputRateUsd)}` });
     blocks.push({ kind: "note", text: PRICE_DELTA_NOTE, indent: 2, muted: true });

--- a/test/pricing/same-file-rereads.test.ts
+++ b/test/pricing/same-file-rereads.test.ts
@@ -1,0 +1,103 @@
+// SPEC-0068 — unit tests for detectSameFileReReads. Real data/prices (haiku
+// input rate = 1.0/token-million, so a 1-call read turn with input=1e6 = $1).
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { detectSameFileReReads } from "../../src/pricing/waste.js";
+import type { Session, SessionTotals, TokenUsage, ToolCall, Turn } from "../../src/parse/types.js";
+
+const dataDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../data/prices");
+const JUNE_15_2026 = Date.UTC(2026, 5, 15, 10, 0, 0);
+const HAIKU = "claude-haiku-4-5";
+
+function usage(input: number): TokenUsage {
+  return { total: input, input, output: 0, cacheRead: 0, cacheCreation: 0 };
+}
+function session(turns: Turn[], overrides: Partial<Session> = {}): Session {
+  const totals: SessionTotals = { tokens: usage(0), turnCount: 0, toolCallCount: 0 };
+  return { id: "s", source: "claude-code", filePath: "/f.jsonl", totals, turns, ...overrides };
+}
+function turn(index: number, calls: ToolCall[], model: string | undefined = HAIKU): Turn {
+  return { index, timestamp: JUNE_15_2026, model, usage: usage(1_000_000), toolCalls: calls };
+}
+const read = (fp: string, status?: "ok" | "error"): ToolCall => ({ name: "Read", input: { file_path: fp }, ...(status ? { status } : {}) });
+const edit = (fp: string): ToolCall => ({ name: "Edit", input: { file_path: fp } });
+const bash = (command: string): ToolCall => ({ name: "Bash", shell: true, input: { command } });
+
+describe("detectSameFileReReads", () => {
+  it("counts same-file re-reads with nothing recorded between", async () => {
+    const s = session([turn(0, [read("a.ts")]), turn(1, [read("a.ts")]), turn(2, [read("a.ts")])]);
+    const f = await detectSameFileReReads(s, dataDir);
+    expect(f?.count).toBe(2);
+    expect(f?.confidence).toBe("low");
+    expect(f?.usd).toBeCloseTo(2, 10);
+  });
+
+  it("does not count a re-read after an Edit to that file", async () => {
+    const s = session([turn(0, [read("a.ts")]), turn(1, [edit("a.ts")]), turn(2, [read("a.ts")])]);
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+
+  it("does not count a re-read after a shell command naming the file", async () => {
+    const s = session([turn(0, [read("a.ts")]), turn(1, [bash("sed -i s/x/y/ a.ts")]), turn(2, [read("a.ts")])]);
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+
+  it("does not count a re-read after a whole-tree shell mutator", async () => {
+    const s = session([turn(0, [read("a.ts")]), turn(1, [bash("git checkout .")]), turn(2, [read("a.ts")])]);
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+
+  it("does not count a re-read across a compaction", async () => {
+    const s = session([turn(0, [read("a.ts")]), turn(2, [read("a.ts")])], { compactions: [{ turnIndex: 1 }] });
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+
+  it("treats different directories as different files", async () => {
+    const s = session([turn(0, [read("src/a.ts")]), turn(1, [read("test/a.ts")])]);
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+
+  it("treats a failed read then a successful read as a retry, not a re-read", async () => {
+    const s = session([turn(0, [read("a.ts", "error")]), turn(1, [read("a.ts", "ok")])]);
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+
+  it("resolves path aliases (./a.ts and a.ts are the same file)", async () => {
+    const s = session([turn(0, [read("./a.ts")]), turn(1, [read("a.ts")])]);
+    expect((await detectSameFileReReads(s, dataDir))?.count).toBe(1);
+  });
+
+  it("keeps usd null when a counted re-read is unpriced (I2)", async () => {
+    const s = session([turn(0, [read("a.ts")]), turn(1, [read("a.ts")])], { unpriceable: true });
+    const f = await detectSameFileReReads(s, dataDir);
+    expect(f?.count).toBe(1);
+    expect(f?.usd).toBeNull();
+  });
+
+  it("excludes a re-read after a shell command naming a multi-dot basename (Codex #1)", async () => {
+    const s = session([turn(0, [read("schema.test.ts")]), turn(1, [bash("sed -i s/x/y/ schema.test.ts")]), turn(2, [read("schema.test.ts")])]);
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+
+  it("excludes a re-read after a shell command naming a no-extension file (Codex #1)", async () => {
+    const s = session([turn(0, [read("Makefile")]), turn(1, [bash("touch Makefile")]), turn(2, [read("Makefile")])]);
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+
+  it("does NOT treat a path-specific git checkout as whole-tree (Codex #2)", async () => {
+    // git checkout of an UNRELATED file must not suppress a.ts re-reads.
+    const s = session([turn(0, [read("a.ts")]), turn(1, [bash("git checkout README.md")]), turn(2, [read("a.ts")])]);
+    expect((await detectSameFileReReads(s, dataDir))?.count).toBe(1);
+  });
+
+  it("treats `prettier . --write` as a whole-tree mutator (Codex #2)", async () => {
+    const s = session([turn(0, [read("a.ts")]), turn(1, [bash("prettier . --write")]), turn(2, [read("a.ts")])]);
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+
+  it("never fires without a Read tool (non-Claude shape)", async () => {
+    const s = session([turn(0, [bash("cat a.ts")]), turn(1, [bash("cat a.ts")])]);
+    expect(await detectSameFileReReads(s, dataDir)).toBeNull();
+  });
+});

--- a/test/receipt/same-file-rereads-render.test.ts
+++ b/test/receipt/same-file-rereads-render.test.ts
@@ -1,0 +1,63 @@
+// SPEC-0068 — end-to-end: the same-file re-reads diagnostic renders in --details
+// and --json as a STANDALONE block, and is never a waste row or a savings claim (R4/R5).
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildReceiptModel } from "../../src/receipt/model.js";
+import { detailsBlocks } from "../../src/receipt/present.js";
+import { toJsonModel } from "../../src/receipt/json.js";
+import { receiptJsonSchema } from "../../src/receipt/exportSchema.js";
+import type { Session, SessionTotals, TokenUsage, ToolCall, Turn } from "../../src/parse/types.js";
+
+const dataDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../data/prices");
+const JUNE_15_2026 = Date.UTC(2026, 5, 15, 10, 0, 0);
+
+function usage(input: number): TokenUsage {
+  return { total: input, input, output: 0, cacheRead: 0, cacheCreation: 0 };
+}
+function readTurn(index: number): Turn {
+  const call: ToolCall = { name: "Read", input: { file_path: "a.ts" } };
+  return { index, timestamp: JUNE_15_2026, model: "claude-haiku-4-5", usage: usage(1_000_000), toolCalls: [call] };
+}
+function reReadSession(): Session {
+  const totals: SessionTotals = { tokens: usage(3_000_000), turnCount: 3, toolCallCount: 3 };
+  return { id: "s", source: "claude-code", filePath: "/f.jsonl", totals, turns: [readTurn(0), readTurn(1), readTurn(2)] };
+}
+
+describe("SPEC-0068 same-file re-reads — render/json integration", () => {
+  it("populates the model and renders in --details", async () => {
+    const model = await buildReceiptModel(reReadSession(), dataDir);
+    expect(model.sameFileReReads?.count).toBe(2);
+    const details = detailsBlocks(model);
+    const row = details.find((b) => b.kind === "row" && b.label === "same-file re-reads");
+    expect(row).toBeDefined();
+    // low-confidence caveat note is present
+    expect(details.some((b) => b.kind === "note" && /low conf/.test(b.text))).toBe(true);
+  });
+
+  it("emits a standalone --json block that validates, with confidence low", async () => {
+    const model = await buildReceiptModel(reReadSession(), dataDir);
+    const json = toJsonModel(model);
+    expect(json.sameFileReReads?.count).toBe(2);
+    expect(json.sameFileReReads?.confidence).toBe("low");
+    expect(receiptJsonSchema.safeParse(json).success).toBe(true);
+  });
+
+  it("is NOT a waste row and carries no savings claim (R4)", async () => {
+    const model = await buildReceiptModel(reReadSession(), dataDir);
+    const json = toJsonModel(model);
+    // The R4 guarantee: same-file re-reads is a STANDALONE block, never a WasteLine kind,
+    // so it can never be summed into the handoff/PR "could have saved" $ (which only sums
+    // WasteLine.usd). Other real waste (e.g. stuck-loop) may co-fire — that's fine, they are
+    // independent diagnostics — but no waste row is ever `same-file-rereads`.
+    expect(json.wasteLines.some((w) => (w as { kind?: string }).kind === "same-file-rereads")).toBe(false);
+    expect(json.sameFileReReads).not.toBeNull();
+  });
+
+  it("is null (no block) when there are no re-reads", async () => {
+    const totals: SessionTotals = { tokens: usage(1_000_000), turnCount: 1, toolCallCount: 1 };
+    const single: Session = { id: "s", source: "claude-code", filePath: "/f.jsonl", totals, turns: [readTurn(0)] };
+    const json = toJsonModel(await buildReceiptModel(single, dataDir));
+    expect(json.sameFileReReads).toBeNull();
+  });
+});


### PR DESCRIPTION
## SPEC-0068 — same-file re-reads (low-confidence diagnostic)

> ⚠️ **Corpus-gated — do not merge yet.** Per SPEC-0068 R6, the re-reads line needs a ≥20-session labeled dogfood corpus confirming the flagged sample is genuinely no-recorded-cause **before it ships to users**. The code is complete and reviewed; this PR is ready for that validation step.

> 📚 **Stacked on #171** (SPEC-0067). Retarget to `main` once #171 merges.

Detects **same-file re-reads** (same normalized path, any range) with no *recorded* edit, compaction, or matching shell command between them — a **neutral low-confidence diagnostic**, never a "wasted"/savings claim. Backed by the arXiv literature and local data (~23% of re-reads across 38 real sessions had no recorded cause).

### Design
- `detectSameFileReReads` in `src/pricing/waste.ts` (extends the private `FlatCall`). Exclusions: an `Edit`/`Write`/`NotebookEdit` to the path, a compaction (turn-granular), or a shell command containing the basename / a whole-tree mutator (`git reset --hard`/`checkout .`/`stash`/`apply`, `prettier`/`eslint` whole-tree, `find -exec`). Failed reads are retries; paths normalized; `usd` null if any counted re-read is unpriced (I2).
- **Standalone diagnostic block** on `ReceiptModel` (NOT a `WasteLine`) → structurally never in the handoff/PR "could have saved" sum (R4 by construction). Rendered in `--details` + `--json` only, off the default receipt until R6 is met.

### Verification
- Codex-reviewed pre-merge; all 6 findings fixed (multi-dot/no-extension shell basenames; path-specific-vs-whole-tree git; `NotebookEdit` path; trailing slash; re-grounding caveat; exclusion tests).
- 18 detector/render tests (incl. the R4 "never a waste row / never in savings" assertion); 675-test suite green; tsc/eslint/spec-lint clean; 0 golden changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
