### PR TITLE
feat: SPEC-0064 R2–R7 — self-contained npm-native pr-check

### DIFF
--- a/docs/adopt/pr-check-caller.yml
+++ b/docs/adopt/pr-check-caller.yml
@@ -1,0 +1,14 @@
+# npm-native, no reusable-workflow `uses:` — no org Actions-policy gate; for trusted
+# same-repo/internal PRs (fork PRs get a read-only token).
+name: aireceipts
+on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npx -y aireceipts-cli@latest pr-check
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/docs/adopt/pr-receipt-check-caller.yml
+++ b/docs/adopt/pr-receipt-check-caller.yml
@@ -6,6 +6,9 @@
 # advanced on every publish (SPEC-0064 R1); pin a `v*` tag instead for a frozen ref.
 name: pr-receipt-check
 on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   check:
     uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest

--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -148,6 +148,10 @@ by deleting the file.
   hook calling `npx aireceipts-cli pr --store ref --push-ref` (the flags ship in the npm
   package; the hook file does not). Either way a contributor can still just run
   `npx aireceipts-cli pr --post`. Each layer is opt-in and notice-only until turned on.
+- **npm-native (no `uses:`)** — for trusted same-repo/internal repos, use the
+  [self-contained caller](adopt/pr-check-caller.yml). It runs
+  `npx -y aireceipts-cli@latest pr-check` in your own workflow, avoids the public
+  reusable-workflow org-policy gate, and keeps fork PRs notice-only.
 
 CI still never generates a receipt itself: the source transcripts stay local (I1/I4).
 Rolling out across a whole org: [docs/adopt/org-rollout.md](adopt/org-rollout.md).

--- a/specs/SPEC-0064-check-distribution.md
+++ b/specs/SPEC-0064-check-distribution.md
@@ -1,102 +1,164 @@
 ---
 id: SPEC-0064
-title: PR-receipt check — release-pinned distribution and an npm-native pr-check
+title: PR-receipt check — release-pinned distribution and a self-contained npm-native pr-check
 status: building
 milestone: M5
-depends: [SPEC-0019, SPEC-0030, SPEC-0057]
+depends: [SPEC-0019, SPEC-0030, SPEC-0057, SPEC-0066]
 ---
 
-# SPEC-0064: PR-receipt check — release-pinned distribution and an npm-native pr-check
+# SPEC-0064: PR-receipt check — release-pinned distribution and a self-contained npm-native pr-check
 
 ## Purpose
 
-Adopters wire the CI presence check by pinning the reusable workflow at `@main` — a
-moving branch on a personal repo, with no release gate. This spec does two things. **R1
-(ship now):** move the adopter pin to `@latest`, a moving tag that tracks the newest
-*published* release and is advanced automatically on every publish, so an org rollout
-pins a release-gated ref instead of raw `main`. **R2–R4 (follow-up):** publish the
-verdict as an `aireceipts pr-check` command so CI can run `npx aireceipts-cli@latest
-pr-check` with no GitHub-repo `uses:` reference at all — the only packaging that removes
-the personal-repo dependency entirely.
+Today an adopter posts the PR receipt one of two ways: locally (`npx aireceipts-cli pr
+--post` with their own `gh`), or by pinning aireceipts' **reusable workflow** via `uses:`.
+The reusable-workflow path has friction that blocks a seamless org rollout: it is an
+*external* workflow in a personal public repo, so an internal org repo can only call it if
+the org's Actions policy permits public reusable workflows, self-hosted runners don't cross
+to it, and a caller `@vX` pin does not actually freeze what runs (the workflow checks out
+`main` + `@latest` internally).
 
-The check only ever *reads a PR's comments* for the marked receipt; generation stays on
-the developer's machine (`npx aireceipts-cli pr --post`). This serves **I1/I4**
-(local-first; zero transcript exposure on the runner) and the "one verdict, N packagings"
-principle established with SPEC-0057: the verdict logic in `scripts/check-pr-receipt.mjs`
-is the single source of truth behind the reusable workflow, the composite action
-(SPEC-0057), and — with R2 — the published CLI.
+**R1 (shipped in v0.4.0):** move the adopter pin to `@latest`. **R2–R7 (this spec):** ship
+a **self-contained** `aireceipts pr-check` command so an adopter's *own* workflow — one job
+running `npx -y aireceipts-cli@latest pr-check`, with **no reusable-workflow `uses:`** —
+fetches the branch's receipt ref, renders + sanitizes it, upserts the marked PR comment via
+`GITHUB_TOKEN`, and returns the presence verdict for optional enforcement. `npx` from public
+npm is not a reusable workflow, so this removes the org-policy gate, the personal-repo
+dependency, and the runner constraint at once.
+
+The hard boundary is unchanged: **CI never generates a receipt** — the transcript lives only
+on the developer's machine (I1/I4). `pr-check` only *transports* what the local hook
+(SPEC-0065) produced on `refs/receipts/<slug>`: fetch → sanitize → render → post.
 
 ## Requirements
 
-- **R1** — A moving `latest` git tag tracks the newest published release. Caller
+- **R1 (shipped)** — A moving `latest` git tag tracks the newest published release. Caller
   templates (`docs/adopt/pr-receipt-check-caller.yml`, the `rollout-dogfood` generator,
-  `docs/pr-receipts.md`, `aireceipts integrations`) pin the reusable workflow at
-  `@latest`. `release-publish.yml`'s `tag-and-release` job force-moves `latest` to the
-  published commit on every publish. The reusable workflow's *internal* self-checkout
-  stays `ref: main` (freshest verdict script for this repo's own dogfood CI; the grep is
-  backward-compatible by design).
-- **R2** — An `aireceipts pr-check` command exposes the `check-pr-receipt.mjs` verdict
-  (`found` / `missing-notice` / `missing-required`) through the published package. It
-  accepts a comments JSON on stdin/path (CI passes the `gh api` output) with
-  `--head-repo`, `--base-repo`, and `--require-same-repo` flags, mirroring the script's
-  interface. Exit code is `0` for `found`/`missing-notice` and `1` for `missing-required`
-  — the CLI never fails a build unless enforcement is opted in.
-- **R3** — The render/native path (`@resvg/resvg-js`) is lazily imported so `pr-check`
-  runs without loading it. A cold `npx aireceipts-cli@latest pr-check` in CI must not
-  download or build native bindings it does not use.
-- **R4** — A documented npm-native caller (`docs/adopt/`) runs the check via
-  `npx aireceipts-cli@latest pr-check` with no `uses:` reference. `pr-check` also runs
-  locally (a developer checks whether their PR carries a receipt before pushing).
+  `docs/pr-receipts.md`, `aireceipts integrations`) pin the reusable workflow at `@latest`;
+  `release-publish.yml` force-moves `latest` on every publish; the reusable workflow's
+  internal self-checkout stays `ref: main`.
+- **R2 — `pr-check` is the self-contained CI entrypoint (fetch → render → post), no base
+  checkout.** It creates a throwaway temp git repo (`git init` in an OS temp dir) and fetches
+  `refs/receipts/<slug>` from the **head** repo via a token-authenticated URL
+  (`https://x-access-token:<token>@github.com/<head-full-name>.git`), reusing SPEC-0066
+  `fetchReceiptRef` — so no `actions/checkout` of the base repo is required. Context resolves
+  from Actions env: base repo full name `GITHUB_REPOSITORY`; head repo full name + PR number
+  from the `GITHUB_EVENT_PATH` payload (`pull_request.head.repo.full_name`,
+  `pull_request.number`); head ref `GITHUB_HEAD_REF`. Flags override:
+  `--pr`, `--base-repo`, `--head-repo` (**full name** `owner/repo`), `--head-ref`. The
+  head-repo **full name** and the derived **clone URL** are kept distinct (full name for
+  verdict/posting; URL, built with the token, only for the fetch). It renders + sanitizes via
+  SPEC-0066 `fetchAndRenderReceipt` + the field-aware sanitizer, then **upserts the single
+  `DOGFOOD_MARKER` comment** on the **base**-repo PR via a **new injected REST client**
+  (`GITHUB_TOKEN`/`GH_TOKEN`, no local `gh`). The posted body is byte-identical to the two-job
+  reusable workflow's output for the same payload.
+- **R3 — the REST upsert is a small injected, paginated helper.** New `src/pr/` module (not
+  the existing `gh`-based `comment.ts`, which shells out to `gh` and is unusable here):
+  given base full name + PR number + token, it lists **all** comment pages, finds the first
+  body starting with `DOGFOOD_MARKER`, and **creates** (POST) if absent or **PATCHes** the
+  existing one — never a second marker comment. It classifies failures cleanly: a `403`
+  (fork read-only token) or `404` degrades to a printed notice + no throw; other errors are
+  reported best-effort. The REST client is injected (a `fetch`-like dep) so tests mock it —
+  **no live network in tests**.
+- **R4 — verdict + enforcement + exit codes.** Reuses `receiptCheckVerdict` semantics:
+  `found` → exit 0; missing on default/fork → `missing-notice`, exit 0; missing on a
+  **same-repo** PR with `--require-same-repo` (or `AIRECEIPTS_REQUIRE_PR_RECEIPT=true`) →
+  `missing-required`, exit 1. Coarse same-repo-vs-fork only; agent-built vs hand-written stays
+  **SPEC-0066 R5 (deferred)**. Fork PRs never fail (read-only token; no transcript on any
+  runner). `pr-check` also runs locally (a dev checks their branch carries a receipt).
+- **R5 — lazy render + honest install cost.** `pr-check` never *loads* `@resvg/resvg-js` at
+  runtime (markdown only; no SVG/PNG) and does not need the native binary to be functional.
+  It does **not** claim to avoid *installing* it — `@resvg/resvg-js` stays a runtime dependency
+  today (making it optional is a separate packaging change, out of scope). "Lean" here means
+  the render code path, not the npm install footprint.
+- **R6 — self-contained adopter workflow + template fix + honest trust model.** Ship
+  `docs/adopt/pr-check-caller.yml`: `permissions: { contents: read, pull-requests: write }`,
+  one job, `npx -y aireceipts-cli@latest pr-check`, no reusable-workflow `uses:` (a first-party
+  `actions/checkout` step is *not needed* — `pr-check` self-fetches — and standard Actions like
+  checkout are not the policy-gated "public reusable workflows"). Also fix
+  `docs/adopt/pr-receipt-check-caller.yml` to add `pull-requests: write` — missing today, so a
+  reusable-workflow adopter's post job silently cannot comment (a real bug, independent of this
+  spec). **Trust model (honest):** the single-job path renders the untrusted, fork-author-
+  controlled payload in the same job that holds the write token. The sanitizer
+  (`src/pr/sanitize.ts`) is a **Markdown-safety** barrier only — it does **not** isolate the
+  token from a package/runtime compromise, and does **not** prove the receipt's dollar
+  provenance (that is the receipt's own I2/I3 discipline). So `pr-check` is for **trusted
+  same-repo / internal** PRs; the **two-job reusable workflow (SPEC-0066)**, which renders
+  token-lessly, stays the defense-in-depth path for **untrusted fork** PRs.
+- **R7 — hidden CI command + determinism + tests.** `pr-check` is a **hidden** command,
+  exactly like its sibling `pr-render-ref` — not in `--help`, so no help golden changes. It is
+  **telemetry-silent** by the same precedent: `pr-render-ref` is not in `COMMAND_VALUES` and
+  neither is `pr-check`; telemetry is auto-off in CI anyway, and a local run is uncounted just
+  as `pr-render-ref`'s is. It is **transport, not generation** (no `receipt_generated`).
+  Documented in `docs/adopt/` and `docs/pr-receipts.md`, not the interactive help. The
+  comment-marker and two-job paths are unchanged; `pr-check` is additive. Tests: context
+  resolution (env vs flags, incl. a fork whose head-repo ≠ base); temp-repo fetch; verdict +
+  exit codes (found / notice / required / fork); REST upsert create-vs-update + 403/404
+  classification against a **mocked** client (no live network); posted body ==
+  `renderPrBody(sanitized)` byte-for-byte; hostile-payload sanitize; lazy-render assertion.
+  `verify-goldens`, the sanitizer injection golden, and existing `pr-receipt-check` tests stay
+  green.
 
 ## Scenarios
 
-- **Given** an adopter repo pins `@latest`, **when** a new release publishes, **then**
-  `release-publish.yml` moves `latest` to that commit and the adopter's next run resolves
-  the release-gated workflow with no edit on their side.
-- **Given** a PR carries the marked receipt comment, **when** `aireceipts pr-check` reads
-  the comments JSON, **then** it prints `found` and exits `0`.
-- **Given** a same-repo PR with no receipt and `--require-same-repo`, **when** `pr-check`
-  runs, **then** it prints `missing-required` and exits `1`; a fork PR under the same flag
-  stays `missing-notice`, exit `0`.
-- **Given** a cold CI runner, **when** it runs `npx aireceipts-cli@latest pr-check`,
-  **then** no `@resvg/resvg-js` native binary is fetched or built.
+- **Given** an internal repo with the self-contained `pr-check` workflow and a branch carrying
+  a receipt ref, **when** a same-repo PR opens, **then** `pr-check` self-inits a temp repo,
+  fetches the ref from the head repo with the token, posts the marked comment on the PR, and
+  exits 0 — no `uses:`, no org Actions-policy toggle, no local `gh`, no base checkout.
+- **Given** the PR re-runs after new pushes, **when** `pr-check` runs again, **then** it
+  PATCHes the one marker comment (paginated lookup finds it) — no duplicate.
+- **Given** a hostile payload on the ref, **when** `pr-check` renders it, **then** the
+  sanitizer neutralizes it; the posted comment never breaks out; the job never throws.
+- **Given** a fork PR (read-only token) with no receipt and enforcement on, **when** `pr-check`
+  runs, **then** a `403` on post degrades to a notice, verdict is `missing-notice`, exit 0.
+- **Given** a same-repo PR with no receipt and `AIRECEIPTS_REQUIRE_PR_RECEIPT=true`, **when**
+  `pr-check` runs, **then** exit 1, `missing-required`.
 
 ## Non-goals
 
-- **Generating receipts in CI.** Generation stays local (I1/I4); the runner has no
-  transcripts and does no pricing work. `pr-check` is a presence checker, never a renderer.
-- **Replacing the reusable workflow or the SPEC-0057 composite action.** Three packagings
-  of one verdict coexist; the adopter picks (reusable workflow / composite action for a
-  GitHub-native `uses:` pin, npm CLI for a GitHub-repo-free pin). Reason: each fits a
-  different adopter constraint and they share `check-pr-receipt.mjs`.
-- **Changing the receipt marker or verdict semantics.** `DOGFOOD_MARKER` and the three
-  verdicts are unchanged; R2 only re-packages them. The marker-parity test stays the gate.
-- **SHA-pinning policy for adopters.** `@latest` is the documented default; adopters who
-  want a frozen ref pin a `v*` tag. This spec does not mandate one over the other.
+- **Generating receipts in CI.** No transcript on the runner (I1/I4); `pr-check` transports
+  the ref, never prices or renders from a transcript.
+- **Replacing the two-job reusable workflow.** It stays the hardened path for untrusted **fork**
+  PRs (token-less render). `pr-check` is the self-contained packaging for trusted (same-repo /
+  internal) PRs and local checks; both share SPEC-0066 fetch/sanitize/render code.
+- **Overloading `pr-render-ref`.** That command is the explicit token-less render entrypoint;
+  `pr-check` is a separate, additive command, not a `--post` flag on it.
+- **Removing `@resvg/resvg-js` from the install / agent-built enforcement / marker or schema
+  changes.** Out of scope (the latter two are SPEC-0066 / unchanged).
 
 ## Test matrix
 
 | Req | Case | Input | Expected |
 |---|---|---|---|
-| R1 | Caller templates pinned | all live caller snippets | reference `@latest`, not `@main` |
-| R1 | Release moves tag | `release-publish.yml` | a step force-moves `latest` to `${GITHUB_SHA}` |
-| R1 | Internal ref unchanged | `pr-receipt-check.yml` | self-checkout stays `ref: main` |
-| R2 | pr-check found | comments JSON with marker | stdout `found`, exit 0 |
-| R2 | pr-check missing-notice | comments JSON, no marker, no enforce | stdout `missing-notice`, exit 0 |
-| R2 | pr-check missing-required | no marker, `--require-same-repo`, same-repo | stdout `missing-required`, exit 1 |
-| R3 | Lean check path | `pr-check` invocation | no `@resvg/resvg-js` import on the code path |
-| R4 | npm-native caller | `npx aireceipts-cli@latest pr-check` | resolves with no `uses:` reference; same command runs locally |
+| R1 | Caller templates pinned | live caller snippets | `@latest`, not `@main` (shipped) |
+| R2 | context from env | Actions env only | base/head full names, PR #, head ref resolved |
+| R2 | flags override env | `--pr`/`--base-repo`/`--head-repo`/`--head-ref` | flags win |
+| R2 | fork head ≠ base | event payload with fork head repo | fetch targets head clone URL; verdict uses full names |
+| R2 | temp-repo fetch | no base checkout | temp `git init` + token URL fetch succeeds |
+| R2 | body parity | valid ref payload | posted body == `renderPrBody(sanitized)` byte-for-byte |
+| R3 | upsert create | no marker comment (paginated) | one marker comment POSTed |
+| R3 | upsert update | existing marker comment | that comment PATCHed; no duplicate |
+| R3 | 403/404 classify | fork read-only token / missing | notice, no throw, no comment |
+| R4 | found / notice / required / fork | ref present/absent × repo relation | exit 0/0/1/0 with matching verdict |
+| R5 | lazy path | `pr-check` invocation | `@resvg/resvg-js` not loaded at runtime |
+| R6 | caller templates | `pr-check-caller.yml` + reusable caller | both declare `pull-requests: write`; pr-check caller has no reusable `uses:` |
+| R7 | hidden command | `--help` output | `pr-check` absent (hidden, like `pr-render-ref`); help golden unchanged |
+| R7 | hostile payload / back-compat | injection corpus; existing tests | sanitized, no throw; comment-marker + two-job paths unchanged |
 
 ## Success criteria
 
-- [x] R1 landed: every live caller template pins `@latest`; `release-publish.yml` advances
-      the tag; a bootstrap `latest` tag exists at the current release.
-- [ ] R2–R4: `aireceipts pr-check` ships in `dist/`, verdict parity with
-      `check-pr-receipt.mjs` is asserted by a test, and the render path stays lazy.
-- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
-      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked
-      (`echo $?`).
+- [x] R1 landed: every live caller template pins `@latest`; `release-publish.yml` advances the
+      tag; a bootstrap `latest` tag exists at the current release.
+- [ ] R2–R6: `aireceipts pr-check` ships in `dist/` and, in a self-contained workflow (no
+      reusable `uses:`, no base checkout), fetches the ref, upserts the marked comment via
+      `GITHUB_TOKEN`, and returns the verdict; render path lazy; reusable-caller permission bug
+      fixed; trust model documented.
+- [ ] R7: telemetry enum + docs + parity; body-parity, upsert create/update + 403/404 (mocked),
+      verdict/exit-code, and hostile-payload tests pass; `verify-goldens` and existing
+      `pr-receipt-check` tests stay green.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked.
 
-**Shipped in v0.4.0:** R1 only (`@latest` pin + tag-move, #164). R2–R4 (the npm-native
-`aireceipts pr-check` command) are not built; the spec stays `status: building` until they
-land.
+**Shipped in v0.4.0:** R1 only (`@latest` pin + tag-move, #164). R2–R7 (the self-contained
+npm-native `pr-check` that fetches + renders + posts + verdicts) are the current build; the
+spec stays `status: building` until they land.

--- a/src/cli/commands/pr-check.ts
+++ b/src/cli/commands/pr-check.ts
@@ -1,0 +1,205 @@
+// SPEC-0064 R2-R7 — hidden npm-native PR receipt check. This command never
+// generates a receipt in CI; it self-fetches the branch's receipt ref, reuses
+// the existing sanitize/render path, and best-effort upserts the marked PR
+// comment with GITHUB_TOKEN.
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fetchAndRenderReceipt, type FetchRenderDeps, type FetchRenderOutcome } from "../../pr/postRef.js";
+import { fetchReceiptRef, readReceiptRef } from "../../pr/store.js";
+import { findMarkerComment, type HttpFetch, upsertMarkerComment } from "../../pr/commentApi.js";
+import type { CommandContext, CommandDef } from "../types.js";
+
+interface TempRepo {
+  cwd: string;
+  cleanup(): void;
+}
+
+export interface PrCheckDeps {
+  http?: HttpFetch;
+  fetchAndRender?: typeof fetchAndRenderReceipt;
+  fetchRef?: FetchRenderDeps["fetchRef"];
+  readRef?: FetchRenderDeps["readRef"];
+  findMarker?: typeof findMarkerComment;
+  upsertMarker?: typeof upsertMarkerComment;
+  makeTempRepo?: () => TempRepo;
+}
+
+interface EventContext {
+  pr?: string;
+  headRepo?: string;
+  headRef?: string;
+}
+
+interface ResolvedContext {
+  baseRepo: string;
+  pr: string;
+  headRepo: string;
+  headRef: string;
+  token: string;
+  requireSameRepo: boolean;
+  sameRepo: boolean;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+function prValue(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return String(value);
+  }
+  return stringValue(value);
+}
+
+function readEventContext(path: string | undefined): EventContext {
+  if (!path) {
+    return {};
+  }
+  try {
+    const root = objectRecord(JSON.parse(readFileSync(path, "utf8")));
+    const pull = objectRecord(root?.pull_request);
+    const head = objectRecord(pull?.head);
+    const repo = objectRecord(head?.repo);
+    return {
+      pr: prValue(pull?.number),
+      headRepo: stringValue(repo?.full_name),
+      headRef: stringValue(head?.ref),
+    };
+  } catch {
+    return {};
+  }
+}
+
+function resolveContext(ctx: CommandContext): { ok: true; value: ResolvedContext } | { ok: false; missing: string[] } {
+  const event = readEventContext(ctx.env.GITHUB_EVENT_PATH);
+  const baseRepo = ctx.options.prBaseRepo ?? ctx.env.GITHUB_REPOSITORY;
+  const pr = ctx.options.prNumber ?? event.pr;
+  const headRepo = ctx.options.prHeadRepo ?? event.headRepo;
+  const headRef = ctx.options.prHeadRef ?? ctx.env.GITHUB_HEAD_REF ?? event.headRef;
+  const token = ctx.env.GH_TOKEN ?? ctx.env.GITHUB_TOKEN;
+  const requireSameRepo = ctx.options.requireSameRepo || ctx.env.AIRECEIPTS_REQUIRE_PR_RECEIPT === "true";
+
+  const missing: string[] = [];
+  if (!baseRepo) missing.push("base repo (--base-repo or GITHUB_REPOSITORY)");
+  if (!pr) missing.push("PR number (--pr or pull_request.number)");
+  if (!headRepo) missing.push("head repo (--head-repo or pull_request.head.repo.full_name)");
+  if (!headRef) missing.push("head ref (--head-ref, GITHUB_HEAD_REF, or pull_request.head.ref)");
+  if (!token) missing.push("token (GH_TOKEN or GITHUB_TOKEN)");
+  if (!baseRepo || !pr || !headRepo || !headRef || !token) {
+    return { ok: false, missing };
+  }
+
+  return {
+    ok: true,
+    value: {
+      baseRepo,
+      pr,
+      headRepo,
+      headRef,
+      token,
+      requireSameRepo,
+      sameRepo: headRepo === baseRepo,
+    },
+  };
+}
+
+export function defaultTempRepo(): TempRepo {
+  const cwd = mkdtempSync(join(tmpdir(), "aireceipts-prcheck-"));
+  const init = spawnSync("git", ["init", "--quiet"], { cwd, encoding: "utf8" });
+  if (init.status !== 0) {
+    rmSync(cwd, { recursive: true, force: true });
+    const stderr = typeof init.stderr === "string" ? init.stderr.trim() : "";
+    throw new Error(stderr || "git init failed");
+  }
+  return {
+    cwd,
+    cleanup: () => {
+      rmSync(cwd, { recursive: true, force: true });
+    },
+  };
+}
+
+async function missingVerdict(ctx: CommandContext, resolved: ResolvedContext, deps: Required<Pick<PrCheckDeps, "findMarker">> & Pick<PrCheckDeps, "http">): Promise<number> {
+  const existing = await deps.findMarker(resolved.baseRepo, resolved.pr, resolved.token, deps.http);
+  if (existing) {
+    ctx.stdout.write("found\n");
+    return 0;
+  }
+
+  if (resolved.requireSameRepo && resolved.sameRepo) {
+    ctx.stdout.write("missing-required\n");
+    ctx.stderr.write("pr-check: receipt ref missing for this same-repo PR.\n");
+    ctx.stderr.write("Run `npx aireceipts-cli pr --store ref --push-ref` locally and push again.\n");
+    return 1;
+  }
+
+  ctx.stdout.write("missing-notice\n");
+  return 0;
+}
+
+export async function runPrCheck(ctx: CommandContext, deps: PrCheckDeps = {}): Promise<number> {
+  const resolved = resolveContext(ctx);
+  if (!resolved.ok) {
+    ctx.stderr.write(`pr-check: missing required context: ${resolved.missing.join(", ")}\n`);
+    return 1;
+  }
+
+  const http = deps.http;
+  const fetchAndRender = deps.fetchAndRender ?? fetchAndRenderReceipt;
+  const fetchRef = deps.fetchRef ?? fetchReceiptRef;
+  const readRef = deps.readRef ?? readReceiptRef;
+  const findMarker = deps.findMarker ?? findMarkerComment;
+  const upsertMarker = deps.upsertMarker ?? upsertMarkerComment;
+  const makeTempRepo = deps.makeTempRepo ?? defaultTempRepo;
+  const cloneUrl = `https://x-access-token:${resolved.value.token}@github.com/${resolved.value.headRepo}.git`;
+
+  let temp: TempRepo;
+  try {
+    temp = makeTempRepo();
+  } catch (error) {
+    ctx.stderr.write(`pr-check: could not initialize temp git repo: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+
+  let out: FetchRenderOutcome;
+  try {
+    out = fetchAndRender({ branch: resolved.value.headRef, remoteUrl: cloneUrl, cwd: temp.cwd }, { fetchRef, readRef });
+  } finally {
+    try {
+      temp.cleanup();
+    } catch {
+      // Best-effort cleanup; the verdict must not depend on tmpdir deletion.
+    }
+  }
+
+  if (out.code === 0 && out.body) {
+    const post = await upsertMarker({ baseRepo: resolved.value.baseRepo, pr: resolved.value.pr, token: resolved.value.token, body: out.body }, http);
+    ctx.stdout.write("found\n");
+    if (post.ok) {
+      ctx.stderr.write(`pr-check: receipt comment ${post.action}\n`);
+    } else if (post.readOnly) {
+      ctx.stderr.write(`pr-check: ${post.reason}; receipt ref was found, so the check remains green\n`);
+    } else {
+      ctx.stderr.write(`pr-check: could not post receipt comment: ${post.reason}\n`);
+    }
+    return 0;
+  }
+
+  if (out.code === 3) {
+    ctx.stderr.write(`pr-check: ${out.message}; treating as missing receipt\n`);
+  }
+  return missingVerdict(ctx, resolved.value, { findMarker, http });
+}
+
+export const command: CommandDef = {
+  name: "pr-check",
+  priority: 60,
+  matches: (options) => options.positional[0] === "pr-check",
+  run: (ctx) => runPrCheck(ctx),
+};

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -45,6 +45,16 @@ export interface CliOptions {
   readonly store?: "comment" | "ref";
   /** SPEC-0065 R2: `aireceipts pr --store ref --push-ref` also pushes the written ref to `origin`. */
   readonly pushRef: boolean;
+  /** SPEC-0064 R2: hidden `pr-check --base-repo owner/repo` override. */
+  readonly prBaseRepo?: string;
+  /** SPEC-0064 R2: hidden `pr-check --head-repo owner/repo` override. */
+  readonly prHeadRepo?: string;
+  /** SPEC-0064 R2: hidden `pr-check --head-ref branch` override. */
+  readonly prHeadRef?: string;
+  /** SPEC-0064 R2: hidden `pr-check --pr <number>` override. */
+  readonly prNumber?: string;
+  /** SPEC-0064 R4: hidden `pr-check --require-same-repo` enforcement flag. */
+  readonly requireSameRepo: boolean;
   /** SPEC-0056: `aireceipts backfill --limit N` caps the swept set to the N most recent matches. */
   readonly limit?: number;
   /** SPEC-0056: `aireceipts backfill --out <dir>` — distinct from `output` (SVG/PNG's `-o`/`--output`). */
@@ -97,6 +107,11 @@ export function parseOptions(argv: string[]): CliOptions {
   let share = false;
   let store: "comment" | "ref" | undefined;
   let pushRef = false;
+  let prBaseRepo: string | undefined;
+  let prHeadRepo: string | undefined;
+  let prHeadRef: string | undefined;
+  let prNumber: string | undefined;
+  let requireSameRepo = false;
   let limit: number | undefined;
   let outDir: string | undefined;
   let format: string | undefined;
@@ -162,6 +177,24 @@ export function parseOptions(argv: string[]): CliOptions {
       store = value;
     } else if (arg === "--push-ref") {
       pushRef = true;
+    } else if (arg === "--base-repo") {
+      prBaseRepo = argv[++i];
+    } else if (arg.startsWith("--base-repo=")) {
+      prBaseRepo = arg.slice("--base-repo=".length);
+    } else if (arg === "--head-repo") {
+      prHeadRepo = argv[++i];
+    } else if (arg.startsWith("--head-repo=")) {
+      prHeadRepo = arg.slice("--head-repo=".length);
+    } else if (arg === "--head-ref") {
+      prHeadRef = argv[++i];
+    } else if (arg.startsWith("--head-ref=")) {
+      prHeadRef = arg.slice("--head-ref=".length);
+    } else if (arg === "--pr") {
+      prNumber = argv[++i];
+    } else if (arg.startsWith("--pr=")) {
+      prNumber = arg.slice("--pr=".length);
+    } else if (arg === "--require-same-repo") {
+      requireSameRepo = true;
     } else if (arg === "--session") {
       prSession = argv[++i];
     } else if (arg.startsWith("--session=")) {
@@ -221,6 +254,11 @@ export function parseOptions(argv: string[]): CliOptions {
     share,
     store,
     pushRef,
+    prBaseRepo,
+    prHeadRepo,
+    prHeadRef,
+    prNumber,
+    requireSameRepo,
     limit,
     outDir,
     help,

--- a/src/pr/commentApi.ts
+++ b/src/pr/commentApi.ts
@@ -1,0 +1,160 @@
+// SPEC-0064 R3 — GitHub REST upsert for the npm-native `pr-check` command.
+// This is deliberately separate from `comment.ts`, which shells out to `gh`;
+// CI has only `GITHUB_TOKEN`, and tests inject this fetch-like seam.
+import { DOGFOOD_MARKER } from "./body.js";
+
+export interface HttpRequestInit {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+export interface HttpResponse {
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+export type HttpFetch = (url: string, init?: HttpRequestInit) => Promise<HttpResponse>;
+
+export const globalHttpFetch: HttpFetch = async (url, init) => {
+  const response = await fetch(url, init);
+  return {
+    status: response.status,
+    json: () => response.json() as Promise<unknown>,
+    text: () => response.text(),
+  };
+};
+
+export interface MarkerComment {
+  id: number;
+}
+
+export type UpsertMarkerOutcome =
+  | { ok: true; action: "created" | "updated" }
+  | { ok: false; reason: string; readOnly?: boolean };
+
+interface FindMarkerResult {
+  ok: boolean;
+  comment?: MarkerComment | null;
+  status?: number;
+  reason?: string;
+}
+
+const PER_PAGE = 100;
+
+function headers(token: string, withJson = false): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "aireceipts",
+    ...(withJson ? { "Content-Type": "application/json" } : {}),
+  };
+}
+
+function commentsUrl(baseRepo: string, pr: string | number, page: number): string {
+  return `https://api.github.com/repos/${baseRepo}/issues/${pr}/comments?per_page=${PER_PAGE}&page=${page}`;
+}
+
+function commentUrl(baseRepo: string, id: number): string {
+  return `https://api.github.com/repos/${baseRepo}/issues/comments/${id}`;
+}
+
+function createUrl(baseRepo: string, pr: string | number): string {
+  return `https://api.github.com/repos/${baseRepo}/issues/${pr}/comments`;
+}
+
+function markerFromPage(page: unknown[]): MarkerComment | null {
+  for (const item of page) {
+    if (item === null || typeof item !== "object") {
+      continue;
+    }
+    const comment = item as { id?: unknown; body?: unknown };
+    if (typeof comment.id === "number" && typeof comment.body === "string" && comment.body.startsWith(DOGFOOD_MARKER)) {
+      return { id: comment.id };
+    }
+  }
+  return null;
+}
+
+async function reasonFrom(response: HttpResponse, action: string): Promise<string> {
+  const detail = (await response.text()).trim();
+  return detail ? `${action}: GitHub API returned ${response.status}: ${detail}` : `${action}: GitHub API returned ${response.status}`;
+}
+
+function failure(status: number, reason: string): UpsertMarkerOutcome {
+  if (status === 403) {
+    return { ok: false, readOnly: true, reason: "read-only token (fork PR)" };
+  }
+  if (status === 404) {
+    return { ok: false, reason };
+  }
+  return { ok: false, reason };
+}
+
+async function findMarkerCommentResult(baseRepo: string, pr: string | number, token: string, http: HttpFetch): Promise<FindMarkerResult> {
+  for (let page = 1; ; page += 1) {
+    const response = await http(commentsUrl(baseRepo, pr, page), {
+      method: "GET",
+      headers: headers(token),
+    });
+    if (response.status !== 200) {
+      return { ok: false, status: response.status, reason: await reasonFrom(response, "list PR comments") };
+    }
+    const parsed = await response.json();
+    if (!Array.isArray(parsed)) {
+      return { ok: false, status: response.status, reason: "list PR comments: response was not an array" };
+    }
+    const marker = markerFromPage(parsed);
+    if (marker) {
+      return { ok: true, comment: marker };
+    }
+    if (parsed.length < PER_PAGE) {
+      return { ok: true, comment: null };
+    }
+  }
+}
+
+export async function findMarkerComment(
+  baseRepo: string,
+  pr: string | number,
+  token: string,
+  http: HttpFetch = globalHttpFetch,
+): Promise<MarkerComment | null> {
+  const result = await findMarkerCommentResult(baseRepo, pr, token, http);
+  return result.ok ? (result.comment ?? null) : null;
+}
+
+export async function upsertMarkerComment(
+  args: { baseRepo: string; pr: string | number; token: string; body: string },
+  http: HttpFetch = globalHttpFetch,
+): Promise<UpsertMarkerOutcome> {
+  const existing = await findMarkerCommentResult(args.baseRepo, args.pr, args.token, http);
+  if (!existing.ok) {
+    return failure(existing.status ?? 0, existing.reason ?? "could not list PR comments");
+  }
+
+  const payload = JSON.stringify({ body: args.body });
+  if (existing.comment) {
+    const response = await http(commentUrl(args.baseRepo, existing.comment.id), {
+      method: "PATCH",
+      headers: headers(args.token, true),
+      body: payload,
+    });
+    if (response.status === 200) {
+      return { ok: true, action: "updated" };
+    }
+    return failure(response.status, await reasonFrom(response, "update PR comment"));
+  }
+
+  const response = await http(createUrl(args.baseRepo, args.pr), {
+    method: "POST",
+    headers: headers(args.token, true),
+    body: payload,
+  });
+  if (response.status === 201) {
+    return { ok: true, action: "created" };
+  }
+  return failure(response.status, await reasonFrom(response, "create PR comment"));
+}

--- a/test/cli/pr-check.test.ts
+++ b/test/cli/pr-check.test.ts
@@ -1,0 +1,326 @@
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { parseOptions } from "../../src/cli/options.js";
+import type { CommandContext } from "../../src/cli/types.js";
+import { command, defaultTempRepo, runPrCheck, type PrCheckDeps } from "../../src/cli/commands/pr-check.js";
+import { DOGFOOD_MARKER, renderPrBody } from "../../src/pr/body.js";
+import { fetchAndRenderReceipt, renderReceiptPayload, type FetchRenderArgs, type FetchRenderOutcome } from "../../src/pr/postRef.js";
+import { PR_RECEIPT_SCHEMA_VERSION, type PrReceiptPayload } from "../../src/pr/payloadTypes.js";
+import { sanitizePrReceiptPayload } from "../../src/pr/sanitize.js";
+import { serializePrReceipt } from "../../src/pr/payload.js";
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function stdinStub(): NodeJS.ReadStream {
+  const stream = Readable.from([]) as unknown as NodeJS.ReadStream;
+  (stream as unknown as { isTTY: boolean }).isTTY = false;
+  return stream;
+}
+
+function fakeContext(argv: string[], env: NodeJS.ProcessEnv): { ctx: CommandContext; out: () => string; err: () => string } {
+  let out = "";
+  let err = "";
+  const stdout = { write: (s: string) => ((out += s), true) } as unknown as NodeJS.WriteStream;
+  const stderr = { write: (s: string) => ((err += s), true) } as unknown as NodeJS.WriteStream;
+  const ctx = {
+    options: parseOptions(argv),
+    stdin: stdinStub(),
+    stdout,
+    stderr,
+    env,
+    cwd: () => process.cwd(),
+    now: () => 0,
+    fs: { writeFile: async () => {} },
+    prompt: async () => false,
+    telemetry: {
+      showPayload: () => ({ enabled: false, events: [] }),
+      noteReceiptGenerated: async () => {},
+      recordExportGenerated: () => {},
+      recordPrFlowCompleted: () => {},
+      recordHookConfigured: () => {},
+      recordIntegrationSurfaceRendered: () => {},
+      noteMilestone: async () => {},
+    },
+    renderHelp: () => "",
+  } as unknown as CommandContext;
+  return { ctx, out: () => out, err: () => err };
+}
+
+function eventFile(headRepo: string, headRef: string, pr = 12): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "aireceipts-prcheck-test-"));
+  const file = path.join(dir, "event.json");
+  writeFileSync(file, JSON.stringify({ pull_request: { number: pr, head: { repo: { full_name: headRepo }, ref: headRef } } }), "utf8");
+  return file;
+}
+
+function tempRepoDeps(): { makeTempRepo: NonNullable<PrCheckDeps["makeTempRepo"]>; cleaned: () => boolean } {
+  let cleaned = false;
+  return {
+    makeTempRepo: () => ({
+      cwd: "/tmp/aireceipts-prcheck-fake",
+      cleanup: () => {
+        cleaned = true;
+      },
+    }),
+    cleaned: () => cleaned,
+  };
+}
+
+function foundBody(body = `${DOGFOOD_MARKER}\nbody`): FetchRenderOutcome {
+  return { code: 0, body, message: "rendered" };
+}
+
+describe("SPEC-0064 pr-check", () => {
+  it("matches the hidden `pr-check` positional only", () => {
+    expect(command.matches(parseOptions(["pr-check"]))).toBe(true);
+    expect(command.matches(parseOptions(["pr-render-ref"]))).toBe(false);
+  });
+
+  it("resolves Actions env context and fetches from the fork head repo", async () => {
+    let capturedFetch: FetchRenderArgs | undefined;
+    let capturedPost: { baseRepo: string; pr: string | number; token: string; body: string } | undefined;
+    const temp = tempRepoDeps();
+    const { ctx, out } = fakeContext(["pr-check"], {
+      GITHUB_REPOSITORY: "base/repo",
+      GITHUB_EVENT_PATH: eventFile("fork/repo", "feature/ref", 17),
+      GITHUB_TOKEN: "tok",
+    });
+
+    const exit = await runPrCheck(ctx, {
+      makeTempRepo: temp.makeTempRepo,
+      fetchAndRender: (args) => {
+        capturedFetch = args;
+        return foundBody();
+      },
+      upsertMarker: async (args) => {
+        capturedPost = args;
+        return { ok: true, action: "created" };
+      },
+      findMarker: async () => null,
+    });
+
+    expect(exit).toBe(0);
+    expect(out()).toBe("found\n");
+    expect(capturedFetch).toEqual({
+      branch: "feature/ref",
+      remoteUrl: "https://x-access-token:tok@github.com/fork/repo.git",
+      cwd: "/tmp/aireceipts-prcheck-fake",
+    });
+    expect(capturedPost).toMatchObject({ baseRepo: "base/repo", pr: "17", token: "tok" });
+    expect(temp.cleaned()).toBe(true);
+  });
+
+  it("lets flags override event/env context", async () => {
+    let capturedFetch: FetchRenderArgs | undefined;
+    let capturedPost: { baseRepo: string; pr: string | number; token: string; body: string } | undefined;
+    const { ctx } = fakeContext(["pr-check", "--pr=9", "--base-repo=flag/base", "--head-repo", "flag/head", "--head-ref", "flag-branch"], {
+      GITHUB_REPOSITORY: "env/base",
+      GITHUB_EVENT_PATH: eventFile("env/head", "env-branch", 2),
+      GH_TOKEN: "gh-token",
+      GITHUB_TOKEN: "github-token",
+    });
+
+    await runPrCheck(ctx, {
+      makeTempRepo: tempRepoDeps().makeTempRepo,
+      fetchAndRender: (args) => {
+        capturedFetch = args;
+        return foundBody();
+      },
+      upsertMarker: async (args) => {
+        capturedPost = args;
+        return { ok: true, action: "updated" };
+      },
+      findMarker: async () => null,
+    });
+
+    expect(capturedFetch?.branch).toBe("flag-branch");
+    expect(capturedFetch?.remoteUrl).toBe("https://x-access-token:gh-token@github.com/flag/head.git");
+    expect(capturedPost).toMatchObject({ baseRepo: "flag/base", pr: "9", token: "gh-token" });
+  });
+
+  it("returns missing-notice when no ref or prior marker exists", async () => {
+    const { ctx, out } = fakeContext(["pr-check"], {
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_EVENT_PATH: eventFile("owner/repo", "branch"),
+      GITHUB_TOKEN: "tok",
+    });
+
+    const exit = await runPrCheck(ctx, {
+      makeTempRepo: tempRepoDeps().makeTempRepo,
+      fetchAndRender: () => ({ code: 2, message: "no ref" }),
+      findMarker: async () => null,
+    });
+
+    expect(exit).toBe(0);
+    expect(out()).toBe("missing-notice\n");
+  });
+
+  it("returns missing-required for enforced same-repo PRs", async () => {
+    const { ctx, out, err } = fakeContext(["pr-check", "--require-same-repo"], {
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_EVENT_PATH: eventFile("owner/repo", "branch"),
+      GITHUB_TOKEN: "tok",
+    });
+
+    const exit = await runPrCheck(ctx, {
+      makeTempRepo: tempRepoDeps().makeTempRepo,
+      fetchAndRender: () => ({ code: 2, message: "no ref" }),
+      findMarker: async () => null,
+    });
+
+    expect(exit).toBe(1);
+    expect(out()).toBe("missing-required\n");
+    expect(err()).toContain("pr --store ref --push-ref");
+  });
+
+  it("keeps a found fork receipt green when posting gets a read-only token", async () => {
+    const { ctx, out, err } = fakeContext(["pr-check"], {
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_EVENT_PATH: eventFile("fork/repo", "branch"),
+      GITHUB_TOKEN: "tok",
+    });
+
+    const exit = await runPrCheck(ctx, {
+      makeTempRepo: tempRepoDeps().makeTempRepo,
+      fetchAndRender: () => foundBody(),
+      upsertMarker: async () => ({ ok: false, readOnly: true, reason: "read-only token (fork PR)" }),
+      findMarker: async () => null,
+    });
+
+    expect(exit).toBe(0);
+    expect(out()).toBe("found\n");
+    expect(err()).toContain("read-only token");
+  });
+
+  it("passes the same sanitized body as fetchAndRenderReceipt/renderPrBody", async () => {
+    let postedBody = "";
+    const payload: PrReceiptPayload = {
+      schemaVersion: PR_RECEIPT_SCHEMA_VERSION,
+      bodyInput: { contributors: [], excludedCount: 0 },
+      extras: {
+        details: [{ label: "[x](javascript:alert(1))", row: [], text: "```hostile```" }],
+        artifactLink: { fileName: "p.html", url: "javascript:alert(1)" },
+      },
+    };
+    const json = serializePrReceipt(payload);
+    const rendered = renderReceiptPayload(json);
+    if (!rendered.ok) {
+      throw new Error(rendered.reason);
+    }
+    const sanitized = sanitizePrReceiptPayload(payload);
+    const expected = renderPrBody(sanitized.bodyInput, sanitized.extras);
+    const { ctx } = fakeContext(["pr-check"], {
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_EVENT_PATH: eventFile("owner/repo", "branch"),
+      GITHUB_TOKEN: "tok",
+    });
+
+    const exit = await runPrCheck(ctx, {
+      makeTempRepo: tempRepoDeps().makeTempRepo,
+      fetchAndRender: (args) => fetchAndRenderReceipt(args, { fetchRef: () => true, readRef: () => json }),
+      upsertMarker: async (args) => {
+        postedBody = args.body;
+        return { ok: true, action: "created" };
+      },
+      findMarker: async () => null,
+    });
+
+    expect(exit).toBe(0);
+    expect(postedBody).toBe(rendered.body);
+    expect(postedBody).toBe(expected);
+    expect(postedBody).not.toMatch(/\]\(\s*javascript:/i);
+  });
+
+  it("does not pull the PNG rasterizer into the pr-check module path", () => {
+    const source = readFileSync(path.join(ROOT, "src/cli/commands/pr-check.ts"), "utf8");
+    const renderSource = readFileSync(path.join(ROOT, "src/pr/postRef.ts"), "utf8");
+    expect(source).not.toContain("@resvg/resvg-js");
+    expect(source).not.toContain("../../receipt/png");
+    expect(renderSource).not.toContain("@resvg/resvg-js");
+  });
+
+  it("defaultTempRepo initializes a real git repo and cleanup removes it", () => {
+    const temp = defaultTempRepo();
+    try {
+      expect(statSync(temp.cwd).isDirectory()).toBe(true);
+      expect(existsSync(path.join(temp.cwd, ".git"))).toBe(true);
+    } finally {
+      temp.cleanup();
+    }
+    expect(existsSync(temp.cwd)).toBe(false);
+  });
+
+  it("runs the real temp repo end-to-end (git init + injected fetch) and posts (R2 matrix)", async () => {
+    const payload: PrReceiptPayload = {
+      schemaVersion: PR_RECEIPT_SCHEMA_VERSION,
+      bodyInput: { contributors: [], excludedCount: 0 },
+      extras: { details: [] },
+    };
+    const json = serializePrReceipt(payload);
+    const rendered = renderReceiptPayload(json);
+    if (!rendered.ok) {
+      throw new Error(rendered.reason);
+    }
+    let postedBody = "";
+    const { ctx, out } = fakeContext(["pr-check"], {
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_EVENT_PATH: eventFile("owner/repo", "branch"),
+      GITHUB_TOKEN: "tok",
+    });
+
+    // No makeTempRepo / fetchAndRender injected → the real defaultTempRepo (`git init`) and
+    // the real fetchAndRenderReceipt run; only the ref fetch/read and REST post are stubbed.
+    const exit = await runPrCheck(ctx, {
+      fetchRef: () => true,
+      readRef: () => json,
+      upsertMarker: async (args) => {
+        postedBody = args.body;
+        return { ok: true, action: "created" };
+      },
+      findMarker: async () => null,
+    });
+
+    expect(exit).toBe(0);
+    expect(out()).toBe("found\n");
+    expect(postedBody).toBe(rendered.body);
+  });
+
+  it("returns exit 1 when the temp repo cannot be created", async () => {
+    const { ctx, err } = fakeContext(["pr-check"], {
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_EVENT_PATH: eventFile("owner/repo", "branch"),
+      GITHUB_TOKEN: "tok",
+    });
+
+    const exit = await runPrCheck(ctx, {
+      makeTempRepo: () => {
+        throw new Error("git init failed");
+      },
+      fetchAndRender: () => foundBody(),
+    });
+
+    expect(exit).toBe(1);
+    expect(err()).toContain("could not initialize temp git repo");
+  });
+
+  it("treats an existing marker comment without a ref as found", async () => {
+    const { ctx, out } = fakeContext(["pr-check"], {
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_EVENT_PATH: eventFile("owner/repo", "branch"),
+      GITHUB_TOKEN: "tok",
+    });
+
+    const exit = await runPrCheck(ctx, {
+      makeTempRepo: tempRepoDeps().makeTempRepo,
+      fetchAndRender: () => ({ code: 2, message: "no ref" }),
+      findMarker: async () => ({ id: 55 }),
+    });
+
+    expect(exit).toBe(0);
+    expect(out()).toBe("found\n");
+  });
+});

--- a/test/pr/commentApi.test.ts
+++ b/test/pr/commentApi.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { DOGFOOD_MARKER } from "../../src/pr/body.js";
+import { findMarkerComment, type HttpFetch, type HttpRequestInit, type HttpResponse, upsertMarkerComment } from "../../src/pr/commentApi.js";
+
+interface HttpCall {
+  url: string;
+  init?: HttpRequestInit;
+}
+
+function response(status: number, jsonValue: unknown, textValue = ""): HttpResponse {
+  return {
+    status,
+    json: async () => jsonValue,
+    text: async () => textValue,
+  };
+}
+
+function mockHttp(responses: HttpResponse[]): { http: HttpFetch; calls: HttpCall[] } {
+  const calls: HttpCall[] = [];
+  const http: HttpFetch = async (url, init) => {
+    calls.push({ url, init });
+    const next = responses.shift();
+    if (!next) {
+      throw new Error(`unexpected request: ${url}`);
+    }
+    return next;
+  };
+  return { http, calls };
+}
+
+describe("SPEC-0064 commentApi", () => {
+  it("creates a marker comment when none exists", async () => {
+    const { http, calls } = mockHttp([response(200, []), response(201, { id: 7 })]);
+    const out = await upsertMarkerComment({ baseRepo: "owner/repo", pr: "12", token: "tok", body: `${DOGFOOD_MARKER}\nbody` }, http);
+
+    expect(out).toEqual({ ok: true, action: "created" });
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toBe("https://api.github.com/repos/owner/repo/issues/12/comments?per_page=100&page=1");
+    expect(calls[1].url).toBe("https://api.github.com/repos/owner/repo/issues/12/comments");
+    expect(calls[1].init?.method).toBe("POST");
+    expect(calls[1].init?.body).toBe(JSON.stringify({ body: `${DOGFOOD_MARKER}\nbody` }));
+  });
+
+  it("paginates to find and update the existing marker comment", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, id) => ({ id, body: "not a receipt" }));
+    const { http, calls } = mockHttp([response(200, firstPage), response(200, [{ id: 42, body: `${DOGFOOD_MARKER}\nold` }]), response(200, { id: 42 })]);
+
+    const out = await upsertMarkerComment({ baseRepo: "owner/repo", pr: 3, token: "tok", body: `${DOGFOOD_MARKER}\nnew` }, http);
+
+    expect(out).toEqual({ ok: true, action: "updated" });
+    expect(calls.map((call) => call.url)).toEqual([
+      "https://api.github.com/repos/owner/repo/issues/3/comments?per_page=100&page=1",
+      "https://api.github.com/repos/owner/repo/issues/3/comments?per_page=100&page=2",
+      "https://api.github.com/repos/owner/repo/issues/comments/42",
+    ]);
+    expect(calls[2].init?.method).toBe("PATCH");
+  });
+
+  it("classifies a 403 as a read-only fork token", async () => {
+    const { http } = mockHttp([response(200, []), response(403, {}, "forbidden")]);
+
+    const out = await upsertMarkerComment({ baseRepo: "owner/repo", pr: 3, token: "tok", body: `${DOGFOOD_MARKER}\nbody` }, http);
+
+    expect(out).toEqual({ ok: false, readOnly: true, reason: "read-only token (fork PR)" });
+  });
+
+  it("classifies a 404 without throwing", async () => {
+    const { http } = mockHttp([response(404, {}, "not found")]);
+
+    const out = await upsertMarkerComment({ baseRepo: "owner/repo", pr: 3, token: "tok", body: `${DOGFOOD_MARKER}\nbody` }, http);
+
+    expect(out.ok).toBe(false);
+    expect(out).not.toHaveProperty("readOnly");
+    if (!out.ok) {
+      expect(out.reason).toContain("404");
+    }
+  });
+
+  it("findMarkerComment follows pages and returns the first marked id", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, id) => ({ id, body: "not a receipt" }));
+    const { http, calls } = mockHttp([response(200, firstPage), response(200, [{ id: 99, body: `${DOGFOOD_MARKER}\nold` }])]);
+
+    await expect(findMarkerComment("owner/repo", 4, "tok", http)).resolves.toEqual({ id: 99 });
+    expect(calls).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## SPEC-0064 R2–R7 — self-contained npm-native `pr-check`

Lets an adopter's own workflow post the PR receipt in **one job with no reusable-workflow
`uses:`** — removing the public-reusable-workflow org-policy gate, the personal-repo
dependency, and the self-hosted-runner constraint that blocked seamless org/internal adoption.

### Whole adopter footprint
```yaml
name: aireceipts
on: [pull_request]
permissions: { contents: read, pull-requests: write }
jobs:
  check:
    runs-on: ubuntu-latest
    steps:
      - run: npx -y aireceipts-cli@latest pr-check
        env: { GH_TOKEN: ${{ github.token }} }
```
No `uses:`, no org Actions-policy toggle, no local `gh`.

### What `pr-check` does
- Hidden command (like `pr-render-ref`). Resolves PR context from Actions env
  (`GITHUB_REPOSITORY`, `GITHUB_EVENT_PATH`, `GITHUB_HEAD_REF`) with flag overrides,
  self-inits a temp git repo, fetches `refs/receipts/<slug>` from the head repo via a
  token-authenticated URL (no base checkout), reuses the SPEC-0066 sanitize/render path, and
  upserts the marked comment via `GITHUB_TOKEN`.
- Verdict/exit: `found` / `missing-notice` → 0; `missing-required` → 1 on a same-repo PR when
  enforcement is on; **fork PRs never fail** (read-only token).
- `src/pr/commentApi.ts`: injected, paginated REST upsert (create/PATCH the single marker
  comment; `403`→read-only/fork, `404` handled) — no local `gh`.
- **Fixes a real bug:** `docs/adopt/pr-receipt-check-caller.yml` gains `pull-requests: write`
  (the reusable post job needs it; without it an adopter's post silently couldn't comment).

### Trust model (honest)
The single-job path renders the untrusted, fork-author-controlled payload in the same job that
holds the write token — the sanitizer is Markdown-safety, **not** token isolation. So `pr-check`
is for **trusted same-repo/internal** PRs; the two-job reusable workflow (SPEC-0066), which
renders token-lessly, stays the defense-in-depth path for **untrusted fork** PRs.

### Gates & review
- **Preflight 11/11** (tarball install+run e2e, determinism ×10, full vitest — 1650 tests,
  goldens, cite-check, spec-lint, hygiene, tsc, eslint).
- Codex design-reviewed the spec (7 findings folded in: temp-repo self-fetch, injected
  paginated REST upsert, honest trust model, hidden/telemetry-silent). Independent code review
  found no defects (security/token-leak, prod wiring, verdict matrix, REST, spec all clean);
  its one item — the spec-mandated real-`git init` temp-repo test — is added.
- SPEC-0064 stays `building` (R1 shipped v0.4.0; R2–R7 here).

### Timing
`pr-check` ships to `@latest` adopters **after the next npm release**. For an immediate internal
dogfood before that release, pin the caller to this branch/a pre-release or merge + cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
