### PR TITLE
feat: SPEC-0069 statusline rich default — burn, context, reset countdown

### DIFF
--- a/docs/statusline.md
+++ b/docs/statusline.md
@@ -31,16 +31,22 @@ instead of `aireceipts` in the `command` field (for example, the output of
 ## Output
 
 ```
-[aireceipts] $1.23 · 12k tok · 5h 24%
-[aireceipts] $2.50 · 20k tok · ⚠ Bash loop ×5
-[aireceipts · Cursor] 8k tok
+[aireceipts] $4.20 · $9/hr · 128k · ctx 42% · 5h 24% ↺2h13m
+[aireceipts] $2.50 · $6/hr · 20k · ⚠ Bash loop ×5 · 5h 41% ↺58m
+[aireceipts · Cursor] 8k
 ```
 
-- `$X.XX · Nk tok` when the session's cost is priced; `Nk tok` only when it
-  isn't (never a fabricated `$` amount).
-- `5h N%` is your official 5-hour rate-limit window usage, straight from the
-  payload Claude Code pipes in (subscribers) — omitted when the payload doesn't
-  carry it, never guessed.
+- `$X.XX` is the session's priced cost (aireceipts' own cited-price figure, incl.
+  subagents); omitted when it can't be priced — never a fabricated `$` amount.
+- `$X/hr` is the session-average burn rate (that same priced cost over the session
+  wall-clock); omitted when the session isn't priced or has no duration yet.
+- `Nk` / `NM` is the session's token count, abbreviated (`12k`, `1.2M`, `501M`).
+- `ctx N%` is how full the current context window is — Claude Code's own
+  pre-calculated `context_window.used_percentage`, omitted when the payload lacks it.
+- `5h N% ↺Xh Ym` is your official 5-hour rate-limit usage (Claude Code's own
+  `rate_limits.five_hour.used_percentage`, subscribers only) plus the time until the
+  window resets, derived from the real `resets_at` — the countdown is dropped (leaving
+  `5h N%`) when `resets_at` is absent or already past, never a guessed time.
 - The waste flag (`⚠ ...`) appears only when a waste detector actually fired
   on the session — its absence is not itself a claim that nothing was found.
 - Outside a piped invocation (or when stdin carries no usable payload),
@@ -51,7 +57,7 @@ instead of `aireceipts` in the `command` field (for example, the output of
 
 ## Custom formats (`--format`)
 
-The default line is the format `brand,cost,tokens,waste,quota5h`. Pick your own
+The default line is the format `brand,cost,burn,tokens,context,waste,quota5h`. Pick your own
 segments with `--format` (comma-separated; a segment with nothing honest to say
 is omitted, and an unknown name exits 1 with the valid list on stderr):
 
@@ -68,9 +74,11 @@ is omitted, and an unknown name exits 1 with the valid list on stderr):
 |---|---|---|
 | `brand` | `[aireceipts]` (stdin) / `[aireceipts · <agent>]` (disk fallback) | — |
 | `cost` | `$X.XX` | priced session total incl. subagents; omitted when unpriced (I2) |
-| `tokens` | `Nk tok` | session + subagent tokens |
+| `burn` | `$X/hr` | session-average burn (priced cost ÷ wall-clock); omitted when unpriced or no duration |
+| `tokens` | `Nk` / `NM` | session + subagent tokens, abbreviated |
+| `context` | `ctx N%` | Claude Code's `context_window.used_percentage` (stdin only) |
 | `waste` | `⚠ ...` | first fired waste detector |
-| `quota5h` / `quota7d` | `5h N%` / `7d N%` | official `rate_limits` passthrough (stdin only) |
+| `quota5h` / `quota7d` | `5h N% ↺Xh Ym` / `7d N% ↺…` | official `rate_limits` passthrough + reset countdown (stdin only) |
 | `quotaEta` | `≈ 5h cap HH:MM UTC` | labeled arithmetic, see below |
 
 ### `quotaEta` honesty rules

--- a/specs/SPEC-0069-statusline-rich-default.md
+++ b/specs/SPEC-0069-statusline-rich-default.md
@@ -1,0 +1,152 @@
+---
+id: SPEC-0069
+title: "Statusline rich default — burn rate, context %, quota reset countdown, M/B tokens"
+status: draft
+milestone: M5
+depends: [SPEC-0062]
+---
+
+# SPEC-0069: Statusline rich default
+
+Invariants: I2 (never a fabricated dollar — a `$` segment renders only when priced), I3
+(every number traceable; the reset countdown derives from Claude Code's real `resets_at`,
+never estimated), I5 (byte-stable output — exact-string `renderSegments` unit tests gate the
+shape), I6 (facts, not rankings). Every
+segment stays an **honest passthrough** of Claude Code's own payload field or a deterministic
+value from aireceipts' own priced ledger — nothing is invented.
+
+## Purpose
+
+The default statusline (`brand,cost,tokens,waste,quota5h`, SPEC-0062) renders `5h 26%` — which
+is Claude Code's authoritative `rate_limits.five_hour.used_percentage`, but reads as ambiguous
+(26% of *what*?) and drops the reset time (the actionable part). It also renders `501,368k tok`
+for ~501M tokens. This spec makes the default line the researched best-in-class shape —
+`[aireceipts] $423 · $80/hr · 501M · ctx 42% · 5h 26% ↺2h13m` — by fixing token formatting,
+adding a **burn rate** and **context %** segment, and giving the 5h window an inline reset
+countdown. **Kill criterion:** any segment that cannot be rendered from a real payload field or
+a priced ledger value (i.e. would require estimating) is cut, not faked.
+
+## Requirements
+
+- **R1 — `tokens` uses abbreviated M/B formatting.** The `tokens` segment renders
+  `formatShortTokens(totalTokens)` (`371k` / `1.2M` / `501M`), not `formatTokensK`'s
+  `501,368k tok`. Fixes the unreadable large-count case.
+- **R2 — new `context` segment.** `ctx N%` from `payload.context_window.used_percentage`
+  (Claude Code sends a pre-calculated 0–100 value; docs confirm). Guarded exactly like the
+  rate-limit windows: absent, non-numeric, or out of `[0,100]` → segment omitted (the same
+  guard rejects the known CC epoch-timestamp bug). `N = Math.round(used_percentage)`.
+- **R3 — new `burn` segment (deterministic, from aireceipts' own ledger).** `$X/hr` where
+  `X` is `totalUsd / (durationMs / 3_600_000)` — the session's priced spend over its
+  wall-clock, from `MiniSummary.totalUsd`/`durationMs` (aireceipts' cited-price figure, NOT
+  Claude Code's estimate, for I2 consistency with the `cost` segment). Rendered as **whole
+  dollars once ≥ `$1/hr`** (glanceable) and **cents below `$1/hr`** (so a real small burn is
+  never rounded away to the misleading `$0/hr`). Omitted when `unpriceable`, `totalUsd` is
+  `null`/non-finite/negative, `durationMs` is absent/non-finite/`≤ 0`, or the computed rate is
+  non-finite (no fabricated `$NaN`/`$Infinity`/negative rate — Codex #1). It is a session-average
+  rate (a labeled fact); a rolling-window burn is a non-goal (below).
+- **R4 — `quota5h` gains an inline reset countdown.** `5h N% ↺Xh Ym` (e.g. `5h 26% ↺2h13m`)
+  where the countdown is `resets_at * 1000 - nowMs` (`resets_at` is epoch **seconds**, per
+  `quotaWindow.ts:16`). Rendered `Xh Ym` above an hour, `Ym` under. The countdown is dropped
+  (leaving `5h N%`) when `resets_at` is absent, already past, non-finite, **or absurdly far out
+  (> ~8 days — a 5h/7d window never resets further, so a garbage/ms-as-seconds value is rejected,
+  not rendered as `↺499505000h0m` — Codex #2)** — never a negative or fabricated time. `quota7d`
+  gets the same treatment.
+- **R5 — the default format becomes the rich line.** `DEFAULT_FORMAT =
+  "brand,cost,burn,tokens,context,waste,quota5h"` (the existing `waste` flag is kept — it
+  renders only when a waste line fired, so it's free on clean sessions and preserves aireceipts'
+  differentiator). `burn` and `context` are added to `SEGMENT_NAMES`
+  so `--format` can name them; `quotaEta`/`quota7d` remain opt-in. A segment with nothing
+  honest to say still returns `null` and is omitted (I2/I3) — so a cheap early session with no
+  duration/context/rate-limit data degrades to just `[aireceipts] $X · <tokens>`.
+- **R6 — no color in v1.** Segments return plain strings (the engine is plain-text). Threshold
+  color-coding (burn/context green/yellow/red) is a deliberate follow-on non-goal.
+- **R7 — exact-string unit tests.** The statusline is verified by byte-exact `renderSegments`
+  unit assertions (there is no golden infrastructure for the statusline in this repo), covering:
+  the new rich default on a full-payload fixture; each new segment's guard (absent/out-of-range/
+  non-finite → omitted); the reset countdown format, its past/absent/**absurd** fallback, and
+  the same countdown on `quota7d`; and M/B token formatting.
+
+## Scenarios
+
+- **Given** a full stdin payload (cost, duration, `context_window.used_percentage`, five_hour
+  `used_percentage`+`resets_at`), **when** the default statusline renders, **then**
+  `[aireceipts] $423 · $80/hr · 501M · ctx 42% · 5h 26% ↺2h13m`.
+- **Given** a payload with `rate_limits` but no `resets_at`, **when** it renders, **then**
+  `… 5h 26%` (no countdown, no fabricated time).
+- **Given** a `resets_at` already in the past, **when** it renders, **then** `5h N%` (fallback,
+  never a negative countdown).
+- **Given** `context_window.used_percentage = 1700000000` (the CC epoch bug), **when** it
+  renders, **then** the `context` segment is omitted (out of `[0,100]`).
+- **Given** an unpriceable (Cursor) session or one with no `durationMs`, **when** it renders,
+  **then** the `burn` segment is omitted (no fabricated `$/hr`).
+- **Given** a session of 501,368,000 tokens, **when** `tokens` renders, **then** `501M`.
+- **Given** the disk-fallback mode (no stdin payload), **when** it renders, **then** `context`
+  and `quota*` are omitted (no payload), `burn` renders if the fallback session is priced.
+
+## Non-goals
+
+- **Color / ANSI thresholds** (burn/context red-yellow-green) — follow-on (R6).
+- **Rolling-window / active-block burn rate** — v1 is session-average (honest, deterministic);
+  a recent-velocity burn needs windowing and its own evidence.
+- **Preferring Claude Code's `cost.total_cost_usd`** over aireceipts' own priced figure — the
+  `cost`/`burn` segments stay on aireceipts' cited-price ledger (I2 consistency); CC's
+  client-side estimate is not mixed in.
+- **A multi-line statusline / powerline** — aireceipts' edge is a glanceable single line.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 tokens M/B | 501,368,000 tokens | `501M` |
+| R2 context | `context_window.used_percentage: 42` | `ctx 42%` |
+| R2 context guard | `used_percentage: 1.7e9` or absent | segment omitted |
+| R3 burn | totalUsd 40, durationMs 1.8e6 (0.5h) | `$80/hr` |
+| R3 burn omitted | unpriceable / totalUsd null / durationMs 0 | segment omitted |
+| R4 countdown | `resets_at` 2h13m ahead | `5h 26% ↺2h13m` |
+| R4 sub-hour | `resets_at` 45m ahead | `↺45m` |
+| R4 no reset | `resets_at` absent | `5h 26%` (no countdown) |
+| R4 past reset | `resets_at` in the past | `5h N%` (fallback) |
+| R4 absurd reset | `resets_at` a ms value (huge) | `5h N%` (countdown omitted, not `↺…000h0m`) |
+| R4 quota7d | `seven_day` reset ahead | `7d N% ↺…` (same countdown) |
+| R5 default | full payload | the rich line, in order |
+| R5 degraded | payload with only cost | `[aireceipts] $X · <tokens>` |
+| R6 plain text | any rendered segment | no ANSI escape codes in the output |
+| R7 non-finite burn | `totalUsd` NaN / `durationMs` NaN | `burn` omitted (no `$NaN/hr`) |
+
+## Success criteria
+
+- [ ] The rich default renders as specified on a full-payload fixture; each new segment omits
+      cleanly on absent/out-of-range data (no fabricated `$/hr`, `%`, or countdown).
+- [ ] Reset countdown derives from real `resets_at` (epoch seconds), with the past/absent
+      fallback; `tokens` uses `formatShortTokens`.
+- [ ] Exact-string `renderSegments` tests pin the rich default and every segment guard
+      (non-finite burn, absurd/absent/past reset, out-of-range context, M/B tokens).
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/spec-lint.mjs` all pass unmasked (`echo $?`).
+
+## Validation
+
+**2026-07-08 · S1 (self):** clean on I2/I3/I6 for the normal path; the self-audit missed the
+non-finite/absurd numeric edges S2 caught.
+
+**2026-07-08 · S2 (Codex, on the implementation): 4 findings, all fixed.**
+1. *Accepted (High, I2).* `burn` didn't guard non-finite/negative `totalUsd`/`durationMs` → could
+   render `$NaN/hr`/`$Infinity/hr`/negative. Now guards finite + non-negative + finite computed
+   rate (R3); tests added.
+2. *Accepted (High, I3).* A garbage/ms-as-seconds `resets_at` rendered `↺499505000h0m`. Added a
+   `MAX_RESET_COUNTDOWN_MS` (~8 days) cap so absurd values omit the countdown (R4); test added.
+3. *Accepted (Medium).* R7 said "goldens" but the statusline has no golden infra here — reworded
+   to byte-exact `renderSegments` unit tests, and added the missing `quota7d` countdown test.
+4. *Accepted (Low).* R3 said `round(...)`; the implementation shows cents below `$1/hr` (so a real
+   small burn isn't hidden as `$0/hr`) — the spec now documents that better behavior, not `round`.
+
+**2026-07-08 · S3 (worth): who + how often** — every Claude Code user with the statusline
+configured, every render; the `5h 26%` label was actively confusing (the maintainer flagged it).
+**do-nothing** — the misleading quota label and unreadable `501,368k` persist. **smaller fix** — the
+label/token fix alone is the floor; the maintainer chose the full rich line (cost/burn/tokens/
+context/quota+reset) via an explicit design question. **steelman the cut** — none: every segment is
+an honest passthrough or a deterministic ledger value, and it's opt-out via `--format`.
+
+**Verdict: BUILD NOW** (built; Codex-reviewed; all findings fixed).
+
+**S4 (spec-lint): pass.**

--- a/src/cli/statuslineSegments.ts
+++ b/src/cli/statuslineSegments.ts
@@ -7,7 +7,7 @@
 // render a partial line.
 import type { MiniSummary } from "../receipt/mini.js";
 import { statuslineWasteFlag } from "../receipt/mini.js";
-import { formatTokensK, formatUsd } from "../receipt/format.js";
+import { formatShortTokens, formatUsd } from "../receipt/format.js";
 import {
   projectCapCrossingMs,
   quotaWindowPath,
@@ -16,9 +16,9 @@ import {
   type QuotaReading,
 } from "./quotaWindow.js";
 
-export const DEFAULT_FORMAT = "brand,cost,tokens,waste,quota5h";
+export const DEFAULT_FORMAT = "brand,cost,burn,tokens,context,waste,quota5h";
 
-export const SEGMENT_NAMES = ["brand", "cost", "tokens", "waste", "quota5h", "quota7d", "quotaEta"] as const;
+export const SEGMENT_NAMES = ["brand", "cost", "burn", "tokens", "context", "waste", "quota5h", "quota7d", "quotaEta"] as const;
 export type SegmentName = (typeof SEGMENT_NAMES)[number];
 
 export interface SegmentContext {
@@ -75,6 +75,42 @@ function utcHhMm(ms: number): string {
   return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())} UTC`;
 }
 
+/** R2 — Claude Code's pre-calculated `context_window.used_percentage` (0–100). Guarded like the rate-limit windows: absent/non-numeric/out-of-range → `null` (also rejects the CC epoch-timestamp bug). */
+function contextPct(payload: unknown): number | null {
+  if (typeof payload !== "object" || payload === null) {
+    return null;
+  }
+  const cw = (payload as Record<string, unknown>).context_window;
+  if (typeof cw !== "object" || cw === null) {
+    return null;
+  }
+  const pct = (cw as Record<string, unknown>).used_percentage;
+  return typeof pct === "number" && Number.isFinite(pct) && pct >= 0 && pct <= 100 ? pct : null;
+}
+
+/** A 5h/7d window never resets more than ~8 days out — a remaining time beyond this means a garbage `resets_at` (e.g. a ms value sent as seconds, or the CC epoch bug), so omit rather than render an absurd countdown (Codex #2). */
+const MAX_RESET_COUNTDOWN_MS = 8 * 24 * 60 * 60 * 1000;
+
+/** R4 — time until a rate-limit window resets, as `2h13m` / `45m`; `null` when `resets_at` is absent, already past, or absurdly far out (never a negative/fabricated time). `resetsAtSec` is epoch SECONDS. */
+function resetCountdown(resetsAtSec: number | null, nowMs: number): string | null {
+  if (resetsAtSec === null) {
+    return null;
+  }
+  const remMs = resetsAtSec * 1000 - nowMs;
+  if (!Number.isFinite(remMs) || remMs <= 0 || remMs > MAX_RESET_COUNTDOWN_MS) {
+    return null;
+  }
+  const totalMin = Math.floor(remMs / 60_000);
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return h > 0 ? `${h}h${m}m` : `${m}m`;
+}
+
+/** R3 — a burn RATE `$/hr`: whole dollars once it's ≥ $1/hr (glanceable), else the cents. */
+function formatRate(perHr: number): string {
+  return perHr >= 1 ? String(Math.round(perHr)) : formatUsd(perHr);
+}
+
 /**
  * R4 — the `≈` ETA segment: reads the prior reading, persists the current one
  * (atomic, last-writer-wins), and projects only when every guard holds.
@@ -105,15 +141,37 @@ const SEGMENTS: Record<SegmentName, (ctx: SegmentContext) => string | null> = {
   brand: (ctx) => (ctx.inputMode === "stdin_payload" ? "[aireceipts]" : `[aireceipts · ${ctx.summary.agentLabel}]`),
   cost: (ctx) =>
     !ctx.summary.unpriceable && ctx.summary.totalUsd !== null ? `$${formatUsd(ctx.summary.totalUsd)}` : null,
-  tokens: (ctx) => formatTokensK(ctx.summary.totalTokens),
+  tokens: (ctx) => formatShortTokens(ctx.summary.totalTokens),
+  // R2 — Claude Code's pre-calculated context-window fullness; omitted when absent (I2/I3).
+  context: (ctx) => {
+    const p = contextPct(ctx.payload);
+    return p === null ? null : `ctx ${Math.round(p)}%`;
+  },
+  // R3 — session-average burn rate from aireceipts' OWN priced ledger (I2 — no fabricated $/hr).
+  burn: (ctx) => {
+    const { totalUsd, durationMs, unpriceable } = ctx.summary;
+    if (unpriceable || totalUsd === null || !Number.isFinite(totalUsd) || totalUsd < 0 || durationMs === undefined || !Number.isFinite(durationMs) || durationMs <= 0) {
+      return null;
+    }
+    const perHr = totalUsd / (durationMs / 3_600_000);
+    return Number.isFinite(perHr) ? `$${formatRate(perHr)}/hr` : null;
+  },
   waste: (ctx) => (ctx.summary.topWaste ? statuslineWasteFlag(ctx.summary.topWaste) : null),
   quota5h: (ctx) => {
     const w = quotaWindow(ctx.payload, "five_hour");
-    return w ? `5h ${Math.round(w.usedPercentage)}%` : null;
+    if (!w) {
+      return null;
+    }
+    const cd = resetCountdown(w.resetsAt, ctx.nowMs);
+    return cd ? `5h ${Math.round(w.usedPercentage)}% ↺${cd}` : `5h ${Math.round(w.usedPercentage)}%`;
   },
   quota7d: (ctx) => {
     const w = quotaWindow(ctx.payload, "seven_day");
-    return w ? `7d ${Math.round(w.usedPercentage)}%` : null;
+    if (!w) {
+      return null;
+    }
+    const cd = resetCountdown(w.resetsAt, ctx.nowMs);
+    return cd ? `7d ${Math.round(w.usedPercentage)}% ↺${cd}` : `7d ${Math.round(w.usedPercentage)}%`;
   },
   quotaEta: quotaEtaSegment,
 };

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -551,7 +551,7 @@ describe("built CLI e2e", () => {
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("[aireceipts]");
     expect(result.stdout).toContain("$0.18");
-    expect(result.stdout).toContain("147k tok");
+    expect(result.stdout).toContain("147k");
     expect(result.stdout.endsWith("\n")).toBe(true);
   });
 

--- a/test/cli/statusline-segments.test.ts
+++ b/test/cli/statusline-segments.test.ts
@@ -87,7 +87,7 @@ describe("SPEC-0062 R3 — parseFormat", () => {
 
 describe("SPEC-0062 R3 — renderSegments", () => {
   it("renders exactly the requested segments, ·-joined", () => {
-    expect(renderSegments(segs("cost,tokens"), ctx())).toBe("$0.50 · 1k tok");
+    expect(renderSegments(segs("cost,tokens"), ctx())).toBe("$0.50 · 1k");
   });
 
   it("duplicate segments render twice", () => {
@@ -106,12 +106,67 @@ describe("SPEC-0062 R3 — renderSegments", () => {
 
   it("I2: cost omits itself on an unpriced session — no zero-fill, no $ bytes", () => {
     const unpriced = ctx({ summary: buildMiniSummary(model({ totalUsd: null })) });
-    expect(renderSegments(segs("cost,tokens"), unpriced)).toBe("1k tok");
+    expect(renderSegments(segs("cost,tokens"), unpriced)).toBe("1k");
   });
 
   it("the default format constant matches the spec-pinned list", () => {
-    expect(DEFAULT_FORMAT).toBe("brand,cost,tokens,waste,quota5h");
+    expect(DEFAULT_FORMAT).toBe("brand,cost,burn,tokens,context,waste,quota5h");
     expect(SEGMENT_NAMES).toContain("quotaEta");
+  });
+});
+
+describe("SPEC-0069 — rich statusline (burn, context, quota countdown, M/B tokens)", () => {
+  it("R1: tokens use abbreviated M formatting", () => {
+    expect(renderSegments(segs("tokens"), ctx({ summary: buildMiniSummary(model({ totalTokens: usage(501_368_000) })) }))).toBe("501M");
+  });
+
+  it("R2: context segment from context_window.used_percentage; omitted when absent/out-of-range", () => {
+    expect(renderSegments(segs("context"), ctx({ payload: { context_window: { used_percentage: 42 } } }))).toBe("ctx 42%");
+    expect(renderSegments(segs("context"), ctx({ payload: { context_window: { used_percentage: 1_700_000_000 } } }))).toBe(""); // CC epoch-bug guard
+    expect(renderSegments(segs("context"), ctx({ payload: {} }))).toBe("");
+  });
+
+  it("R3: burn is a priced $/hr over the session wall-clock; omitted with no duration/price (no fabricated rate)", () => {
+    expect(renderSegments(segs("burn"), ctx({ summary: buildMiniSummary(model({ totalUsd: 40, durationMs: 1_800_000 })) }))).toBe("$80/hr"); // $40 / 0.5h
+    expect(renderSegments(segs("burn"), ctx())).toBe(""); // model() has no durationMs
+    expect(renderSegments(segs("burn"), ctx({ summary: buildMiniSummary(model({ durationMs: 1_800_000, totalUsd: null })) }))).toBe("");
+    expect(renderSegments(segs("burn"), ctx({ summary: buildMiniSummary(model({ durationMs: 1_800_000, unpriceable: true, totalUsd: null })) }))).toBe("");
+    // Codex #1 — non-finite / negative inputs never render a fabricated $NaN/$Infinity/negative rate
+    expect(renderSegments(segs("burn"), ctx({ summary: buildMiniSummary(model({ totalUsd: NaN, durationMs: 1_800_000 })) }))).toBe("");
+    expect(renderSegments(segs("burn"), ctx({ summary: buildMiniSummary(model({ totalUsd: 40, durationMs: NaN })) }))).toBe("");
+    expect(renderSegments(segs("burn"), ctx({ summary: buildMiniSummary(model({ totalUsd: -5, durationMs: 1_800_000 })) }))).toBe("");
+  });
+
+  it("R4: quota5h shows an inline reset countdown, with sub-hour / no-reset / past-reset handling", () => {
+    const at = (msBefore: number) => ctx({ payload: quotaPayload(26), nowMs: RESETS_AT_MS - msBefore });
+    expect(renderSegments(segs("quota5h"), at((2 * 3600 + 13 * 60) * 1000))).toBe("5h 26% ↺2h13m");
+    expect(renderSegments(segs("quota5h"), at(45 * 60 * 1000))).toBe("5h 26% ↺45m");
+    expect(renderSegments(segs("quota5h"), ctx({ payload: { rate_limits: { five_hour: { used_percentage: 26 } } }, nowMs: 0 }))).toBe("5h 26%"); // no resets_at
+    expect(renderSegments(segs("quota5h"), ctx({ payload: quotaPayload(26), nowMs: RESETS_AT_MS + 60_000 }))).toBe("5h 26%"); // reset already past
+    // Codex #2 — a ms-as-seconds / garbage resets_at is beyond ~8 days out → countdown omitted, not ↺…000h0m
+    expect(renderSegments(segs("quota5h"), ctx({ payload: { rate_limits: { five_hour: { used_percentage: 26, resets_at: 1_800_018_000_000 } } }, nowMs: 0 }))).toBe("5h 26%");
+  });
+
+  it("R4: quota7d gets the same reset countdown", () => {
+    const payload = { rate_limits: { seven_day: { used_percentage: 55, resets_at: WINDOW.resets_at } } };
+    expect(renderSegments(segs("quota7d"), ctx({ payload, nowMs: RESETS_AT_MS - 30 * 60 * 1000 }))).toBe("7d 55% ↺30m");
+  });
+
+  it("R5: the rich default renders every segment in order", () => {
+    const summary = buildMiniSummary(model({ totalUsd: 423.26, durationMs: 7_200_000, totalTokens: usage(501_368_000) })); // $423.26 / 2h = $212/hr
+    const payload = { context_window: { used_percentage: 42 }, rate_limits: { five_hour: { used_percentage: 26, resets_at: WINDOW.resets_at } } };
+    const nowMs = RESETS_AT_MS - (2 * 3600 + 13 * 60) * 1000;
+    expect(renderSegments(segs(DEFAULT_FORMAT), ctx({ summary, payload, nowMs }))).toBe("[aireceipts] $423.26 · $212/hr · 501M · ctx 42% · 5h 26% ↺2h13m");
+  });
+
+  it("R5: degrades to cost + tokens when no payload/duration data", () => {
+    expect(renderSegments(segs(DEFAULT_FORMAT), ctx({ payload: null }))).toBe("[aireceipts] $0.50 · 1k");
+  });
+
+  it("R6: rendered segments contain no ANSI escape codes", () => {
+    const summary = buildMiniSummary(model({ totalUsd: 40, durationMs: 1_800_000, totalTokens: usage(501_368_000) }));
+    const payload = { context_window: { used_percentage: 42 }, rate_limits: { five_hour: { used_percentage: 26, resets_at: WINDOW.resets_at } } };
+    expect(renderSegments(segs(DEFAULT_FORMAT), ctx({ summary, payload, nowMs: 0 }))).not.toContain(String.fromCharCode(27));
   });
 });
 

--- a/test/receipt/statusline-render.test.ts
+++ b/test/receipt/statusline-render.test.ts
@@ -1,7 +1,7 @@
 // SPEC-0007 R1 rules on the SPEC-0062 segments engine: the one-liner's
 // rendering rules, exercised directly against constructed `ReceiptModel`s (no
 // fixture I/O — `renderSegments` over `buildMiniSummary` is pure given a
-// context). The default line is the format `brand,cost,tokens,waste,quota5h`.
+// context). The default line is the format `brand,cost,burn,tokens,context,waste,quota5h`.
 import { describe, expect, it } from "vitest";
 import { buildMiniSummary } from "../../src/receipt/mini.js";
 import { DEFAULT_FORMAT, parseFormat, renderSegments, type SegmentContext } from "../../src/cli/statuslineSegments.js";
@@ -63,12 +63,12 @@ function renderDefault(model: ReceiptModel, over: Partial<SegmentContext> = {}):
 describe("default line (R1 priced, no waste)", () => {
   it("renders [aireceipts] $usd · Nk tok with no waste-flag segment", () => {
     const model = baseModel({ totalUsd: 1.23, totalTokens: usage(12345) });
-    expect(renderDefault(model)).toBe("[aireceipts] $1.23 · 12k tok");
+    expect(renderDefault(model)).toBe("[aireceipts] $1.23 · 12k");
   });
 
   it("disk-fallback mode names the session's agent in the brand", () => {
     const model = baseModel({ agentLabel: "Codex", source: "codex" });
-    expect(renderDefault(model, { inputMode: "disk_fallback" })).toBe("[aireceipts · Codex] $1.23 · 12k tok");
+    expect(renderDefault(model, { inputMode: "disk_fallback" })).toBe("[aireceipts · Codex] $1.23 · 12k");
   });
 });
 
@@ -85,14 +85,14 @@ describe("default line (R1 unpriced — I2: zero $ bytes)", () => {
       sessionTotalTokens: usage(8000),
     });
     const line = renderDefault(model);
-    expect(line).toBe("[aireceipts] 8k tok");
+    expect(line).toBe("[aireceipts] 8k");
     expect(line).not.toContain("$");
   });
 
   it("renders tokens-only when nothing in the session priced (totalUsd null)", () => {
     const model = baseModel({ totalUsd: null, totalTokens: usage(500) });
     const line = renderDefault(model);
-    expect(line).toBe("[aireceipts] 1k tok");
+    expect(line).toBe("[aireceipts] 500");
     expect(line).not.toContain("$");
   });
 });
@@ -108,7 +108,7 @@ describe("default line (R1 waste flags)", () => {
       wallClockMs: 15000,
     };
     const model = baseModel({ totalUsd: 2.5, totalTokens: usage(20000), wasteLines: [waste] });
-    expect(renderDefault(model)).toBe("[aireceipts] $2.50 · 20k tok · ⚠ Bash loop ×5");
+    expect(renderDefault(model)).toBe("[aireceipts] $2.50 · 20k · ⚠ Bash loop ×5");
   });
 
   it("appends a trivial-spans flag with the eligible turn count", () => {
@@ -120,7 +120,7 @@ describe("default line (R1 waste flags)", () => {
       cheaperModel: "claude-haiku-4-5",
     };
     const model = baseModel({ totalUsd: 2.5, totalTokens: usage(20000), wasteLines: [waste] });
-    expect(renderDefault(model)).toBe("[aireceipts] $2.50 · 20k tok · ⚠ 7 trivial spans");
+    expect(renderDefault(model)).toBe("[aireceipts] $2.50 · 20k · ⚠ 7 trivial spans");
   });
 
   it("omits the waste segment entirely when nothing fired (I6: absence, not a claim)", () => {
@@ -152,15 +152,15 @@ describe("default line (R1 waste flags)", () => {
 });
 
 describe("SPEC-0062 R2 — quota on the default line", () => {
-  const payload = { rate_limits: { five_hour: { used_percentage: 23.5, resets_at: 1_800_000_000 } } };
+  const payload = { rate_limits: { five_hour: { used_percentage: 23.5 } } };
 
   it("appends the official 5h percentage, integer-rounded", () => {
-    expect(renderDefault(baseModel(), { payload })).toBe("[aireceipts] $1.23 · 12k tok · 5h 24%");
+    expect(renderDefault(baseModel(), { payload })).toBe("[aireceipts] $1.23 · 12k · 5h 24%");
   });
 
   it("omits the segment for an out-of-range percentage (SPEC-0014 R4: never a guess)", () => {
     const bad = { rate_limits: { five_hour: { used_percentage: 130 } } };
-    expect(renderDefault(baseModel(), { payload: bad })).toBe("[aireceipts] $1.23 · 12k tok");
+    expect(renderDefault(baseModel(), { payload: bad })).toBe("[aireceipts] $1.23 · 12k");
   });
 
   it("the 7d window stays off the default line", () => {

--- a/test/receipt/subagents.test.ts
+++ b/test/receipt/subagents.test.ts
@@ -211,7 +211,7 @@ describe("SPEC-0061 R1 — the SUBAGENTS row across templates", () => {
 describe("SPEC-0061 R3/R4 — statusline and mini fold the aggregate in", () => {
   it("statusline $ and tokens cover parent + children, format unchanged", () => {
     const model = baseModel({ subagents: { ...AGG, pricedUsd: 9.85, tokensTotal: 1_000_000 } });
-    expect(renderStatusline(model)).toBe("[aireceipts] $10.03 · 1,012k tok");
+    expect(renderStatusline(model)).toBe("[aireceipts] $10.03 · 1M");
   });
 
   it("statusline stays tokens-only when the parent is unpriced (I2)", () => {


### PR DESCRIPTION
## SPEC-0069 — statusline rich default

The default statusline rendered `[aireceipts] $423.26 · 501,368k tok · 5h 26%`. The `5h 26%`
is Claude Code's own authoritative `rate_limits.five_hour.used_percentage` — accurate, but it
read as ambiguous (26% of *what*?) and dropped the reset time (the actionable part); and
`501,368k tok` is unreadable for ~501M tokens. This makes the default the researched
best-in-class shape:

```
[aireceipts] $423.26 · $212/hr · 501M · ctx 42% · 5h 26% ↺2h13m
```

### Changes
- **R1** — `tokens` uses `formatShortTokens` (`501M`), not `501,368k tok`.
- **R2** — new `context` segment from Claude Code's own `context_window.used_percentage`,
  guarded to `[0,100]` (also rejects the known CC epoch-timestamp bug).
- **R3** — new `burn` segment: session-average `$X/hr` from aireceipts' **own** priced ledger
  (I2 consistency with `cost`), whole dollars once `>= $1/hr`, cents below. Omitted — never a
  fabricated `$NaN`/`$Infinity`/negative — when unpriced, non-finite, or duration-less.
- **R4** — `quota5h`/`quota7d` gain an inline reset countdown `↺Xh Ym` derived from the real
  `resets_at`; dropped (leaving `5h N%`) when absent/past/absurd (`> ~8 days`, so a garbage
  ms-as-seconds value can't render `↺…000h0m`).
- **R5** — default format → `brand,cost,burn,tokens,context,waste,quota5h`; `burn`/`context`
  are `--format`-nameable. `waste` stays (renders only when a detector fired — free on clean
  sessions).
- **R6** — plain text only, no ANSI in v1.
- **R7** — byte-exact `renderSegments` unit tests.

Every segment stays an honest passthrough of Claude Code's own payload field or a deterministic
value from aireceipts' priced ledger — nothing is estimated (I2/I3).

### Validation
- `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `node scripts/spec-lint.mjs` — clean.
- 67 statusline unit tests + the built-CLI statusline e2e cases + subagent-rollup tests pass.
- **Codex-reviewed** (S2): 4 findings, all fixed — non-finite/negative `burn` guard,
  absurd-`resets_at` countdown cap, spec R7 reworded to unit-tests + `quota7d` test, R3
  rounding wording aligned to the cents-below-`$1` behavior. **S3 verdict: build now.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
