### PR TITLE
chore: release v0.6.0 — automatic receipt production + robust attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.5.0):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.6.0):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,
@@ -103,8 +103,15 @@ after each release — don't hand-edit it elsewhere.*
   statusline** — burn rate, context %, `M`/`B` tokens, inline 5h reset countdown (SPEC-0071);
   the **samosa tip link off by default** on PR-posted surfaces, behind `--samosa` (SPEC-0070);
   and a faster parse/preflight path — in-process sqlite, goldens compile cache, parallel
-  preflight (SPEC-0063) — plus **incremental mutation testing** on the money paths (SPEC-0069).
-  40 specs at `status: shipped`.
+  preflight (SPEC-0063) — plus **incremental mutation testing** on the money paths (SPEC-0069);
+  **agent auto-attach** — a hidden `hook pre-push` subcommand wired via a committed
+  `.claude/settings.json` `PreToolUse` hook that writes+pushes the receipt ref on a branch push
+  with no manual command and never blocks the push (SPEC-0073, v0.6.0), completing the two-file
+  adopter kit; and **robust attribution** — `git patch-id` recovery credits a session whose SHA
+  was orphaned by `--amend`/rebase, with an authorship guard so a cherry-pick can't steal credit
+  from a session that already directly claimed the commit (a narrower residual — a cherry-pick
+  onto a branch SHA the true author never claims — is documented in the spec's Non-goals)
+  (SPEC-0072, v0.6.0). 42 specs at `status: shipped`.
 - **In progress (`building`):** SPEC-0044 cost-attribution confidence — its
   implemented slices ship in v0.2.0 (ConfidenceEvent contract + no-silent-drop,
   cost matrix, rows-sum-to-total, cache-write caveat, parse-skip/load-failure

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,34 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
-## v0.5.0 — 2026-07-08
+## v0.6.0 — 2026-07-08
+
+Minor: receipts can now be produced **automatically** on push, and PR attribution is more
+robust. No change to rendered receipt output (goldens byte-identical); both additions are
+opt-in / internal.
+
+### Added
+
+- **Agent auto-attach** (SPEC-0073): a hidden `aireceipts hook pre-push` subcommand, wired as a
+  Claude Code `PreToolUse` hook via a committed `.claude/settings.json`, writes and pushes the
+  receipt ref (`refs/receipts/<slug>`) when the coding agent runs a branch push — so a receipt
+  is produced with no manual command. It **never blocks the push** (exits 0 on every path, no
+  stdout, bounded by the hook timeout) and only acts on a real `origin`/current-branch push
+  (tokenized detection; skips dry-run/delete/tags/non-origin/repo-retargeting/`refs/receipts`).
+  The adopter kit is now **two files** — the `pr-check` workflow (produces nothing on its own)
+  plus the `.claude/settings.json` hook (`docs/adopt/`, `aireceipts integrations`).
+
+### Fixed
+
+- **Robust PR-receipt attribution** (SPEC-0072): a session whose commit SHA was orphaned by
+  `git commit --amend` (or rebase) is now correctly credited by matching its stable
+  `git patch-id` to the branch commit, instead of showing "no branch commit" while an unrelated
+  helper takes the credit. Strictly under-crediting — duplicated diffs, empty/merge commits, and
+  a diff already directly claimed by another session never produce a match (no fabricated or
+  stolen credit, I2). Adds an `unanchored-git-write` confidence signal that floors the total when
+  a real git-write can't be tied to the branch.
+
+
 
 Minor: PR receipts gain a **self-contained CI path** (no external reusable workflow), the
 default **statusline** gets richer, and the **samosa tip link** leaves the default PR-posted

--- a/docs/releases/0.6.0-verdict.md
+++ b/docs/releases/0.6.0-verdict.md
@@ -1,0 +1,82 @@
+# Release verdict — v0.6.0
+
+- **Candidate version:** 0.6.0
+- **Content SHA:** `9ff63f2` (HEAD of `main` after both feature merges)
+- **Changelog range:** `v0.5.0..9ff63f2` — two commits.
+- **Bump rationale:** MINOR — two additive capabilities, no rendered-output/format break (goldens byte-identical).
+- **Date:** 2026-07-08 (UTC)
+
+## Scope
+
+- **SPEC-0072** — robust PR-receipt attribution via `git patch-id` recovery (#179, merged).
+- **SPEC-0073** — agent auto-attach: hidden `hook pre-push` subcommand + two-file adopter kit (#181, merged).
+
+Both flip `building → shipped` (42 shipped). No dependency changes.
+
+## Release-commit note
+
+The release commit adds only the version bump, `docs/CHANGELOG.md` v0.6.0 section, the two spec
+`status: shipped` flips, and the `AGENTS.md` inventory refresh — no code or golden change.
+`release-publish.yml` re-runs the full preflight on the exact tagged SHA.
+
+## Mechanical checks (on `9ff63f2`)
+
+- `node scripts/preflight-release.mjs` → **11/11 RELEASE-READY** (build, lean tarball, spec-lint,
+  hygiene, verify-goldens, tsc, cite-check, eslint, determinism ×10, full vitest incl. tarball
+  install+run e2e).
+- `node scripts/verify-goldens.mjs` → **102 artifacts byte-identical** (no render change).
+- `npx vitest run` → **134 files / 1735 tests passed**, no flake (EM run).
+- Deps: **none** (package.json + package-lock diffs empty vs v0.5.0). `npm audit --production` → 0 vulnerabilities.
+- CI green on the exact SHA `9ff63f2` (CI + scorecard), verified not a cousin.
+- Spec count `grep -rl '^status: shipped' specs/ | wc -l` → **42**, matches AGENTS.md.
+
+## Persona panel (isolated contexts)
+
+### Engineering Manager — GO
+Semver correct (goldens byte-identical). Zero dep changes; ref format (`src/pr/store.ts`)
+untouched → clean `@0.5.0` rollback (and the adopter hook pins `@latest`, so a CLI pin doesn't
+strand it). Adopter `claude-settings.json` is not in the npm `files` list (repo-only). CI verified
+on `9ff63f2`. Full suite 1735/1735, no flake. Both adversarial-review guards present:
+`directlyClaimed` (SPEC-0072 cherry-pick guard, contributors.ts) and `retargeted` (SPEC-0073 `-C`
+guard, gitWrite.ts), with passing regression tests.
+
+### QA / adversarial — GO
+No I2 violation across ~20 probes. `hook pre-push` never wrote stdout, never exited non-zero, and
+never attached on any must-not-attach shape (dry-run/delete/non-origin/`-C` retarget/quoted/
+array-form/compound/non-Bash/empty/malformed/5MB stdin/non-git cwd) — matches the well-commented
+`classifyPush` logic. Core (`--demo`, newest-session, `pr` dry-run) crash-free; all derived figures
+labeled arithmetic/floor, unpriced tokens kept as counts (never converted to $).
+
+## Docs panel (`/review-docs`, blocking) — GO after one fix
+
+Independent honesty review of the v0.6.0 changelog + AGENTS.md against code. Result:
+**DOCS-NO-GO on first pass, one finding**, now fixed:
+
+- **Over-claim (medium): `AGENTS.md` "a cherry-pick can't steal credit"** was unqualified, but the
+  `directlyClaimed` guard only blocks promotion onto a SHA *already directly claimed by another
+  session* — the spec's own Non-goals document a narrower residual (a cherry-pick onto a SHA the
+  true author never claims). **Fixed**: the AGENTS line is now scoped to match the code, the
+  changelog (which was already correctly scoped), and the spec. Note: the changelog claim
+  ("a diff already directly claimed … never produces a match") passed as-is.
+
+All other claims **PASS** against code: SPEC-0073 hook semantics (exit 0 every path, silent on
+stdout *and* stderr — code is stricter than the claim; hidden; telemetry-silent; classifyPush
+skips dry-run/delete/tags/non-origin/retargeted/receipts), the two-file adopter kit, SPEC-0072
+under-crediting mechanics (duplicated/empty/merge → no match), `unanchored-git-write`, goldens
+byte-identical, the 42-spec count, and the building-list frontmatter parity.
+
+## Open risks / follow-ups (non-blocking)
+
+1. **Auto-attach reaches adopters only after this publish** (they run `@latest`), and requires the
+   **two-file kit** — the dogfood repos currently carry only the workflow; a follow-up adds the
+   `.claude/settings.json` hook.
+2. SPEC-0072 known residual (spec Non-goals): a cherry-pick of an author's commit that leaves **zero**
+   direct claim can still be promoted — needs author-identity evidence patch-id can't provide.
+3. #170 (CSV formula-injection), #161 (subagents/ under-count) — carried, pre-existing.
+
+## Verdict
+
+Both personas GO; mechanical gates green on the exact content SHA; goldens byte-identical. Pending
+the blocking docs-panel result (recorded above), this is a GO.
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",

--- a/specs/SPEC-0072-attribution-robustness.md
+++ b/specs/SPEC-0072-attribution-robustness.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0072
 title: Robust branch-commit anchors — amend/orphan patch-id recovery and the helper/committer asymmetry
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0024, SPEC-0032, SPEC-0038, SPEC-0044]
 ---
@@ -186,16 +186,16 @@ inferred into credit.
 
 ## Success criteria
 
-- [ ] R1 recovers message-only/no-diff-change amends using `git patch-id --stable` and a fixed
+- [x] R1 recovers message-only/no-diff-change amends using `git patch-id --stable` and a fixed
       local diff producer, no network, via the injected `CommandRunner` (`src/pr/git.ts`).
-- [ ] R1 uniqueness is evaluated across all branch commits and orphan candidates; duplicated diffs
+- [x] R1 uniqueness is evaluated across all branch commits and orphan candidates; duplicated diffs
       (including one already direct-claimed) never produce a promotion.
-- [ ] Empty/merge/pruned commits under-credit (no promotion, no crash), never fabricate.
-- [ ] No message subject is ever recovered from `-F`/`-c`/`-C` argv; a changed `-F` file produces
+- [x] Empty/merge/pruned commits under-credit (no promotion, no crash), never fabricate.
+- [x] No message subject is ever recovered from `-F`/`-c`/`-C` argv; a changed `-F` file produces
       no credit (adversarial test passes).
-- [ ] A committing session with a real git-write call is never left indistinguishable from a
+- [x] A committing session with a real git-write call is never left indistinguishable from a
       session that made none (R3's new event, R4's locked scope).
-- [ ] The resolved-anchor pass runs before the message-fallback claim pass, preserving SPEC-0032
+- [x] The resolved-anchor pass runs before the message-fallback claim pass, preserving SPEC-0032
       R3a order-independence.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked.

--- a/specs/SPEC-0073-agent-prepush-hook.md
+++ b/specs/SPEC-0073-agent-prepush-hook.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0073
 title: "Agent auto-attach — a hook pre-push subcommand + zero-install adopter kit"
-status: building
+status: shipped
 milestone: M5
 depends: [SPEC-0064, SPEC-0065]
 ---
@@ -133,12 +133,12 @@ ref (SPEC-0065). It **never blocks the push from succeeding** and never fabricat
 
 ## Success criteria
 
-- [ ] `aireceipts hook pre-push` ships (hidden), parses the PreToolUse payload with the tokenized
+- [x] `aireceipts hook pre-push` ships (hidden), parses the PreToolUse payload with the tokenized
       `gitWrite` parser, attaches the ref only on an `origin`/current-branch push, writes zero
       stdout, and exits 0 on every path (push never blocked; bounded delay only).
-- [ ] Per-event settings helpers land; the `.claude/settings.json` PreToolUse entry
+- [x] Per-event settings helpers land; the `.claude/settings.json` PreToolUse entry
       install/idempotency/coexistence with SessionEnd (and pre-existing PreToolUse entries) is
       tested; the two-file adopter kit + `integrations` recipe document it, incl. the
       no-op-without-hook and the sibling-collision warnings.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`, `node scripts/spec-lint.mjs` all pass unmasked.


### PR DESCRIPTION
## Release v0.6.0 — ready to dispatch

Prepares the `0.6.0` cut (content frozen at `main` `9ff63f2`). Merge this, then run
`release-publish.yml` (OIDC, no token). This PR does not publish.

### What ships (two merged features since v0.5.0)

- **Agent auto-attach** (SPEC-0073, #181) — a hidden `hook pre-push` subcommand, wired via a
  committed `.claude/settings.json` PreToolUse hook, writes+pushes the receipt ref on a branch
  push with **no manual command** and **never blocks the push**. Completes the two-file adopter
  kit (workflow + hook). This is the piece that makes receipts generate automatically.
- **Robust attribution** (SPEC-0072, #179) — `git patch-id` recovery credits a session whose SHA
  was orphaned by `--amend`/rebase; strictly under-credits (dup/empty/merge/already-claimed → no
  match); adds an `unanchored-git-write` confidence floor.

Both flip to `status: shipped` (**42 shipped**). No rendered-output change (goldens
byte-identical). No dependency changes.

### Gates & review

- **Release-manager verdict: GO** (`docs/releases/0.6.0-verdict.md`) — EM + QA panels both GO.
- **Docs panel: GO after one fix** — caught an unqualified "cherry-pick can't steal credit"
  over-claim in AGENTS.md; scoped it to match the code + spec (the changelog was already correct).
- **Preflight 11/11**; tsc/eslint/vitest (1735 tests)/goldens/spec-lint (71) green. Codex
  release-commit review: version parity, docs-only diff, claims-match-code, spec statuses, 42
  count, no secrets — all confirmed.

### Follow-ups (non-blocking)

- Auto-attach reaches adopters only after this publish (they run `@latest`), and needs the
  **two-file kit** — the dogfood repos currently carry only the workflow; a follow-up adds the
  `.claude/settings.json` hook.
- SPEC-0072 residual (spec Non-goals): a cherry-pick onto a SHA the true author never claims can
  still be promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
