### PR TITLE
perf: SPEC-0069 incremental mutation testing, nightly full sweep

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,24 +1,37 @@
 name: Mutation
 
-# Runs Stryker mutation testing on the money paths — src/pricing/** AND
-# src/pr/** (the PR-attribution path, added SPEC-0044 M3) — the anti-gaming
-# moat (AGENTS.md): agent-written tests routinely hit ~100% coverage but a
-# lower mutation score, so coverage alone doesn't prove the tests assert
-# anything real. The break threshold in stryker.config.json fails CI if the
-# combined score drops below it.
+# Stryker mutation testing on the money paths — src/pricing/** AND src/pr/**
+# (the PR-attribution path, SPEC-0044 M3) — the anti-gaming moat (AGENTS.md):
+# agent-written tests routinely hit ~100% coverage but a lower mutation score,
+# so coverage alone doesn't prove the tests assert anything real. The break
+# threshold in stryker.config.json fails the job if the combined score drops
+# below it.
+#
+# SPEC-0069 — the exhaustive full sweep runs NIGHTLY (and rebuilds the shared
+# incremental baseline); PRs run INCREMENTALLY against that baseline, so a PR
+# touching a few files finishes in minutes instead of ~40. Both enforce the
+# same break:60 floor. Mutation stays advisory (not a required check).
 
 on:
   pull_request:
     paths:
       - "src/pricing/**"
       - "src/pr/**"
+  schedule:
+    # Nightly full sweep at 07:17 UTC (off the :00 rush). Refreshes the baseline
+    # PRs restore, bounding incremental staleness to <= 1 day.
+    - cron: "17 7 * * *"
+  workflow_dispatch: {}
 
-# SPEC-0033 R2 — least-privilege baseline; this job only reads and runs tests.
+# SPEC-0033 R2 — least-privilege baseline; these jobs only read and run tests.
 permissions:
   contents: read
 
 jobs:
-  mutation:
+  # PR path: fast, incremental, advisory. Restores the nightly baseline (read
+  # only) and re-runs mutation only on changed code.
+  mutation-pr:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -30,7 +43,18 @@ jobs:
 
       - run: npm ci
 
-      - name: mutation score
+      # Read-only restore: the exact key never hits (per-SHA), so restore-keys
+      # falls back to the most recent nightly baseline (created on the default
+      # branch, readable from PR branches). A miss just means a cold full run.
+      - name: restore mutation baseline
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: reports/stryker-incremental.json
+          key: stryker-inc-pr-${{ github.sha }}
+          restore-keys: |
+            stryker-inc-
+
+      - name: mutation score (incremental)
         run: |
           if [ ! -d src/pricing ] || [ -z "$(ls -A src/pricing 2>/dev/null)" ]; then
             echo "src/pricing/ is empty — nothing to mutate yet (Tier 0 harness). Skipping."
@@ -42,10 +66,46 @@ jobs:
             echo "Stryker config in the same PR that introduces src/pricing/." >&2
             exit 1
           fi
-          npx stryker run
-        # break=60 (stryker.config.json) is the enforced FLOOR — the same
-        # standard as src/pricing/, now extended (SPEC-0044 M3) to src/pr/**,
-        # which previously had ZERO mutation enforcement. It prevents the money
-        # paths' combined score from regressing below 60%. A tighter
-        # score-not-decreased ratchet against a stored main baseline is a
-        # follow-up (needs baseline persistence in CI).
+          npx stryker run --incremental
+
+  # Nightly / on-demand path: the exhaustive full sweep. --force re-tests every
+  # mutant AND rewrites a clean baseline, which is then cached for PRs to warm-
+  # start against. Enforces the same break:60 floor on the full surface.
+  mutation-nightly:
+    # Default branch only: the baseline PRs restore must come from main, and a
+    # cache saved from a side ref could poison it. workflow_dispatch is honored
+    # only on main for the same reason.
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: mutation score (full sweep, rebuild baseline)
+        run: |
+          if [ ! -d src/pricing ] || [ -z "$(ls -A src/pricing 2>/dev/null)" ]; then
+            echo "src/pricing/ is empty — nothing to mutate yet (Tier 0 harness). Skipping."
+            exit 0
+          fi
+          if [ ! -f stryker.config.json ] && [ ! -f stryker.conf.json ]; then
+            echo "FAIL: src/pricing/ exists but no Stryker config does." >&2
+            echo "Pricing code requires mutation testing (AGENTS.md gates) — add a" >&2
+            echo "Stryker config in the same PR that introduces src/pricing/." >&2
+            exit 1
+          fi
+          npx stryker run --incremental --force
+
+      # Save the fresh baseline under a per-SHA key; PR jobs restore it via the
+      # stryker-inc- prefix. Runs on the default branch, so PRs can read it.
+      - name: save mutation baseline
+        if: always() && hashFiles('reports/stryker-incremental.json') != ''
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: reports/stryker-incremental.json
+          key: stryker-inc-${{ github.sha }}

--- a/specs/SPEC-0069-mutation-incremental.md
+++ b/specs/SPEC-0069-mutation-incremental.md
@@ -1,0 +1,111 @@
+---
+id: SPEC-0069
+title: "Mutation testing — incremental PR runs, nightly full sweep"
+status: building # PR open; shipped flips on merge
+milestone: M5
+depends: [SPEC-0044]
+---
+
+# SPEC-0069: Mutation testing — incremental PR runs, nightly full sweep
+
+## Purpose
+
+The `Mutation` job (Stryker on `src/pricing/**` + `src/pr/**` — the money paths' anti-gaming
+moat, SPEC-0044 M3) runs ~40 minutes on every PR that touches those trees, testing ~4,300
+mutants exhaustively. 84% of that surface is `src/pr` comment/receipt *rendering*, where
+mutation testing has the worst signal-to-noise (equivalent mutants in string/formatting
+code depress the score with noise, not real test gaps — and the rendered strings are
+already byte-pinned by golden + exact-string tests). This spec keeps the moat exactly as
+strong on the money paths while removing the wasted time: PR runs go **incremental**
+(reuse prior mutant results, re-run only changed code) and the exhaustive full sweep moves
+to a **nightly** job that also refreshes the shared baseline. It changes *what executes*,
+never *what is mutated or gated* — no mutator is dropped, so coverage is identical.
+Empirically validated: Stryker's own incremental example reuses 94% of mutants, and a
+local reuse run dropped a module from 4m32s to 16s. Serves the AGENTS.md gate rationale
+(agent tests reach ~100% coverage but weaker mutation scores) — faster proof, not less
+proof, on the money paths.
+
+## Requirements
+
+- **R1** — `stryker.config.json` enables incremental mode: `"incremental": true`,
+  `"incrementalFile": "reports/stryker-incremental.json"`. Stryker reuses a KILLED
+  mutant when its culprit test is unchanged, and a SURVIVED mutant when no test changed
+  and no new test covers it; changed code re-runs. A full report is still produced every
+  run — incremental changes *what executes*, never *what is reported or gated*.
+- **R2** — The PR `Mutation` job (`on: pull_request`, paths `src/pricing/**`,
+  `src/pr/**`) restores the incremental baseline from cache (read-only, `restore-keys`
+  prefix) and runs `npx stryker run --incremental`. It stays **advisory** (not a required
+  check) and keeps the existing empty-`src/pricing` and missing-config guards. A cold
+  cache (before any nightly has populated one) degrades gracefully to a full run.
+- **R3** — A **nightly** job (`on: schedule` + `workflow_dispatch`, **guarded to the
+  default branch** so only `main` writes the shared baseline) runs the exhaustive full
+  sweep with `npx stryker run --incremental --force` (re-tests every mutant AND rewrites a
+  fresh baseline), then saves `reports/stryker-incremental.json` to cache under a key PRs
+  restore via prefix. Running on the default branch, its cache is readable by PR branches.
+  This bounds incremental staleness to ≤1 day and keeps a daily exhaustive guarantee on
+  the money paths. It keeps the same empty-`src/pricing` and missing-config guards as the
+  PR job.
+- **R4** — No mutator is disabled and the `src/pricing` + `src/pr` mutate scope and the
+  `break: 60` floor are unchanged. Every mutant Stryker generates today is still
+  generated, still tested (on the nightly full sweep, or on a PR when its code/tests
+  changed), and still gated — the money-path coverage is byte-for-byte identical; only
+  the *scheduling* of when each mutant runs changes. No product code changes.
+
+## Scenarios
+
+- **Given** a PR touching one `src/pr` file with a warm cached baseline **When** the
+  Mutation job runs **Then** only mutants in changed code (and mutants whose covering
+  tests changed) execute; the rest are reused; wall clock is a few minutes, not ~40.
+- **Given** the nightly schedule fires **When** the job runs **Then** every mutant is
+  re-tested (`--force`), a fresh baseline is written and cached, and a score below
+  `break: 60` fails the job.
+- **Given** a mutated arithmetic, conditional, or string-literal mutant anywhere in the
+  money paths **When** the nightly sweep runs (or a PR touches its code/tests) **Then** it
+  is still generated and must be killed — no mutator is disabled, so the moat is intact.
+- **Given** a cold cache (no prior nightly) **When** a PR Mutation job runs **Then**
+  `--incremental` builds the baseline from scratch (full run) and the job still reports
+  a score — no failure from a missing incremental file.
+- **Given** a `workflow_dispatch` on a non-default ref **When** it fires **Then** the
+  nightly job does not run — only `main` writes the shared baseline.
+
+## Non-goals
+
+- A score-ratchet (fail only if the score drops vs a stored main baseline): StrykerJS has
+  no native mechanism; the fixed `break: 60` floor stays. Deferred (would need custom
+  baseline-diff scripting).
+- Trimming cosmetic mutators (`ignoreStatic`, `mutator.excludedMutations: ["StringLiteral"]`):
+  **considered and rejected.** Both are global-only in Stryker — they cannot be scoped to
+  rendering files — and both drop real money-path mutants: `ignoreStatic` would ignore
+  static arithmetic like `src/pr/select.ts`'s `OVERLAP_SLACK_MS = 15 * 60 * 1000`
+  (an attribution window), and excluding `StringLiteral` would drop the model-prefix /
+  vendor-id routing literals in `src/pricing/resolve.ts` that choose the price table.
+  Incremental + nightly delivers the speedup without that coverage tradeoff.
+- Narrowing the `src/pr` mutate glob to only its numeric/attribution files: kept whole so
+  the nightly sweep still scores rendering. A future spec may narrow if the nightly full
+  run itself becomes too slow.
+- Cross-machine sharding across a CI matrix: StrykerJS has no native support (issue #2707,
+  closed stale); incremental + nightly is expected to suffice. Revisit only if the nightly
+  full run itself becomes too slow.
+- Making Mutation a required check: it stays advisory, as today.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 incremental reuse | 2nd run, unchanged file | prior results reused; wall clock collapses (locally 4m32s → 16s) |
+| R2 PR job | PR touching src/pricing/** or src/pr/** | restores baseline, runs `--incremental`, advisory, guards intact |
+| R2 cold cache | PR before any nightly | full run, score reported, no missing-file failure |
+| R3 nightly | schedule / workflow_dispatch on main | `--incremental --force` full sweep, fresh baseline saved to cache |
+| R3 dispatch off main | workflow_dispatch on a side ref | nightly job skipped (no baseline write) |
+| R4 no mutator dropped | any pricing/pr mutant (arithmetic, conditional, StringLiteral, static) | still generated + gated (attribution.ts scored 81.60% locally) |
+| R4 floor unchanged | combined score < 60 | job fails (break threshold) |
+
+## Success criteria
+
+- [ ] `stryker.config.json` valid; a scoped local run passes ≥ `break` (attribution.ts
+      81.60% confirmed) and incremental reuse demonstrably reuses prior results.
+- [ ] `.github/workflows/mutation.yml` has a PR incremental job + a nightly full-sweep
+      job, cache restore/save wired, actions SHA-pinned, `actionlint`/`zizmor` clean.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs`,
+      `node scripts/hygiene.mjs` all pass unmasked (`echo $?`) — no product code changed.

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -7,6 +7,8 @@
   "reporters": ["progress", "clear-text", "html"],
   "thresholds": { "high": 80, "low": 60, "break": 60 },
   "concurrency": 4,
+  "incremental": true,
+  "incrementalFile": "reports/stryker-incremental.json",
   "tempDirName": ".stryker-tmp",
   "cleanTempDir": true
 }


### PR DESCRIPTION
## What this adds

SPEC-0069: makes the `Mutation` CI job fast without weakening the money-path moat. Today it runs **~40 min on every PR** touching `src/pricing/**` or `src/pr/**`, exhaustively re-testing ~4,300 mutants. This changes *when* each mutant runs, never *whether* it runs.

## What changed

- `stryker.config.json` — enable **incremental mode** (`incremental` + `incrementalFile: reports/stryker-incremental.json`). Runs reuse prior mutant results and re-test only changed code (Stryker's own example reuses 94%).
- `.github/workflows/mutation.yml` — split into:
  - **PR job** (`--incremental`): restores the nightly baseline from cache **read-only**, advisory, keeps the empty-`src/pricing` + missing-config guards.
  - **Nightly job** (`schedule` + `workflow_dispatch`, **guarded to `main`**): `--incremental --force` full sweep, saves a fresh baseline to cache for PRs to warm-start against.
  - Same `break: 60` floor on both; `actions/cache` SHA-pinned; only `main` writes the shared baseline (no PR cache poisoning).
- `specs/SPEC-0069-mutation-incremental.md` — the spec.

## What to review, in order

1. **Safety — is the moat intact?** `stryker.config.json`: **no mutator is disabled**, mutate scope and `break: 60` unchanged. Every mutant is still generated and gated; only its *scheduling* changes (nightly full sweep, or on a PR when its code/tests changed).
2. **Cache correctness**, `mutation.yml:44-111`: PR uses `actions/cache/restore` (read-only, `restore-keys: stryker-inc-` prefix → latest nightly); nightly uses `actions/cache/save` under a per-SHA key, guarded to `github.ref == 'refs/heads/main'`. GitHub cache scope lets PRs read default-branch caches; cold cache degrades to a full run.
3. **The rejected lever** — `Non-goals`: I dropped a cosmetic-mutant trim (`ignoreStatic` + `excludedMutations: StringLiteral`) after review showed both are global-only and drop real money-path mutants (static arithmetic like `src/pr/select.ts` `OVERLAP_SLACK_MS`; pricing routing literals in `src/pricing/resolve.ts`).

## Evidence

Gates (unmasked): tsc 0 · eslint 0 · vitest 1625/1625 · goldens byte-identical · determinism ×10 · spec-lint 0 · hygiene 0. No product code changed.

Local Stryker validation (final config): `src/pricing/attribution.ts` scores **81.60%** (above the 60 floor); **incremental reuse drops a same-module re-run from 4m32s → 16s**.

Empirical confirmation of the rejected trim: excluding those mutators *inflated* attribution.ts from 81.60% → 92.11% by hiding real survivors — i.e. the trim was masking genuine money-path test gaps. Dropped.

Spec: `specs/SPEC-0069-mutation-incremental.md`.

Independent critic (Codex, deep effort, per `/review-pr`): first pass **REJECT** — caught that `ignoreStatic`/`StringLiteral` exclusion weakened money-path coverage; fixed by dropping the trim + two workflow guards; re-review **APPROVE, no findings**, gates re-run independently.

## Notes

Same-author disclosure: built by Claude, deep review by Codex (different model family) per `/review-pr`. Net effect: PR mutation runs go from ~40 min to a few minutes; the exhaustive guarantee moves to a nightly sweep on `main`; the anti-gaming moat is byte-for-byte as strong. Advisory (not a required check), unchanged.
