### PR TITLE
chore: release v0.5.0 — pr-check, richer statusline, samosa opt-in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.4.0):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.5.0):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,
@@ -97,18 +97,20 @@ after each release — don't hand-edit it elsewhere.*
   producer writing `refs/receipts/<slug>`, a pre-push auto-attach hook, and CI rendering +
   posting the receipt from the ref via `GITHUB_TOKEN` behind a hardened trust-boundary
   sanitizer with opt-in **same-repo** enforcement (SPEC-0065/0066 — the capability ships in
-  v0.4.0; both specs stay `building` for their final slices, listed below), the adopter pin
-  moved to `@latest` (SPEC-0064 R1); and a faster parse/preflight path — in-process
-  sqlite, goldens compile cache, parallel preflight (SPEC-0063). 36 specs at
-  `status: shipped`.
+  v0.4.0; both specs stay `building` for their final slices, listed below); a **self-contained
+  npm-native `pr-check`** an adopter runs in its own workflow with no reusable-workflow `uses:`
+  and no org Actions-policy gate (SPEC-0064, shipped v0.5.0, #176); a **richer default
+  statusline** — burn rate, context %, `M`/`B` tokens, inline 5h reset countdown (SPEC-0071);
+  the **samosa tip link off by default** on PR-posted surfaces, behind `--samosa` (SPEC-0070);
+  and a faster parse/preflight path — in-process sqlite, goldens compile cache, parallel
+  preflight (SPEC-0063) — plus **incremental mutation testing** on the money paths (SPEC-0069).
+  40 specs at `status: shipped`.
 - **In progress (`building`):** SPEC-0044 cost-attribution confidence — its
   implemented slices ship in v0.2.0 (ConfidenceEvent contract + no-silent-drop,
   cost matrix, rows-sum-to-total, cache-write caveat, parse-skip/load-failure
   drops, subagent double-count fix, mutation-gated PR path); the spec stays
   `building` until its `--self-check` kill-criterion and cost-model docs land.
-  SPEC-0064 (PR-check distribution) — R1 (`@latest` pin + release tag-move) shipped in
-  v0.4.0; R2–R4 (the npm-native `aireceipts pr-check` command) remain, so it stays
-  `building`. SPEC-0065 (seamless producer + hook) — R1–R3/R6 (`store=ref` producer,
+  SPEC-0065 (seamless producer + hook) — R1–R3/R6 (`store=ref` producer,
   pre-push auto-attach hook, determinism) shipped in v0.4.0; R5 (local `--list`/`week`/
   `stats` reads of `refs/receipts` + prune) is not wired, so it stays `building`.
   SPEC-0066 (CI posts from the ref) — R1–R4/R6 (fetch, validate, sanitize, render, post via

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.5.0 — 2026-07-08
+
+Minor: PR receipts gain a **self-contained CI path** (no external reusable workflow), the
+default **statusline** gets richer, and the **samosa tip link** leaves the default PR-posted
+surfaces (now opt-in). Two deliberate output changes — statusline default and the PR-posted
+footer — both called out below.
+
+### Added
+
+- **Self-contained `pr-check`** (SPEC-0064 R2–R7): an adopter's own workflow can run
+  `npx -y aireceipts-cli@latest pr-check` in a single job — **no reusable-workflow `uses:`**,
+  no org Actions-policy gate — to fetch the branch's receipt ref, render + sanitize it, and
+  upsert the marked PR comment via `GITHUB_TOKEN` (no local `gh`). Hidden command; for trusted
+  same-repo/internal PRs (the two-job reusable workflow stays the hardened path for untrusted
+  fork PRs). Also fixes the reusable-caller template, which was missing `pull-requests: write`.
+
+### Changed (deliberate output changes)
+
+- **Richer default statusline** (SPEC-0071): the default line now carries a burn rate (`$/hr`),
+  context-window %, abbreviated `M`/`B` token counts, and an inline 5h reset countdown — e.g.
+  `[aireceipts] $423 · $80/hr · 501M · ctx 42% · 5h 26% ↺2h13m`. Every segment renders from a
+  real payload field or a priced ledger value; nothing is estimated.
+- **Samosa tip link off by default** (SPEC-0070): the `buy me a samosa` link no longer appears
+  on the surfaces aireceipts posts onto a PR (the comment's `<details>` and the artifact
+  footer). Opt back in with `--samosa`; the standalone tip page and the docs-site footer are
+  unchanged.
+
+### Internal / CI
+
+- **Incremental mutation testing** (SPEC-0069): Stryker runs incrementally on PRs that touch
+  the money paths (`src/pricing/**`, `src/pr/**`), with a nightly full sweep — the same
+  anti-gaming moat at a fraction of the wall-clock. No product code change.
+
 ## v0.4.0 — 2026-07-07
 
 Minor: PR receipts can now **attach and post themselves**. A receipt travels with the

--- a/docs/releases/0.5.0-verdict.md
+++ b/docs/releases/0.5.0-verdict.md
@@ -1,0 +1,70 @@
+# Release verdict — v0.5.0
+
+- **Candidate version:** 0.5.0
+- **Frozen content SHA:** `e2c7e76` (HEAD of `main` at freeze; main is under concurrent
+  development, so the release is pinned to this SHA, not "latest main").
+- **Changelog range:** `v0.4.0..e2c7e76` — four merged PRs.
+- **Bump rationale:** MINOR — new capability + two deliberate, additive output changes; no
+  format break (goldens updated deliberately for the `--samosa` help text + PR-artifact footer).
+- **Date:** 2026-07-08 (UTC)
+
+## Scope (what ships)
+
+- **SPEC-0064 R2–R7** — self-contained npm-native `pr-check` (#176, mine).
+- **SPEC-0071** — richer default statusline: burn rate, context %, `M`/`B` tokens, 5h reset
+  countdown (#175).
+- **SPEC-0070** — samosa tip link off by default on PR-posted surfaces, opt-in `--samosa` (#177).
+- **SPEC-0069** — incremental mutation testing on the money paths + nightly full sweep (#174).
+
+All four specs flip `→ shipped` (40 shipped). #175/#177/#174 are other contributors' work;
+described factually and verified against code (docs panel below).
+
+## Release-commit note (read before dispatch)
+
+The release commit adds the version bump, `docs/CHANGELOG.md` v0.5.0 section, the four spec
+`status: shipped` flips, the `AGENTS.md` inventory refresh, **and one small code fix** the docs
+panel required: a `B` (billion) branch in `formatShortTokens` (`src/receipt/format.ts`) + a
+billion-scale test, so the changelog/AGENTS/SPEC-0071 "M/B tokens" claim is actually true (the
+code previously did only `k`/`M`). `release-publish.yml` re-runs the full preflight on the exact
+tagged SHA.
+
+## Mechanical checks (on the release edits)
+
+- `node scripts/preflight-release.mjs` → **11/11 RELEASE-READY** — publish-shape manifest,
+  `dist/cli.js` build, lean tarball, spec-lint, hygiene, verify-goldens, `tsc`, cite-check,
+  `eslint`, determinism ×10, full `vitest` incl. tarball install+run e2e.
+- `grep -rl '^status: shipped' specs/ | wc -l` → **40**, matches `AGENTS.md`.
+- No `SPEC-0069` id collision (0069=mutation, 0070=samosa, 0071=statusline; each `id:` matches
+  its filename).
+
+## Docs panel (`/review-docs`, blocking) — GO after one fix
+
+Independent honesty review of the v0.5.0 changelog + AGENTS.md against code (three of four
+features are other contributors' work). Result: **DOCS-NO-GO on first pass, one finding**, now
+fixed:
+
+- **Over-claim: "M/B tokens".** `formatShortTokens` implemented only `k`/`M` — a billion-scale
+  count rendered `"1000M"`, never `"1.5B"` — yet the changelog, AGENTS.md, and SPEC-0071's own
+  title/R1 claimed `M/B`. **Fixed** by implementing the `B` branch + a billion-scale test, so
+  the shipped claim is true and SPEC-0071 R1 is actually met.
+
+All other claims **PASS** against code: `pr-check` (hidden, no `uses:`, token upsert), the
+reusable-caller `pull-requests: write` fix, statusline rich shape is the *default* (not opt-in)
+with nothing estimated, samosa off-by-default on PR surfaces with the tip page + docs footer
+untouched, incremental mutation testing with no product-code change, and the spec-status /
+40-count / no-collision consistency.
+
+## Open risks / follow-ups (non-blocking)
+
+1. **PR-receipt attribution fragility** (found this session, user-approved fast-follow): the
+   committing session can show "no branch commit" (transcript-SHA anchoring breaks on
+   `--amend`, `-F`/`-c` commits, backgrounded commit output; the SHA-less-codex-helper vs
+   committing-session asymmetry). Own spec + PR; does NOT block 0.5.0.
+2. #170 (CSV formula-injection), #161 (subagents/ under-count) — carried, pre-existing.
+
+## Verdict
+
+Mechanical gates green on the release edits; the blocking docs panel is GO after the single
+M/B fix; all other claims verified against code. Content frozen at `e2c7e76`.
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",

--- a/specs/SPEC-0064-check-distribution.md
+++ b/specs/SPEC-0064-check-distribution.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0064
 title: PR-receipt check — release-pinned distribution and a self-contained npm-native pr-check
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0019, SPEC-0030, SPEC-0057, SPEC-0066]
 ---
@@ -149,16 +149,15 @@ on the developer's machine (I1/I4). `pr-check` only *transports* what the local 
 
 - [x] R1 landed: every live caller template pins `@latest`; `release-publish.yml` advances the
       tag; a bootstrap `latest` tag exists at the current release.
-- [ ] R2–R6: `aireceipts pr-check` ships in `dist/` and, in a self-contained workflow (no
+- [x] R2–R6: `aireceipts pr-check` ships in `dist/` and, in a self-contained workflow (no
       reusable `uses:`, no base checkout), fetches the ref, upserts the marked comment via
       `GITHUB_TOKEN`, and returns the verdict; render path lazy; reusable-caller permission bug
       fixed; trust model documented.
-- [ ] R7: telemetry enum + docs + parity; body-parity, upsert create/update + 403/404 (mocked),
+- [x] R7: telemetry enum + docs + parity; body-parity, upsert create/update + 403/404 (mocked),
       verdict/exit-code, and hostile-payload tests pass; `verify-goldens` and existing
       `pr-receipt-check` tests stay green.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked.
 
-**Shipped in v0.4.0:** R1 only (`@latest` pin + tag-move, #164). R2–R7 (the self-contained
-npm-native `pr-check` that fetches + renders + posts + verdicts) are the current build; the
-spec stays `status: building` until they land.
+**Shipped:** R1 in v0.4.0 (`@latest` pin + tag-move, #164); R2–R7 in v0.5.0 (the self-contained
+npm-native `pr-check` that fetches + renders + posts + verdicts, #176). Spec fully `shipped`.

--- a/specs/SPEC-0069-mutation-incremental.md
+++ b/specs/SPEC-0069-mutation-incremental.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0069
 title: "Mutation testing — incremental PR runs, nightly full sweep"
-status: building # PR open; shipped flips on merge
+status: shipped
 milestone: M5
 depends: [SPEC-0044]
 ---
@@ -102,10 +102,10 @@ proof, on the money paths.
 
 ## Success criteria
 
-- [ ] `stryker.config.json` valid; a scoped local run passes ≥ `break` (attribution.ts
+- [x] `stryker.config.json` valid; a scoped local run passes ≥ `break` (attribution.ts
       81.60% confirmed) and incremental reuse demonstrably reuses prior results.
-- [ ] `.github/workflows/mutation.yml` has a PR incremental job + a nightly full-sweep
+- [x] `.github/workflows/mutation.yml` has a PR incremental job + a nightly full-sweep
       job, cache restore/save wired, actions SHA-pinned, `actionlint`/`zizmor` clean.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs`,
       `node scripts/hygiene.mjs` all pass unmasked (`echo $?`) — no product code changed.

--- a/specs/SPEC-0070-samosa-flag-off-by-default.md
+++ b/specs/SPEC-0070-samosa-flag-off-by-default.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0070
 title: "Samosa tip link behind an opt-in flag, off by default on PR-posted surfaces"
-status: draft
+status: shipped
 milestone: M5
 depends: [SPEC-0034, SPEC-0066]
 ---
@@ -102,12 +102,12 @@ occurrences, so the criterion is satisfied and locally verifiable.
 
 ## Success criteria
 
-- [ ] `--samosa` is off by default; the comment and artifact carry no tip link unless it is set.
-- [ ] With `--samosa`, both surfaces render the exact SPEC-0034 link/glyph as before.
-- [ ] The default artifact page has zero external references; its golden is regenerated.
-- [ ] The `samosa` flag round-trips through `store=ref` / `postRef` (strict schema accepts it;
+- [x] `--samosa` is off by default; the comment and artifact carry no tip link unless it is set.
+- [x] With `--samosa`, both surfaces render the exact SPEC-0034 link/glyph as before.
+- [x] The default artifact page has zero external references; its golden is regenerated.
+- [x] The `samosa` flag round-trips through `store=ref` / `postRef` (strict schema accepts it;
       omitting it deserializes as off).
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/spec-lint.mjs` all pass unmasked (`echo $?`).
 
 ## Validation

--- a/specs/SPEC-0071-statusline-rich-default.md
+++ b/specs/SPEC-0071-statusline-rich-default.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0071
 title: "Statusline rich default — burn rate, context %, quota reset countdown, M/B tokens"
-status: draft
+status: shipped
 milestone: M5
 depends: [SPEC-0062]
 ---
@@ -115,13 +115,13 @@ a priced ledger value (i.e. would require estimating) is cut, not faked.
 
 ## Success criteria
 
-- [ ] The rich default renders as specified on a full-payload fixture; each new segment omits
+- [x] The rich default renders as specified on a full-payload fixture; each new segment omits
       cleanly on absent/out-of-range data (no fabricated `$/hr`, `%`, or countdown).
-- [ ] Reset countdown derives from real `resets_at` (epoch seconds), with the past/absent
+- [x] Reset countdown derives from real `resets_at` (epoch seconds), with the past/absent
       fallback; `tokens` uses `formatShortTokens`.
-- [ ] Exact-string `renderSegments` tests pin the rich default and every segment guard
+- [x] Exact-string `renderSegments` tests pin the rich default and every segment guard
       (non-finite burn, absurd/absent/past reset, out-of-range context, M/B tokens).
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/spec-lint.mjs` all pass unmasked (`echo $?`).
 
 ## Validation

--- a/src/receipt/format.ts
+++ b/src/receipt/format.ts
@@ -119,9 +119,10 @@ export function formatTokensK(n: number): string {
 }
 
 /**
- * SPEC-0026 round 2 — abbreviated token counts for stat lines (`371k`, `1.2M`).
- * One decimal only while it disambiguates (< 10 of the unit), deterministic
- * rounding; never truncates a digit mid-value.
+ * SPEC-0026 round 2 / SPEC-0071 R1 — abbreviated token counts for stat lines
+ * (`371k`, `1.2M`, `1.5B`). One decimal only while it disambiguates (< 10 of the
+ * unit), deterministic rounding; never truncates a digit mid-value. The `B`
+ * branch takes over exactly where `M` would otherwise render `1000M`.
  */
 export function formatShortTokens(n: number): string {
   if (n < 1000) {
@@ -129,7 +130,13 @@ export function formatShortTokens(n: number): string {
   }
   const unit = (v: number, suffix: string): string =>
     `${v < 9.95 ? v.toFixed(1).replace(/\.0$/u, "") : String(Math.round(v))}${suffix}`;
-  return n < 999_500 ? unit(n / 1000, "k") : unit(n / 1_000_000, "M");
+  if (n < 999_500) {
+    return unit(n / 1000, "k");
+  }
+  if (n < 999_500_000) {
+    return unit(n / 1_000_000, "M");
+  }
+  return unit(n / 1_000_000_000, "B");
 }
 
 /**

--- a/test/cli/statusline-segments.test.ts
+++ b/test/cli/statusline-segments.test.ts
@@ -120,6 +120,12 @@ describe("SPEC-0071 — rich statusline (burn, context, quota countdown, M/B tok
     expect(renderSegments(segs("tokens"), ctx({ summary: buildMiniSummary(model({ totalTokens: usage(501_368_000) })) }))).toBe("501M");
   });
 
+  it("R1: billion-scale tokens use the B suffix (never 1000M)", () => {
+    expect(renderSegments(segs("tokens"), ctx({ summary: buildMiniSummary(model({ totalTokens: usage(1_500_000_000) })) }))).toBe("1.5B");
+    // just past the M ceiling: ~999.5M rounds up into B, never renders "1000M"
+    expect(renderSegments(segs("tokens"), ctx({ summary: buildMiniSummary(model({ totalTokens: usage(999_500_000) })) }))).toBe("1B");
+  });
+
   it("R2: context segment from context_window.used_percentage; omitted when absent/out-of-range", () => {
     expect(renderSegments(segs("context"), ctx({ payload: { context_window: { used_percentage: 42 } } }))).toBe("ctx 42%");
     expect(renderSegments(segs("context"), ctx({ payload: { context_window: { used_percentage: 1_700_000_000 } } }))).toBe(""); // CC epoch-bug guard


### PR DESCRIPTION
## Release v0.5.0 — ready to dispatch

Prepares the `0.5.0` cut, **frozen at `main` `e2c7e76`** (main is under concurrent
development). Merge this, then run `release-publish.yml` (OIDC, no token). This PR does not
publish.

### What ships (four merged PRs since v0.4.0)

- **Self-contained `pr-check`** (SPEC-0064 R2–R7, #176) — an adopter's own workflow runs
  `npx -y aireceipts-cli@latest pr-check` in one job: **no reusable-workflow `uses:`, no org
  Actions-policy gate**. Fetches the branch's receipt ref, renders + sanitizes, upserts the
  marked PR comment via `GITHUB_TOKEN`. Also fixes the reusable-caller template (missing
  `pull-requests: write`).
- **Richer default statusline** (SPEC-0071, #175) — *deliberate output change*: burn rate,
  context %, `M`/`B` tokens, inline 5h reset countdown. Every segment from a real payload/ledger
  value; nothing estimated.
- **Samosa tip link off by default** on PR-posted surfaces, opt-in `--samosa` (SPEC-0070, #177)
  — *deliberate output change*.
- **Incremental mutation testing** on the money paths + nightly full sweep (SPEC-0069, #174).

`AGENTS.md`: **40 specs shipped**; SPEC-0064/0069/0070/0071 flipped to `shipped`.

### Gates & review

- **Release-manager verdict: GO** — `docs/releases/0.5.0-verdict.md`.
- **Docs-honesty panel: GO after one fix.** Caught a real over-claim: `formatShortTokens` only
  did `k`/`M`, but changelog/AGENTS/SPEC-0071 R1 claimed `M`/`B`. **Fixed** by implementing the
  `B` (billion) branch + a billion-scale test — the shipped claim is now true. All other claims
  (pr-check, statusline-is-default, samosa off-by-default with tip page/docs untouched, mutation
  testing, 40-count, no id-collision) verified against code.
- **Preflight 11/11** (tarball install+run, determinism ×10, full vitest, goldens, cite-check,
  spec-lint, hygiene). **Codex diff review: REVIEW-OK.**

### Known follow-up (non-blocking, user-approved)

PR-receipt **attribution fragility** — a committing session can show "no branch commit"
(transcript-SHA anchoring breaks on `--amend`, `-F`/`-c` commits, backgrounded commit output;
plus the SHA-less-codex-helper vs committing-session asymmetry). Own spec + PR in parallel;
does not block this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
