### PR TITLE
fix: SPEC-0073 pre-push hook timeout 10s->60s (cold-cache npx headroom)

### DIFF
--- a/docs/adopt/claude-settings.json
+++ b/docs/adopt/claude-settings.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "npx -y aireceipts-cli@latest hook pre-push",
-            "timeout": 10
+            "timeout": 60
           }
         ]
       }

--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -135,7 +135,7 @@ who viewed which receipt.
              {
                "type": "command",
                "command": "npx -y aireceipts-cli@latest hook pre-push",
-               "timeout": 10
+               "timeout": 60
              }
            ]
          }

--- a/specs/SPEC-0073-agent-prepush-hook.md
+++ b/specs/SPEC-0073-agent-prepush-hook.md
@@ -68,7 +68,11 @@ ref (SPEC-0065). It **never blocks the push from succeeding** and never fabricat
   them to operate **per event** (add/detect/remove keyed on `(event, command)`), preserving
   unrelated keys, existing SessionEnd entries, and any pre-existing PreToolUse entries. The kit
   adds a `PreToolUse` entry with `matcher: "Bash"` running `npx -y aireceipts-cli@<pin> hook
-  pre-push` with a per-hook `timeout` (bounds R2's delay). It is **separate** from the SessionEnd
+  pre-push` with a per-hook `timeout` (bounds R2's delay). The pre-push timeout is **larger than
+  the SessionEnd `--mini` hook's** (60s vs 10s): its first invocation on a cold npm cache must
+  download the package (incl. the `@resvg/resvg-js` native dep) before it can write the ref, and
+  10s can expire mid-download — silently missing the first push's receipt. 60s is still bounded
+  (the push is never gated on the receipt). It is **separate** from the SessionEnd
   `--mini` entry (SPEC-0006) — both coexist; installing/removing one never touches the other.
   Idempotent: re-adding is a no-op; `(PreToolUse, command)` is the identity key.
 - **R4 — the two-file adopter kit.** `docs/adopt/` documents the automatic setup as **two**

--- a/src/hook/settings.ts
+++ b/src/hook/settings.ts
@@ -17,6 +17,17 @@ export const PRE_PUSH_HOOK_COMMAND = "npx -y aireceipts-cli@latest hook pre-push
  */
 export const HOOK_TIMEOUT_SECONDS = 10;
 
+/**
+ * The pre-push hook needs more headroom than the SessionEnd `--mini` render: it
+ * runs `npx -y aireceipts-cli@latest`, whose FIRST invocation on a cold npm
+ * cache downloads the package (incl. the `@resvg/resvg-js` native dep) before it
+ * can write+push the ref. 10s (SessionEnd's value) can expire mid-download, so
+ * the first push in a fresh clone would silently miss its receipt. 60s is still
+ * a bound (the push is never gated on the receipt; SPEC-0073 R2), just enough for
+ * a cold first run. The internal sibling sets no timeout at all (600s default).
+ */
+export const PRE_PUSH_HOOK_TIMEOUT_SECONDS = 60;
+
 export const SESSION_END_EVENT = "SessionEnd";
 export const PRE_TOOL_USE_EVENT = "PreToolUse";
 
@@ -38,7 +49,7 @@ export const PRE_PUSH_SPEC: HookCommandSpec = {
   event: PRE_TOOL_USE_EVENT,
   matcher: "Bash",
   command: PRE_PUSH_HOOK_COMMAND,
-  timeout: HOOK_TIMEOUT_SECONDS,
+  timeout: PRE_PUSH_HOOK_TIMEOUT_SECONDS,
 };
 
 export function hookCommandEntry(spec: HookCommandSpec): Record<string, unknown> {

--- a/src/setup/integrations.ts
+++ b/src/setup/integrations.ts
@@ -154,7 +154,7 @@ export const INTEGRATION_RECIPES: readonly IntegrationRecipe[] = [
       "          {",
       '            "type": "command",',
       '            "command": "npx -y aireceipts-cli@latest hook pre-push",',
-      '            "timeout": 10',
+      '            "timeout": 60',
       "          }",
       "        ]",
       "      }",

--- a/test/hook/settings.test.ts
+++ b/test/hook/settings.test.ts
@@ -105,7 +105,7 @@ describe("SPEC-0073 PreToolUse hook settings", () => {
     expect(entry.hooks[0].type).toBe("command");
     expect(entry.hooks[0].command).toBe(PRE_PUSH_HOOK_COMMAND);
     expect(entry.hooks[0].command).toContain("@latest hook pre-push");
-    expect(entry.hooks[0].timeout).toBe(10);
+    expect(entry.hooks[0].timeout).toBe(60);
   });
 
   it("adds alongside existing SessionEnd and PreToolUse entries without touching them", () => {


### PR DESCRIPTION
## Fix: pre-push auto-attach hook timeout 10s → 60s

The SPEC-0073 adopter auto-attach hook (`.claude/settings.json` `PreToolUse`) reused the
SessionEnd hook's `timeout: 10`. But the pre-push hook's **first** invocation on a cold npm
cache must `npx -y` download `aireceipts-cli` (incl. the `@resvg/resvg-js` native dep) before
it can write the ref — 10s can expire mid-download, so the first push in a fresh clone
silently misses its receipt (self-heals on the next push; never blocks the push either way).
The internal sibling sets **no** timeout (600s default); **60s** is enough for a cold first
run while staying bounded (the push is never gated on the receipt — SPEC-0073 R2).

### Changes
- New `PRE_PUSH_HOOK_TIMEOUT_SECONDS = 60` (`src/hook/settings.ts`); `PRE_PUSH_SPEC` uses it.
  `HOOK_TIMEOUT_SECONDS = 10` (SessionEnd `--mini`, fast render) is **unchanged**.
- Bumped the adopter template (`docs/adopt/claude-settings.json`), the `integrations` recipe
  (`src/setup/integrations.ts`), the `docs/pr-receipts.md` example, the settings test, and the
  SPEC-0073 R3 rationale.

### Provenance
Found by the org dogfood PR review bots (Codex P2 "allow enough time for first-run npx"). The
same bots' "timeout is milliseconds" claim was a **false positive** — Claude Code hook timeouts
are **seconds** (verified against the official docs), so the value was never ~10ms.

### Gates
tsc / eslint / vitest / spec-lint green; goldens **102 byte-identical**; preflight **11/11**.
Codex diff review: **REVIEW-OK** (SessionEnd untouched, seconds confirmed, no golden drift).

Note: the 10 org dogfood auto-attach PRs were already bumped to 60 directly; this aligns the
aireceipts source so future adopters + the rollout generator inherit 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
