### PR TITLE
feat: SPEC-0072 — robust PR-receipt attribution (patch-id recovery)

### DIFF
--- a/specs/SPEC-0072-attribution-robustness.md
+++ b/specs/SPEC-0072-attribution-robustness.md
@@ -1,0 +1,201 @@
+---
+id: SPEC-0072
+title: Robust branch-commit anchors — amend/orphan patch-id recovery and the helper/committer asymmetry
+status: building
+milestone: M5
+depends: [SPEC-0024, SPEC-0032, SPEC-0038, SPEC-0044]
+---
+
+# SPEC-0072: Robust branch-commit anchors — amend/orphan patch-id recovery and the helper/committer asymmetry
+
+## Purpose
+
+SPEC-0024's SHA anchor (`claimedBranchShas` / `classifyBranchAnchors`, `src/pr/slice.ts:70`) and
+SPEC-0032's message-anchor fallback (`firstCommitSubject`, `src/pr/messageAnchor.ts:30`) both
+require a branch SHA (or its commit subject) to survive **verbatim in a git-write tool call's own
+OUTPUT** (SPEC-0038 R1b's line grammars, `writeOutputShas`, `src/pr/gitWrite.ts:262`). Four
+concrete gaps in that requirement were root-caused live in a dogfood session: (1) `git commit
+--amend` orphans the transcript's SHA — the branch carries the amended SHA, the transcript only
+ever saw the pre-amend one; (2) `git commit -F <file>` / `-c <commit>` / `-C <commit>` skip the
+`-m` subject entirely (`VALUE_TAKING_SHORT` in `firstCommitSubject`), so the message-anchor
+fallback can't fire; (3) a commit whose output is fully suppressed or redirected away from the tool
+call's own captured output leaves no hex run to match; (4) `selectContributors`
+(`src/pr/contributors.ts:193`) credits a same-worktree Codex session that made **zero** git writes
+(`anchors.writeCount === 0`) via cwd+time alone, while a session that made a **real** `git
+commit`/`git push` call (`writeCount > 0`) but whose SHA/subject didn't survive falls to the
+honest-excluded bucket — doing verifiable git work is currently worse for credit than doing none.
+This produced a receipt where a one-minute, zero-commit Codex helper was the PR's only credited
+cost and an hours-long committing session showed "no branch commit."
+
+This spec closes gaps (1) and (4) with **provable** local evidence and deliberately declines the
+unsafe shortcuts for (2)/(3). The governing constraint is I2 — **never fabricate credit; prefer
+under-crediting to any inferred or guessed match.** Every mechanism here is deterministic given
+fixed repo state (I1) and runs entirely against the local object database with no network (I4).
+Degraded cases stay degraded and now carry a sharper uncertainty signal (I3) rather than being
+inferred into credit.
+
+## Requirements
+
+- **R1 — patch-id recovery for orphaned commit SHAs (amend/rebase).** Add a resolved-anchor pass
+  that, for each session's `git commit` tool-call output SHA (per `writeOutputShas`,
+  `src/pr/gitWrite.ts:262`) that does not prefix-match any `branchShas` entry (an "orphan
+  candidate") and whose commit object is still resolvable locally
+  (`git cat-file -e <sha>^{commit}`), computes a stable diff fingerprint and matches it against
+  branch commits. Concretely:
+  - Fingerprint with `git patch-id --stable` (the default algorithm is unstable in Git ≥2.42) fed
+    by a fixed local diff producer (`git diff-tree -p --no-color <sha>` / equivalent `git show`),
+    so identical repo state always yields the identical id (I1), computed with no network (I4).
+  - **Uniqueness is evaluated across ALL branch commits and ALL other orphan candidates, not only
+    the as-yet-unclaimed ones.** A branch commit that is already directly SHA-claimed still counts
+    toward the uniqueness denominator. An orphan is promoted only if its patch-id is a **unique**
+    1:1 match against exactly one branch commit and appears nowhere else in that combined set.
+    Add/revert/reapply, cherry-picked duplicates, and any commit whose diff is shared by two or
+    more commits therefore produce **no** promotion — a duplicated diff can never masquerade as a
+    unique match.
+  - **Authorship guard — uniqueness is necessary but NOT sufficient.** Patch-id proves diff
+    EQUALITY, not authorship. A promotion is additionally rejected when its target branch SHA is
+    already **directly** claimed by any session's own git-write output. So a session that merely
+    *reproduces* a different session's uniquely-diffed, already-landed commit — a `cherry-pick`,
+    or an independent rebuild of the same change — is never credited for it (the direct claimant
+    is the proven author). The amend case is unaffected: an amended branch SHA is never directly
+    claimed (the transcript holds only the orphaned pre-amend SHA). Without this guard a
+    cherry-pick of another session's unique commit would be promoted and bill the cherry-picker's
+    whole session to the PR — a direct I2 violation (found in adversarial review).
+  - **Commits with no computable patch-id are excluded as both orphan candidates and match
+    targets:** empty commits (`--allow-empty`, no diff) and merge commits (no default patch-id).
+    They are skipped, never promoted, never crash — under-credit only.
+  - A promoted orphan SHA joins the same recovered-SHA set that feeds `hasOwn` exactly as a direct
+    match would. No match (content-changing amend, pruned/`git gc`'d object, empty/merge, or
+    non-unique diff) leaves the session on today's existing path — strictly additive recovery,
+    never a new way to lose credit.
+- **R2 — no unsafe message-argv widening (safety boundary, tested).** `-F <file>`, `-c
+  <commit-ish>`, and `-C <commit-ish>` are explicitly NOT given a message-subject recovery path.
+  Reading a `-F` file at receipt time is unsound: the file can have changed since the commit and
+  would manufacture a false message match against an unrelated unique branch subject (a direct I2
+  violation). `-c`/`-C` are equally unsound: `-c` reuses a message AND reopens it for **editing**,
+  so the referenced commit's subject is not proof of the final committed subject, and even `-C`
+  (reuse without editing) only proves the source subject, not what landed on the branch. A normal
+  `-F`/`-c`/`-C` commit that succeeds still emits its branch SHA in tool output (covered by the
+  existing SHA anchor), and the amend/orphan variant is covered by R1's patch-id recovery — so
+  none of these flags need an unsafe subject path. `firstCommitSubject`'s existing behavior of
+  skipping these flags' arguments is therefore correct and stays. This requirement is a regression
+  lock (test-only) asserting a changed `-F` file does not produce credit.
+- **R3 — a distinct signal for "tried to write git, couldn't be anchored."** Add a new
+  `ConfidenceEvent` variant (`src/pr/confidence.ts:28`) — `unanchored-git-write` — emitted, in
+  place of the generic `silenced-git-write`, when a repo-pool, current-worktree candidate has
+  `anchors.writeCount > 0` (`BranchAnchorSummary`, `src/pr/slice.ts:64`) and is still not credited
+  after R1's widened resolution. This must NOT change who gets credited — it only sharpens the
+  reporting layer's I3 signal, distinguishing "this session made a real, verifiable git-write call
+  we structurally could not tie to the branch" from "this session made no git-write signal at
+  all." `summarizeConfidence`'s exhaustive switch (`src/pr/confidence.ts:77`) and
+  `ConfidenceSummary` gain the matching case/field; `isFloored` (`src/pr/confidence.ts:104`)
+  treats it as floor-triggering exactly like `silenced-git-write` does today.
+- **R4 — the helper rule never expands to committers (locked, tested).** The SHA-less Codex helper
+  rule (`isCodex && anchors.writeCount === 0 && here`, `src/pr/contributors.ts:193`) stays scoped
+  to sessions with zero real git-write calls. R1 is the only fix for bug (4): by recovering
+  amended/orphaned SHAs, more genuine committers earn `hasOwn` and stop needing any benefit of the
+  doubt; a session that made a real git-write call and still can't be anchored is never credited by
+  inference (I2) — it is labeled via R3's new event instead. Test-only regression lock; the
+  asymmetry's fix is evidentiary strengthening, not a threshold change to the helper rule.
+- **R5 — resolved-anchor pass placement and order-independence.** R1's recovery cannot live in
+  `classifyBranchAnchors` (`src/pr/slice.ts:70`), which is pure and only sees branch SHAs. It is a
+  new resolved-anchor pass in `selectContributors` (`src/pr/contributors.ts`) that takes an
+  injected `CommandRunner` (`src/pr/git.ts`) and runs across **all** candidates **before** the
+  per-session credit loop and before the message-fallback claim pass
+  (`src/pr/contributors.ts:115-159`) — preserving SPEC-0032 R3a's all-candidates-before-credit
+  ordering. A patch-id-recovered claim poisons its SHA for every other candidate exactly like a
+  direct match does today; `claimedBranchShas` alone cannot produce these recovered claims.
+
+## Scenarios
+
+- **Given** a session whose transcript shows `[main abc1234] fix: thing` from a `git commit
+  --amend`, and the branch's actual (amended) commit is `def5678` with an unchanged diff, **when**
+  the receipt is built, **then** `abc1234`'s stable patch-id uniquely matches `def5678`'s and the
+  session is credited via `anchor` — no longer excluded.
+- **Given** a branch containing an add/revert/reapply pair (two commits with identical patch-ids)
+  and a session holding an orphaned SHA whose diff matches both, **when** R1 runs, **then** the
+  patch-id is non-unique across all branch commits, so no promotion occurs and the session stays on
+  its existing (uncredited) path.
+- **Given** a session that ran `git commit -F .github/meta/commit.txt` where the file was edited
+  after the commit, **when** attribution runs, **then** no message subject is read from the file
+  and no credit is manufactured; the session is credited only if its real branch SHA survived in
+  output (SHA anchor) or R1 recovers it.
+- **Given** a same-worktree, same-window session that made a real `git commit` call
+  (`writeCount === 1`) that R1 cannot resolve (fully suppressed output, content-changed amend), and
+  a separate same-worktree Codex session that made zero git writes, **when** the receipt is built,
+  **then** the Codex session is still credited via `helper` (unaffected) and the committing session
+  emits `unanchored-git-write` (not `silenced-git-write`) — distinctly labeled, never credited by
+  inference.
+- **Given** a local squash (`git rebase -i` combining three session-authored commits into one
+  pushed commit), **when** R1 runs, **then** none of the three orphaned commits' patch-ids equal
+  the squashed commit's (a diff union, not a 1:1 diff), so no session is falsely credited.
+
+## Non-goals
+
+- **Content-changing amends.** An amend that changes the diff produces a different patch-id — no
+  recovery; the existing floor stays, correctly, since the transcript's commit and the branch's
+  commit are genuinely different work.
+- **Pruned orphan objects.** If `git gc` (or object expiry) removed the pre-amend commit before
+  receipt generation, `git cat-file -e` fails and R1 cannot run — no recovery, no crash.
+- **Empty and merge commits.** No computable default patch-id — excluded as orphan candidates and
+  as match targets (R1). Under-credit only.
+- **Message recovery from `-F`/`-c`/`-C` argv.** Deliberately declined as unsound (R2) — a changed
+  `-F` file or an edited `-c` message could manufacture a false subject match. The amend/orphan
+  case those flags share with `-m` is handled by R1 instead.
+- **Known residual — cherry-pick onto an *unclaimed* branch SHA.** R1's authorship guard rejects a
+  promotion onto a branch SHA that is directly claimed. It does NOT cover the strictly narrower
+  tail where the genuine author leaves **zero** direct claim on that SHA (their `git commit` output
+  was fully swallowed AND they never amended, so nothing anchors it) while a *different* session
+  cherry-picked the same unique diff into a resolvable orphan — that copier could still be promoted.
+  This requires the real author to be simultaneously unanchorable, which is the same
+  "independent-identical-diff, no direct claim" tail SPEC-0072's under-crediting philosophy already
+  accepts; closing it would need author-identity evidence patch-id cannot provide. Documented, not
+  fixed here.
+- **Fully swallowed commit output with zero hex run in that call's own output** (e.g. `git commit
+  -m x > log 2>&1 &`, disowned). This spec does not scan *other*, non-git-verb tool calls' outputs
+  for SHA-shaped lines — doing so would reopen exactly the contamination SPEC-0038 closed. A
+  structural floor, now labeled via R3's `unanchored-git-write`.
+- **Squash-merge fabrication.** Explicitly tested to confirm patch-id comparison does NOT partially
+  or fuzzily match a multi-commit squash to any single constituent — a guardrail, not a feature.
+- **Cross-agent/delegated spend rollup.** A session spawning Codex/Sonnet subagents and their cost
+  rolling into the PR total is a separate concern (partly addressed by SPEC-0061) — out of scope.
+- **Widening the helper rule to committing sessions.** Rejected by design (R4) — crediting a
+  session with unresolved git writes via cwd+time alone would be a guess, violating I2.
+
+## Test matrix
+
+| Req | Case | Input | Expected |
+|---|---|---|---|
+| R1 | message-only amend | orphan SHA output, amended branch SHA, same diff | unique stable patch-id match → credited via `anchor` |
+| R1 | content-changing amend | orphan SHA, amended branch SHA, different diff | no patch-id match → existing floor (unchanged) |
+| R1 | pruned orphan object | orphan SHA no longer in odb (`cat-file -e` fails) | no recovery; no crash; existing floor |
+| R1 | duplicate diff, unclaimed | orphan patch-id equals 2+ branch commits, none direct-claimed | non-unique across all branch commits → no promotion |
+| R1 | duplicate diff, one direct-claimed | orphan diff equals a direct-SHA-claimed commit + one other | claimed commit still counts in denominator → non-unique → no credit |
+| R1 | empty commit | orphan from `git commit --allow-empty` | no computable patch-id → not promoted, no crash |
+| R1 | merge commit target | branch merge commit as candidate target | no default patch-id → excluded as target |
+| R2 | changed `-F` file | `git commit -F commit.txt`, file edited after commit | file NOT read; no message credit manufactured |
+| R2 | `-c`/`-C` reuse | `git commit -c <sha>` / `-C <sha>` | no subject recovery attempted; credit only via SHA anchor or R1 |
+| R3 | committer-vs-helper asymmetry | committing session unrecoverable + zero-write Codex helper, same worktree/window | helper still credited (`helper`); committer emits `unanchored-git-write`, not `silenced-git-write` |
+| R3 | confidence exhaustiveness | new `unanchored-git-write` variant | `summarizeConfidence` switch handles it; `isFloored` treats it as floor-triggering |
+| R4 | helper rule scope regression | Codex session with `writeCount > 0` and no resolvable anchor | never credited via `helper` (writeCount check unchanged) |
+| R5 | resolved-anchor pass ordering | R1-recovered claim, candidates in any list order | same recovered-SHA/claim set regardless of order; poisons other candidates (SPEC-0032 R3a parity) |
+| — | backgrounded output, partially captured | `git commit -m x \| tee log` (own call output still has the line) | handled by existing `writeOutputShas`; unaffected |
+| — | fully swallowed output | `git commit -m x > log 2>&1 &`, disowned, zero hex run | no recovery (named non-goal); emits `unanchored-git-write` |
+| — | squash-merge guardrail | 3 session commits locally squashed into 1 pushed commit | no single orphan's patch-id equals the squash's; none falsely credited |
+| — | commit + codex-helper combo | one session commits (recovered via R1) AND spawns `codex exec` in-window | both credited (`anchor` + `helper`), no double count |
+
+## Success criteria
+
+- [ ] R1 recovers message-only/no-diff-change amends using `git patch-id --stable` and a fixed
+      local diff producer, no network, via the injected `CommandRunner` (`src/pr/git.ts`).
+- [ ] R1 uniqueness is evaluated across all branch commits and orphan candidates; duplicated diffs
+      (including one already direct-claimed) never produce a promotion.
+- [ ] Empty/merge/pruned commits under-credit (no promotion, no crash), never fabricate.
+- [ ] No message subject is ever recovered from `-F`/`-c`/`-C` argv; a changed `-F` file produces
+      no credit (adversarial test passes).
+- [ ] A committing session with a real git-write call is never left indistinguishable from a
+      session that made none (R3's new event, R4's locked scope).
+- [ ] The resolved-anchor pass runs before the message-fallback claim pass, preserving SPEC-0032
+      R3a order-independence.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked.

--- a/src/pr/anchorRecovery.ts
+++ b/src/pr/anchorRecovery.ts
@@ -1,0 +1,107 @@
+// SPEC-0072 R1 — recover amended/rebased git-commit output SHAs by matching a
+// locally resolvable orphan commit's stable patch-id to exactly one branch
+// commit. This is intentionally under-crediting: duplicated diffs, empty
+// commits, merge commits, missing objects, and git failures produce no match.
+import type { Session } from "../parse/types.js";
+import type { CommandRunner } from "./git.js";
+import { matchesBranchSha, toolCallGitVerb, writeOutputShas } from "./gitWrite.js";
+
+export interface OrphanCommitCandidate {
+  /** File-unique session key, used only by callers to route a recovered SHA back to a session. */
+  sessionId: string;
+  /** A git-commit output SHA/prefix that does not prefix-match any branch SHA. */
+  sha: string;
+}
+
+export interface AnchorRecoveryInput {
+  branchShas: readonly string[];
+  candidates: readonly OrphanCommitCandidate[];
+  runGit: CommandRunner;
+  cwd?: string;
+}
+
+/** Commit-output SHAs that are not direct branch anchors and may still be locally recoverable. */
+export function orphanCommitOutputShas(session: Session, branchShas: readonly string[]): string[] {
+  const out: string[] = [];
+  for (const turn of session.turns) {
+    for (const call of turn.toolCalls) {
+      if (toolCallGitVerb(call) !== "commit") {
+        continue;
+      }
+      for (const sha of writeOutputShas("commit", String(call.output ?? ""))) {
+        if (!matchesBranchSha(sha, branchShas) && !out.includes(sha)) {
+          out.push(sha);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+function commitExists(runGit: CommandRunner, sha: string, cwd?: string): boolean {
+  return runGit("git", ["cat-file", "-e", `${sha}^{commit}`], { cwd }).code === 0;
+}
+
+function stablePatchId(runGit: CommandRunner, sha: string, cwd?: string): string | null {
+  if (!commitExists(runGit, sha, cwd)) {
+    return null;
+  }
+  const diff = runGit("git", ["diff-tree", "-p", "--no-color", sha], { cwd });
+  if (diff.code !== 0 || diff.stdout.trim() === "") {
+    return null;
+  }
+  const patch = runGit("git", ["patch-id", "--stable"], { cwd, stdin: diff.stdout });
+  if (patch.code !== 0) {
+    return null;
+  }
+  const [id] = patch.stdout.trim().split(/\s+/);
+  return /^[0-9a-f]{40}$/.test(id) ? id : null;
+}
+
+function bump(map: Map<string, number>, key: string): void {
+  map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+/**
+ * Return recovered orphan -> branch SHA promotions. A promotion exists only
+ * when the orphan patch-id maps to one branch commit and that patch-id is not
+ * duplicated by any other branch commit or orphan candidate.
+ */
+export function recoverBranchAnchors(input: AnchorRecoveryInput): Map<string, string> {
+  const branchByPatch = new Map<string, string[]>();
+  const branchCounts = new Map<string, number>();
+  for (const sha of input.branchShas) {
+    const patchId = stablePatchId(input.runGit, sha, input.cwd);
+    if (patchId === null) {
+      continue;
+    }
+    const shas = branchByPatch.get(patchId) ?? [];
+    shas.push(sha);
+    branchByPatch.set(patchId, shas);
+    bump(branchCounts, patchId);
+  }
+
+  const orphanPatches: Array<{ sha: string; patchId: string }> = [];
+  const orphanCounts = new Map<string, number>();
+  for (const candidate of input.candidates) {
+    const patchId = stablePatchId(input.runGit, candidate.sha, input.cwd);
+    if (patchId === null) {
+      continue;
+    }
+    orphanPatches.push({ sha: candidate.sha, patchId });
+    bump(orphanCounts, patchId);
+  }
+
+  const recovered = new Map<string, string>();
+  for (const orphan of orphanPatches) {
+    const branchMatches = branchByPatch.get(orphan.patchId) ?? [];
+    if (branchMatches.length !== 1) {
+      continue;
+    }
+    if ((branchCounts.get(orphan.patchId) ?? 0) !== 1 || (orphanCounts.get(orphan.patchId) ?? 0) !== 1) {
+      continue;
+    }
+    recovered.set(orphan.sha, branchMatches[0]);
+  }
+  return recovered;
+}

--- a/src/pr/body.ts
+++ b/src/pr/body.ts
@@ -323,6 +323,18 @@ function totalBlocks(input: PrBodyInput): Block[] {
     });
     blocks.push({ kind: "note", text: "(in repo + branch window, no branch commit)", muted: true });
   }
+  // SPEC-0072 R3 — sharper signal for excluded candidates that made a real git
+  // write but still could not be tied to the branch after patch-id recovery.
+  const unanchored = input.confidence?.unanchoredGitWrite ?? 0;
+  if (unanchored > 0) {
+    blocks.push({
+      kind: "note",
+      text: `${plural(unanchored, "session")} made git writes that could not be anchored`,
+      muted: true,
+      spaceBefore: true,
+    });
+    blocks.push({ kind: "note", text: "(see docs/trust.md)", muted: true });
+  }
   // SPEC-0044 A1 — anchor-pool sessions that touched the branch but couldn't be
   // sliced precisely: counted-absence, DISTINCT from the excluded note above
   // (the coverage-map C.2 hole — never a silent drop).

--- a/src/pr/confidence.ts
+++ b/src/pr/confidence.ts
@@ -33,6 +33,9 @@ export type ConfidenceEvent =
   // A repo+window candidate that isn't proven ours (no branch SHA) — the
   // long-standing honest "excluded" count (SPEC-0023 R4 / SPEC-0032).
   | { kind: "silenced-git-write"; sessionId: string }
+  // SPEC-0072 R3: a repo+window candidate made a real git write, but no direct,
+  // message, or patch-id recovered anchor could tie it to this branch.
+  | { kind: "unanchored-git-write"; sessionId: string }
   // A subagent transcript that couldn't be parsed — listed, never dropped.
   | { kind: "unreadable-subagent"; sessionId: string }
   // A3: cache-write tokens priced at the base input rate because the vendor's
@@ -55,6 +58,8 @@ export interface ConfidenceSummary {
   unattributableAnchorPool: number;
   /** repo+window candidates not proven ours (the classic excluded count). */
   silencedGitWrite: number;
+  /** repo+window candidates with git writes that could not be anchored after recovery. */
+  unanchoredGitWrite: number;
   /** subagents that couldn't be parsed. */
   unreadableSubagent: number;
   /** sessions whose cache-write cost is a lower bound (no published cache-write rate). */
@@ -79,6 +84,7 @@ export function summarizeConfidence(events: readonly ConfidenceEvent[]): Confide
     switch (e.kind) {
       case "unattributable-anchor-pool":
       case "silenced-git-write":
+      case "unanchored-git-write":
       case "unreadable-subagent":
       case "cost-lower-bound-cache-tier":
       case "unreadable-session":
@@ -93,6 +99,7 @@ export function summarizeConfidence(events: readonly ConfidenceEvent[]): Confide
   return {
     unattributableAnchorPool: distinctSessions(events, "unattributable-anchor-pool"),
     silencedGitWrite: distinctSessions(events, "silenced-git-write"),
+    unanchoredGitWrite: distinctSessions(events, "unanchored-git-write"),
     unreadableSubagent: distinctSessions(events, "unreadable-subagent"),
     costLowerBoundCacheTier: distinctSessions(events, "cost-lower-bound-cache-tier"),
     unreadableSession: distinctSessions(events, "unreadable-session"),
@@ -105,6 +112,7 @@ export function isFloored(summary: ConfidenceSummary): boolean {
   return (
     summary.unattributableAnchorPool > 0 ||
     summary.silencedGitWrite > 0 ||
+    summary.unanchoredGitWrite > 0 ||
     summary.unreadableSubagent > 0 ||
     summary.costLowerBoundCacheTier > 0 ||
     summary.unreadableSession > 0 ||

--- a/src/pr/contributors.ts
+++ b/src/pr/contributors.ts
@@ -9,8 +9,9 @@
 // rankings (I6): codex / orchestrator (spawned subagents or launched agents) /
 // builder.
 import type { Session, SessionSummary } from "../parse/types.js";
+import { orphanCommitOutputShas, recoverBranchAnchors, type OrphanCommitCandidate } from "./anchorRecovery.js";
 import { classifyBranchAnchors, computeSlice, type BranchAnchorSummary, type SliceResult } from "./slice.js";
-import { cwdInsideRoots } from "./git.js";
+import { cwdInsideRoots, type CommandRunner } from "./git.js";
 import { isCodexExec, toolCallInvocations } from "./gitWrite.js";
 import { claimedBranchShas, eligibleSubjects, hasForeignShaWrites, sessionCommitSubjects } from "./messageAnchor.js";
 import type { ConfidenceEvent } from "./confidence.js";
@@ -60,6 +61,8 @@ export interface ContributorDeps {
   currentWorktreeRoot: string | null;
   /** Branch commit subjects aligned with `branchShas` (SPEC-0032). Absent/empty → message fallback off. */
   branchSubjects?: readonly string[];
+  /** Injected local git runner for SPEC-0072 patch-id anchor recovery. */
+  runGit: CommandRunner;
 }
 
 /** True if the session's cwd is inside the current process's worktree (not a sibling worktree). */
@@ -83,12 +86,16 @@ export async function selectContributors(
 ): Promise<ContributorSelection> {
   const contributors: RawContributor[] = [];
   const events: ConfidenceEvent[] = [];
-  // excludedCount derives from the silenced-git-write events (kept as a field
-  // for the well-tested body wiring); the events are the R1 source of truth.
+  // excludedCount derives from the repo+current-worktree uncredited events
+  // (kept as a field for the well-tested body wiring); the events are the R1
+  // source of truth.
   // filePath is the file-unique identity; summary.id collides across nested
   // candidates (nestedCandidates synthesizes id: agentId) — S2 finding 3.
-  const excludeHere = (summary: SessionSummary): void => {
-    events.push({ kind: "silenced-git-write", sessionId: summary.filePath });
+  const excludeHere = (summary: SessionSummary, anchors?: BranchAnchorSummary | null): void => {
+    events.push({
+      kind: anchors !== null && anchors !== undefined && anchors.writeCount > 0 ? "unanchored-git-write" : "silenced-git-write",
+      sessionId: summary.filePath,
+    });
   };
 
   // Pass 1 — load and classify EVERYTHING first, so SHA claims are computed
@@ -112,6 +119,54 @@ export async function selectContributors(
     loaded.push({ summary, here, pool, session, anchors: session ? classifyBranchAnchors(session.turns, branchShas) : null });
   }
 
+  const orphanCandidates: OrphanCommitCandidate[] = [];
+  const orphanOwners = new Map<string, Set<Loaded>>();
+  for (const l of loaded) {
+    if (!l.session) {
+      continue;
+    }
+    for (const sha of orphanCommitOutputShas(l.session, branchShas)) {
+      orphanCandidates.push({ sessionId: l.summary.filePath, sha });
+      const owners = orphanOwners.get(sha) ?? new Set<Loaded>();
+      owners.add(l);
+      orphanOwners.set(sha, owners);
+    }
+  }
+  // SPEC-0072 R1 authorship guard — patch-id proves diff-EQUALITY, not authorship.
+  // A branch SHA that a session's own git-write OUTPUT already directly claims has
+  // a proven author; never re-credit it to a different session whose orphan merely
+  // *reproduces* the diff (a cherry-pick, or an independent rebuild of the same
+  // change). Computed from direct claims only, so it is available before recovery.
+  // The amend case is unaffected: an amended branch SHA is never directly claimed
+  // (the transcript holds only the orphaned pre-amend SHA).
+  const directlyClaimed = new Set<string>();
+  for (const l of loaded) {
+    if (l.session) {
+      for (const sha of claimedBranchShas(l.session, branchShas)) {
+        directlyClaimed.add(sha);
+      }
+    }
+  }
+  const recoveredByLoaded = new Map<Loaded, Set<string>>();
+  const recovered = recoverBranchAnchors({
+    branchShas,
+    candidates: orphanCandidates,
+    runGit: deps.runGit,
+    cwd: deps.currentWorktreeRoot ?? undefined,
+  });
+  for (const [orphanSha, branchSha] of recovered) {
+    // Never promote onto a branch SHA a different session already directly proved.
+    if (directlyClaimed.has(branchSha)) {
+      continue;
+    }
+    for (const owner of orphanOwners.get(orphanSha) ?? []) {
+      const shas = recoveredByLoaded.get(owner) ?? new Set<string>();
+      shas.add(branchSha);
+      recoveredByLoaded.set(owner, shas);
+    }
+  }
+  const hasRecoveredOwn = (l: Loaded): boolean => (recoveredByLoaded.get(l)?.size ?? 0) > 0;
+
   // SPEC-0032 R3 — the eligible-subject set: branch subjects on commits no
   // candidate SHA-claims, unique on the branch. Empty when subjects weren't
   // supplied (fallback off).
@@ -121,6 +176,9 @@ export async function selectContributors(
       // Any write verb claims (push output too — a push-anchored commit's
       // subject must not stay eligible; S5 finding 1).
       for (const sha of claimedBranchShas(l.session, branchShas)) {
+        claimedShas.add(sha);
+      }
+      for (const sha of recoveredByLoaded.get(l) ?? []) {
         claimedShas.add(sha);
       }
     }
@@ -139,7 +197,7 @@ export async function selectContributors(
       continue;
     }
     const isCodex = l.summary.source === "codex";
-    const shaIncluded = l.anchors.hasOwn || (isCodex && l.anchors.writeCount === 0);
+    const shaIncluded = l.anchors.hasOwn || hasRecoveredOwn(l) || (isCodex && l.anchors.writeCount === 0);
     if (shaIncluded) {
       continue;
     }
@@ -177,7 +235,7 @@ export async function selectContributors(
       // it used to vanish silently — SPEC-0044 B4: "couldn't read" ≠ "not ours",
       // so its absence is now counted via a typed event (floors the total).
       if (here) {
-        excludeHere(summary);
+        excludeHere(summary, anchors);
       } else {
         events.push({ kind: "unreadable-session", sessionId: summary.filePath });
       }
@@ -190,7 +248,8 @@ export async function selectContributors(
     // no branch SHA, or a SHA-less Codex session from a sibling worktree or
     // the anchor pool, is not proven ours (R1) — unless the SPEC-0032 message
     // fallback structurally credits it (weaker basis, labeled on the row).
-    const include = anchors.hasOwn || (isCodex && anchors.writeCount === 0 && here);
+    const recoveredOwn = hasRecoveredOwn(l);
+    const include = anchors.hasOwn || recoveredOwn || (isCodex && anchors.writeCount === 0 && here);
     if (include) {
       const slice = computeSlice(session.turns, branchShas);
       // SPEC-0038 R2a — an anchor-pool session contributes ONLY with a
@@ -211,7 +270,7 @@ export async function selectContributors(
         summary,
         session,
         slice,
-        basis: anchors.hasOwn ? "anchor" : "helper",
+        basis: anchors.hasOwn || recoveredOwn ? "anchor" : "helper",
       });
     } else if (messageCredited.has(l)) {
       contributors.push({
@@ -224,7 +283,7 @@ export async function selectContributors(
       });
     } else if (here) {
       // Plausibly ours (this worktree) but unproven — surface it in the honest note.
-      excludeHere(summary);
+      excludeHere(summary, anchors);
     }
     // else: a sibling-worktree or anchor-pool candidate with no branch-SHA proof — not ours, ignored.
   }
@@ -233,7 +292,7 @@ export async function selectContributors(
     (a, b) => (a.session.startedAt ?? 0) - (b.session.startedAt ?? 0) || a.summary.id.localeCompare(b.summary.id),
   );
   const excludedCount = new Set(
-    events.filter((e) => e.kind === "silenced-git-write").map((e) => e.sessionId),
+    events.filter((e) => e.kind === "silenced-git-write" || e.kind === "unanchored-git-write").map((e) => e.sessionId),
   ).size;
   return { contributors, excludedCount, events };
 }

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -237,6 +237,7 @@ async function resolveContributors(
     branchSubjects: subjects,
     loadSession,
     currentWorktreeRoot: currentWorktreeRoot(deps.runGit, deps.cwd) ?? deps.cwd,
+    runGit: deps.runGit,
   });
   return { ...selection, sidechains };
 }

--- a/test/pr/anchorRecovery.test.ts
+++ b/test/pr/anchorRecovery.test.ts
@@ -195,9 +195,15 @@ describe("SPEC-0072 R1 - patch-id anchor recovery", () => {
     const cwd = await tempRepo();
     const main = currentBranch(cwd);
     const branchSha = await commitFile(cwd, "shared.txt", "shared change\n", "feat: shared change");
+    // Cherry-pick onto a DIFFERENT parent (an unrelated commit) so the orphan gets a
+    // distinct SHA while keeping the identical diff (equal patch-id). Cherry-picking the
+    // tip straight onto its own parent would reproduce the byte-identical commit SHA and
+    // never exercise the guard.
     git(cwd, ["checkout", "--quiet", "-b", "cherry", `${branchSha}~1`]);
+    await commitFile(cwd, "unrelated.txt", "noise\n", "chore: unrelated work");
     git(cwd, ["cherry-pick", "--no-edit", branchSha]);
     const orphanSha = head(cwd);
+    expect(orphanSha).not.toBe(branchSha);
     git(cwd, ["checkout", "--quiet", main]);
 
     const author = makeSession("author", cwd, [bashTurn(0, "git commit -m shared", commitOutput(branchSha, "feat: shared change"))], "claude-code", 1000);

--- a/test/pr/anchorRecovery.test.ts
+++ b/test/pr/anchorRecovery.test.ts
@@ -1,0 +1,372 @@
+// SPEC-0072 - patch-id recovery for orphaned commit anchors. These tests use
+// real temporary git repositories so the stable patch-id boundary is exercised
+// against local git object state, not a mocked fingerprint.
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSource, Session, SessionSummary, Turn } from "../../src/parse/types.js";
+import { emptyUsage, withTotal } from "../../src/parse/util.js";
+import { defaultRunner } from "../../src/pr/git.js";
+import { selectContributors, type PoolCandidate } from "../../src/pr/contributors.js";
+import { summarizeConfidence } from "../../src/pr/confidence.js";
+
+const dirs: string[] = [];
+const usage = withTotal({ ...emptyUsage(), input: 1000, output: 100 });
+
+async function tempRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "aireceipts-anchor-"));
+  dirs.push(dir);
+  git(dir, ["init", "--quiet"]);
+  git(dir, ["config", "user.email", "tests@example.com"]);
+  git(dir, ["config", "user.name", "Receipt Tests"]);
+  git(dir, ["config", "commit.gpgsign", "false"]);
+  await writeFile(join(dir, "README.md"), "base\n");
+  git(dir, ["add", "README.md"]);
+  git(dir, ["commit", "--quiet", "-m", "base"]);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function git(cwd: string, args: string[], input?: string): string {
+  const res = spawnSync("git", args, { cwd, input, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
+  if (res.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${res.stderr}`);
+  }
+  return res.stdout.trim();
+}
+
+function currentBranch(cwd: string): string {
+  return git(cwd, ["branch", "--show-current"]);
+}
+
+function head(cwd: string): string {
+  return git(cwd, ["rev-parse", "HEAD"]);
+}
+
+async function commitFile(cwd: string, file: string, content: string, subject: string): Promise<string> {
+  await writeFile(join(cwd, file), content);
+  git(cwd, ["add", file]);
+  git(cwd, ["commit", "--quiet", "-m", subject]);
+  return head(cwd);
+}
+
+function commitOutput(sha: string, subject: string): string {
+  return `[feat ${sha.slice(0, 7)}] ${subject}\n 1 file changed`;
+}
+
+function bashTurn(index: number, command: string, output: string): Turn {
+  return {
+    index,
+    timestamp: 1000 + index,
+    model: "claude-opus-4-8",
+    usage,
+    toolCalls: [{ name: "Bash", shell: true, input: { command }, output, status: "ok" }],
+  };
+}
+
+function makeSession(
+  id: string,
+  cwd: string,
+  turns: Turn[],
+  source: AgentSource = "claude-code",
+  startedAt = 1000,
+): Session {
+  return {
+    id,
+    source,
+    filePath: `${cwd}/${id}.jsonl`,
+    cwd,
+    startedAt,
+    endedAt: startedAt + 1000,
+    totals: { tokens: usage, turnCount: turns.length, toolCallCount: turns.length },
+    turns,
+  };
+}
+
+function repo(s: Session): PoolCandidate {
+  return { summary: s, pool: "repo" };
+}
+
+function depsFor(cwd: string, sessions: Session[], branchSubjects: readonly string[] = []) {
+  const byId = new Map(sessions.map((s) => [s.id, s]));
+  return {
+    loadSession: async (summary: SessionSummary) => byId.get(summary.id) ?? null,
+    currentWorktreeRoot: cwd,
+    branchSubjects,
+    runGit: defaultRunner,
+  };
+}
+
+async function amendRepo(changeContent: boolean): Promise<{ cwd: string; oldSha: string; newSha: string }> {
+  const cwd = await tempRepo();
+  await commitFile(cwd, "feature.txt", "one\n", "feat: original change");
+  const oldSha = head(cwd);
+  if (changeContent) {
+    await writeFile(join(cwd, "feature.txt"), "two\n");
+    git(cwd, ["add", "feature.txt"]);
+  }
+  git(cwd, ["commit", "--amend", "--quiet", "-m", "feat: amended branch change"]);
+  return { cwd, oldSha, newSha: head(cwd) };
+}
+
+async function duplicatePatchRepo(): Promise<{ cwd: string; firstSha: string; revertSha: string; reapplySha: string; orphanSha: string }> {
+  const cwd = await tempRepo();
+  const main = currentBranch(cwd);
+  git(cwd, ["checkout", "--quiet", "-b", "orphan"]);
+  const orphanSha = await commitFile(cwd, "dup.txt", "same\n", "feat: orphan duplicate");
+  git(cwd, ["checkout", "--quiet", main]);
+  const firstSha = await commitFile(cwd, "dup.txt", "same\n", "feat: add duplicate");
+  git(cwd, ["revert", "--quiet", "--no-edit", firstSha]);
+  const revertSha = head(cwd);
+  const reapplySha = await commitFile(cwd, "dup.txt", "same\n", "feat: reapply duplicate");
+  return { cwd, firstSha, revertSha, reapplySha, orphanSha };
+}
+
+describe("SPEC-0072 R1 - patch-id anchor recovery", () => {
+  it("credits a message-only amend by matching the orphan SHA's stable patch-id", async () => {
+    const { cwd, oldSha, newSha } = await amendRepo(false);
+    const s = makeSession("amended", cwd, [bashTurn(0, "git commit -m original", commitOutput(oldSha, "feat: original change"))]);
+
+    const sel = await selectContributors([repo(s)], [newSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors.map((c) => [c.summary.id, c.basis])).toEqual([["amended", "anchor"]]);
+    expect(sel.contributors[0].slice.kind).toBe("full");
+    expect(sel.excludedCount).toBe(0);
+  });
+
+  it("does not credit a content-changing amend whose patch-id differs", async () => {
+    const { cwd, oldSha, newSha } = await amendRepo(true);
+    const s = makeSession("changed", cwd, [bashTurn(0, "git commit -m original", commitOutput(oldSha, "feat: original change"))]);
+
+    const sel = await selectContributors([repo(s)], [newSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(sel.excludedCount).toBe(1);
+    const confidence = summarizeConfidence(sel.events);
+    expect(confidence.unanchoredGitWrite).toBe(1);
+    expect(confidence.silencedGitWrite).toBe(0);
+  });
+
+  it("skips an unresolvable orphan object without crashing", async () => {
+    const cwd = await tempRepo();
+    const branchSha = await commitFile(cwd, "branch.txt", "branch\n", "feat: branch");
+    const missing = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    const s = makeSession("missing", cwd, [bashTurn(0, "git commit -m missing", commitOutput(missing, "feat: missing"))]);
+
+    const sel = await selectContributors([repo(s)], [branchSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+
+  it("refuses duplicate branch diffs even when none are directly claimed", async () => {
+    const { cwd, firstSha, revertSha, reapplySha, orphanSha } = await duplicatePatchRepo();
+    const s = makeSession("orphan", cwd, [bashTurn(0, "git commit -m duplicate", commitOutput(orphanSha, "feat: orphan duplicate"))]);
+
+    const sel = await selectContributors([repo(s)], [reapplySha, revertSha, firstSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+
+  it("refuses duplicate branch diffs even when one duplicate is already direct-claimed", async () => {
+    const { cwd, firstSha, revertSha, reapplySha, orphanSha } = await duplicatePatchRepo();
+    const direct = makeSession("direct", cwd, [bashTurn(0, "git commit -m direct", commitOutput(firstSha, "feat: add duplicate"))], "claude-code", 2000);
+    const orphan = makeSession("orphan", cwd, [bashTurn(0, "git commit -m duplicate", commitOutput(orphanSha, "feat: orphan duplicate"))], "claude-code", 1000);
+
+    const sel = await selectContributors([repo(orphan), repo(direct)], [reapplySha, revertSha, firstSha], depsFor(cwd, [direct, orphan]));
+
+    expect(sel.contributors.map((c) => c.summary.id)).toEqual(["direct"]);
+    expect(sel.excludedCount).toBe(1);
+  });
+
+  it("does not credit a session that cherry-picked another session's already-claimed unique commit", async () => {
+    // Authorship guard: patch-id proves diff-equality, not authorship. Session `author`
+    // lands a unique-diff commit (direct SHA claim); session `cherry` reproduces the exact
+    // diff as a local orphan (cherry-pick) — its own commit output reports the new SHA.
+    // The orphan's patch-id is unique among the observed branch/orphan sets, so without the
+    // guard it would be promoted onto the author's SHA and bill the cherry session's whole
+    // work to the PR. It must stay uncredited (I2).
+    const cwd = await tempRepo();
+    const main = currentBranch(cwd);
+    const branchSha = await commitFile(cwd, "shared.txt", "shared change\n", "feat: shared change");
+    git(cwd, ["checkout", "--quiet", "-b", "cherry", `${branchSha}~1`]);
+    git(cwd, ["cherry-pick", "--no-edit", branchSha]);
+    const orphanSha = head(cwd);
+    git(cwd, ["checkout", "--quiet", main]);
+
+    const author = makeSession("author", cwd, [bashTurn(0, "git commit -m shared", commitOutput(branchSha, "feat: shared change"))], "claude-code", 1000);
+    const cherry = makeSession("cherry", cwd, [bashTurn(0, "git commit -m mine", commitOutput(orphanSha, "feat: mine"))], "claude-code", 2000);
+
+    const sel = await selectContributors([repo(author), repo(cherry)], [branchSha], depsFor(cwd, [author, cherry]));
+
+    expect(sel.contributors.map((c) => c.summary.id)).toEqual(["author"]);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+
+  it("excludes empty commit targets and orphans from recovery", async () => {
+    const cwd = await tempRepo();
+    const main = currentBranch(cwd);
+    git(cwd, ["checkout", "--quiet", "-b", "empty-orphan"]);
+    git(cwd, ["commit", "--quiet", "--allow-empty", "-m", "empty orphan"]);
+    const orphanSha = head(cwd);
+    git(cwd, ["checkout", "--quiet", main]);
+    git(cwd, ["commit", "--quiet", "--allow-empty", "-m", "empty target"]);
+    const targetSha = head(cwd);
+    const s = makeSession("empty", cwd, [bashTurn(0, "git commit --allow-empty -m empty", commitOutput(orphanSha, "empty orphan"))]);
+
+    const sel = await selectContributors([repo(s)], [targetSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+
+  it("excludes merge commits as recovery targets", async () => {
+    const cwd = await tempRepo();
+    const main = currentBranch(cwd);
+    git(cwd, ["checkout", "--quiet", "-b", "side"]);
+    const sideSha = await commitFile(cwd, "side.txt", "side\n", "feat: side");
+    git(cwd, ["checkout", "--quiet", main]);
+    await commitFile(cwd, "main.txt", "main\n", "feat: main");
+    git(cwd, ["merge", "--quiet", "--no-ff", "-m", "merge side", "side"]);
+    const mergeSha = head(cwd);
+    const s = makeSession("merge-target", cwd, [bashTurn(0, "git commit -m side", commitOutput(sideSha, "feat: side"))]);
+
+    const sel = await selectContributors([repo(s)], [mergeSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+
+  it("is independent of candidate order and recovered claims poison message fallback", async () => {
+    const { cwd, oldSha, newSha } = await amendRepo(false);
+    const branchSubject = "feat: amended branch change";
+    const recovered = makeSession("recovered", cwd, [bashTurn(0, "git commit -m original", commitOutput(oldSha, "feat: original change"))]);
+    const quiet = makeSession("quiet", cwd, [bashTurn(0, `git commit --quiet -m "${branchSubject}"`, "")], "claude-code", 2000);
+
+    for (const order of [
+      [repo(recovered), repo(quiet)],
+      [repo(quiet), repo(recovered)],
+    ]) {
+      const sel = await selectContributors(order, [newSha], depsFor(cwd, [recovered, quiet], [branchSubject]));
+      expect(sel.contributors.map((c) => [c.summary.id, c.basis])).toEqual([["recovered", "anchor"]]);
+      expect(sel.excludedCount).toBe(1);
+    }
+  });
+
+  it("does not fuzzily match a squashed branch commit to any constituent orphan", async () => {
+    const cwd = await tempRepo();
+    const main = currentBranch(cwd);
+    git(cwd, ["checkout", "--quiet", "-b", "pre-squash"]);
+    const first = await commitFile(cwd, "a.txt", "a\n", "feat: a");
+    await commitFile(cwd, "b.txt", "b\n", "feat: b");
+    await commitFile(cwd, "c.txt", "c\n", "feat: c");
+    git(cwd, ["checkout", "--quiet", main]);
+    await writeFile(join(cwd, "a.txt"), "a\n");
+    await writeFile(join(cwd, "b.txt"), "b\n");
+    await writeFile(join(cwd, "c.txt"), "c\n");
+    git(cwd, ["add", "a.txt", "b.txt", "c.txt"]);
+    git(cwd, ["commit", "--quiet", "-m", "feat: squash all"]);
+    const squashSha = head(cwd);
+    const s = makeSession("squashed", cwd, [bashTurn(0, "git commit -m a", commitOutput(first, "feat: a"))]);
+
+    const sel = await selectContributors([repo(s)], [squashSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+});
+
+describe("SPEC-0072 R2/R4/R5 - safety locks around recovery", () => {
+  it("does not recover a message subject from a changed -F file", async () => {
+    const cwd = await tempRepo();
+    const subject = "feat: file supplied subject";
+    await writeFile(join(cwd, "commit.txt"), `${subject}\n\nbody\n`);
+    await writeFile(join(cwd, "file.txt"), "content\n");
+    git(cwd, ["add", "file.txt"]);
+    git(cwd, ["commit", "--quiet", "-F", "commit.txt"]);
+    const branchSha = head(cwd);
+    await writeFile(join(cwd, "commit.txt"), "feat: edited after commit\n");
+    const s = makeSession("file-message", cwd, [bashTurn(0, "git commit -F commit.txt", "")]);
+
+    const sel = await selectContributors([repo(s)], [branchSha], depsFor(cwd, [s], [subject]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+
+  it.each(["-c", "-C"])("does not recover a message subject from git commit %s", async (flag) => {
+    const cwd = await tempRepo();
+    const subject = "feat: reused message subject";
+    const branchSha = await commitFile(cwd, "reuse.txt", "reuse\n", subject);
+    const s = makeSession("reuse-message", cwd, [bashTurn(0, `git commit ${flag} ${branchSha}`, "")]);
+
+    const sel = await selectContributors([repo(s)], [branchSha], depsFor(cwd, [s], [subject]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+
+  it("keeps the Codex helper rule scoped to sessions with writeCount === 0", async () => {
+    const cwd = await tempRepo();
+    const branchSha = await commitFile(cwd, "branch.txt", "branch\n", "feat: branch");
+    const s = makeSession("codex-writer", cwd, [bashTurn(0, "git commit -m x", "nothing to commit, working tree clean")], "codex");
+
+    const sel = await selectContributors([repo(s)], [branchSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(sel.excludedCount).toBe(1);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+
+  it("still credits a direct SHA line from partially captured tee output", async () => {
+    const cwd = await tempRepo();
+    const branchSha = await commitFile(cwd, "tee.txt", "tee\n", "feat: tee");
+    const s = makeSession("tee", cwd, [bashTurn(0, "git commit -m tee | tee log", commitOutput(branchSha, "feat: tee"))]);
+
+    const sel = await selectContributors([repo(s)], [branchSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors.map((c) => [c.summary.id, c.basis])).toEqual([["tee", "anchor"]]);
+    expect(sel.excludedCount).toBe(0);
+  });
+
+  it("labels a fully swallowed git-write output as unanchored when no message fallback applies", async () => {
+    const cwd = await tempRepo();
+    const branchSha = await commitFile(cwd, "swallowed.txt", "swallowed\n", "feat: swallowed output");
+    const s = makeSession("swallowed", cwd, [bashTurn(0, "git commit -F commit.txt > log 2>&1 &", "")]);
+
+    const sel = await selectContributors([repo(s)], [branchSha], depsFor(cwd, [s]));
+
+    expect(sel.contributors).toHaveLength(0);
+    expect(summarizeConfidence(sel.events).unanchoredGitWrite).toBe(1);
+  });
+
+  it("credits an amended committer and a zero-write Codex helper separately", async () => {
+    const { cwd, oldSha, newSha } = await amendRepo(false);
+    const builder = makeSession(
+      "builder",
+      cwd,
+      [
+        bashTurn(0, "git commit -m original", commitOutput(oldSha, "feat: original change")),
+        bashTurn(1, "codex exec 'help with tests'", "done"),
+      ],
+      "claude-code",
+      1000,
+    );
+    const helper = makeSession("helper", cwd, [bashTurn(0, "ls test", "anchorRecovery.test.ts")], "codex", 2000);
+
+    const sel = await selectContributors([repo(builder), repo(helper)], [newSha], depsFor(cwd, [builder, helper]));
+
+    expect(sel.contributors.map((c) => [c.summary.id, c.basis])).toEqual([
+      ["builder", "anchor"],
+      ["helper", "helper"],
+    ]);
+    expect(new Set(sel.contributors.map((c) => c.summary.filePath)).size).toBe(2);
+    expect(sel.excludedCount).toBe(0);
+  });
+});

--- a/test/pr/attribution-fidelity.test.ts
+++ b/test/pr/attribution-fidelity.test.ts
@@ -26,6 +26,7 @@ const OTHER_SHA = "9876fed" + "c".repeat(33);
 const usage = { input: 100, output: 10, cacheRead: 0, cacheWrite: 0 };
 const turn = (index: number, toolCalls: ToolCall[]): Turn => ({ index, timestamp: 1000 + index, model: "claude-opus-4-8", usage, toolCalls });
 const PUSH = "git pu" + "sh";
+const noGit = () => ({ stdout: "", stderr: "", code: 1, missing: false });
 
 describe("R1a — only adapter-flagged shells mint git verbs", () => {
   it("an unflagged tool carrying a command field and SHAs in output yields no verb, no anchor", () => {
@@ -106,6 +107,7 @@ describe("R2 — fallback bounding", () => {
     const sel = await selectContributors(candidates, [BRANCH_SHA], {
       loadSession: async () => s.session as never,
       currentWorktreeRoot: "/home/dev/repo",
+      runGit: noGit,
     });
     expect(sel.contributors).toHaveLength(0);
     expect(sel.excludedCount).toBe(0); // distinct from `excluded` (repo+window, no commit) — SPEC-0024 fence copy stays true
@@ -119,6 +121,7 @@ describe("R2 — fallback bounding", () => {
     const sel = await selectContributors([{ summary: s.summary as never, pool: "anchor" }], [BRANCH_SHA], {
       loadSession: async () => s.session as never,
       currentWorktreeRoot: "/home/dev/repo",
+      runGit: noGit,
     });
     expect(sel.contributors).toHaveLength(1);
     expect(sel.contributors[0].slice.kind).toBe("slice");
@@ -130,6 +133,7 @@ describe("R2 — fallback bounding", () => {
     const sel = await selectContributors([{ summary: s.summary as never, pool: "repo" }], [BRANCH_SHA], {
       loadSession: async () => s.session as never,
       currentWorktreeRoot: "/home/dev/repo",
+      runGit: noGit,
     });
     expect(sel.contributors).toHaveLength(1);
     expect(sel.contributors[0].slice.kind).toBe("full");

--- a/test/pr/confidence.test.ts
+++ b/test/pr/confidence.test.ts
@@ -27,11 +27,13 @@ describe("SPEC-0044 · summarizeConfidence", () => {
       { kind: "unattributable-anchor-pool", sessionId: "a" }, // dup session — counts once
       { kind: "unattributable-anchor-pool", sessionId: "b" },
       { kind: "silenced-git-write", sessionId: "c" },
+      { kind: "unanchored-git-write", sessionId: "e" },
       { kind: "cost-lower-bound-cache-tier", sessionId: "d" },
     ];
     const s = summarizeConfidence(events);
     expect(s.unattributableAnchorPool).toBe(2);
     expect(s.silencedGitWrite).toBe(1);
+    expect(s.unanchoredGitWrite).toBe(1);
     expect(s.costLowerBoundCacheTier).toBe(1);
     expect(s.unreadableSubagent).toBe(0);
   });
@@ -42,9 +44,22 @@ describe("SPEC-0044 · summarizeConfidence", () => {
     expect(isFloored(summarizeConfidence([{ kind: "unattributable-anchor-pool", sessionId: "y" }]))).toBe(true);
     // each disjunct isolated (so a deleted one is caught, not masked by a sibling):
     expect(isFloored(summarizeConfidence([{ kind: "silenced-git-write", sessionId: "s" }]))).toBe(true);
+    expect(isFloored(summarizeConfidence([{ kind: "unanchored-git-write", sessionId: "g" }]))).toBe(true);
     expect(isFloored(summarizeConfidence([{ kind: "unreadable-subagent", sessionId: "sub" }]))).toBe(true);
     expect(isFloored(summarizeConfidence([{ kind: "unreadable-session", sessionId: "u" }]))).toBe(true);
     expect(isFloored(summarizeConfidence([{ kind: "dropped-transcript-records", sessionId: "d" }]))).toBe(true);
+  });
+});
+
+describe("SPEC-0072 R3 · unanchored git-write renders (not silent)", () => {
+  it("floors the total AND renders a distinct git-write note", () => {
+    const body = renderPrReceiptText({
+      contributors: [builder()],
+      excludedCount: 1,
+      confidence: summarizeConfidence([{ kind: "unanchored-git-write", sessionId: "writer.jsonl" }]),
+    });
+    expect(body).toMatch(/TOTAL priced\.+≥/);
+    expect(body).toContain("1 session made git writes that could not be anchored");
   });
 });
 

--- a/test/pr/contributors.test.ts
+++ b/test/pr/contributors.test.ts
@@ -32,6 +32,7 @@ function namedToolTurn(index: number, name: string, input: unknown): Turn {
 }
 
 const CURRENT_ROOT = "/home/dev/repo";
+const noGit = () => ({ stdout: "", stderr: "", code: 1, missing: false });
 
 function makeSession(
   id: string,
@@ -71,6 +72,7 @@ function loaderFor(sessions: Session[]) {
   return {
     loadSession: async (summary: SessionSummary) => byId.get(summary.id) ?? null,
     currentWorktreeRoot: CURRENT_ROOT,
+    runGit: noGit,
   };
 }
 

--- a/test/pr/messageAnchor.test.ts
+++ b/test/pr/messageAnchor.test.ts
@@ -22,6 +22,7 @@ const SUBJ_A = "feat: quiet-committed spec subject A";
 const SUBJ_B = "fix: the other branch commit subject B";
 const usage = withTotal({ ...emptyUsage(), input: 1000, output: 100 });
 const CURRENT_ROOT = "/home/dev/repo";
+const noGit = () => ({ stdout: "", stderr: "", code: 1, missing: false });
 
 function bashTurn(index: number, command: string, output: string): Turn {
   return {
@@ -58,6 +59,7 @@ function loaderFor(sessions: Session[], branchSubjects: readonly string[] = [SUB
     loadSession: async (summary: SessionSummary) => byId.get(summary.id) ?? null,
     currentWorktreeRoot: CURRENT_ROOT,
     branchSubjects,
+    runGit: noGit,
   };
 }
 
@@ -238,6 +240,7 @@ describe("SPEC-0032 R4/R5 · credit through selectContributors", () => {
     const sel = await selectContributors([repo(q)], [SHA_A, SHA_B], {
       loadSession: async () => q,
       currentWorktreeRoot: CURRENT_ROOT,
+      runGit: noGit,
     });
     expect(sel.contributors).toHaveLength(0);
     expect(sel.excludedCount).toBe(1);


### PR DESCRIPTION
## SPEC-0072 — robust PR-receipt attribution (patch-id recovery)

Fixes the attribution fragility found **live dogfooding PR #176**: a committing session showed
"no branch commit" (its SHA anchor was orphaned by `git commit --amend`) while a 1-minute Codex
helper was credited as the whole PR cost.

### What it does
- **Patch-id recovery** (`src/pr/anchorRecovery.ts`): when a session's `git commit` output SHA
  doesn't prefix-match any branch commit (orphaned by `--amend`/rebase/backgrounded output),
  recover it by matching its stable `git patch-id --stable` to **exactly one** branch commit.
  Under-crediting by design (I2 — never a fabricated match): duplicated diffs (add/revert,
  cherry-pick, two orphans same diff), empty/`--allow-empty`, merge commits, missing objects, and
  any git failure → **no** match. Uniqueness is evaluated across **all** branch commits + orphan
  candidates.
- **Authorship guard**: a promotion is rejected if its target branch SHA is already **directly**
  claimed by another session — patch-id proves diff-*equality*, not authorship.
- **`unanchored-git-write` confidence event**: distinguishes "made a git-write we couldn't tie to
  the branch" from "no git-write at all" — floors the total, never invents credit. The Codex
  helper rule stays locked to `writeCount === 0`; no unsafe `-F`/`-c`/`-C` message widening.

### The review caught (and we fixed) a real I2 violation
The build passed every gate, but **adversarial review found a HIGH-severity false-credit path**:
a session that **cherry-picks** another session's unique commit would be mis-credited *and* have
its **entire session billed** to the PR. Fixed with the authorship guard + a real-git regression
test that constructs the exact exploit and asserts no credit; **re-reviewed → REVIEW-OK**. One
strictly-narrower residual (the true author leaves zero direct claim) is documented in the spec's
known-residuals.

### Gates
- `tsc` / `eslint` / `spec-lint` (70) / `verify-goldens` (**102 byte-identical — no rendering
  change**) green.
- 18-row adversarial temp-git matrix (amend / content-changing amend / duplicate-diff /
  empty / merge / cherry-pick / changed-`-F` / `-c`/`-C` / squash / order-independence /
  commit+codex-helper / swallowed-output).
- **Note:** local vitest flakes under concurrent-session load on the dev Mac; **CI's clean runner
  is the authoritative full-suite check.**

SPEC-0072 `status: building`. Follow-up (separate): cross-agent/delegated subagent spend isn't yet
rolled into the PR total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
