### PR TITLE
chore: release v0.6.1 — pre-push hook timeout headroom

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.6.0):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.6.1):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.6.1 — 2026-07-08
+
+Patch: the agent auto-attach hook (SPEC-0073) shipped with a 10s `timeout` — too tight for its
+**first** `npx -y aireceipts-cli@latest` run on a cold npm cache (which downloads the package,
+including the `@resvg/resvg-js` native dep, before it can write the ref). On a fresh clone the
+first push could hit the timeout and silently skip its receipt. Bumped the pre-push hook timeout
+to **60s** (still bounded — the push is never gated on the receipt). The SessionEnd `--mini` hook
+timeout is unchanged (10s). No other behavior change; rendered output is byte-identical.
+
 ## v0.6.0 — 2026-07-08
 
 Minor: receipts can now be produced **automatically** on push, and PR attribution is more

--- a/docs/releases/0.6.1-verdict.md
+++ b/docs/releases/0.6.1-verdict.md
@@ -1,0 +1,55 @@
+# Release verdict — v0.6.1
+
+- **Candidate version:** 0.6.1 (patch)
+- **Content SHA:** `b16b671` (HEAD of `main` after #183)
+- **Changelog range:** `v0.6.0..b16b671` — one commit (#183).
+- **Bump rationale:** PATCH — a single config value (`PRE_PUSH_HOOK_TIMEOUT_SECONDS` 10 → 60) plus
+  the docs/recipe/test that carry it. No runtime-logic change, no format change (goldens
+  byte-identical).
+- **Date:** 2026-07-08 (UTC)
+
+## Right-sizing (why not the full 4-persona panel)
+
+The `/release-manager` panel exists to judge risk, the product's face, and the release story.
+This release changes **no product logic, no rendered output, no dependency, and no public API** —
+it raises one hook's timeout constant and updates the docs/test that mirror it. Designer (goldens
+byte-identical) and PM (no user-facing surface or story change beyond the changelog line, verified
+below) findings are structurally empty. So the verdict is scoped to the **mechanical gates + an EM
+risk pass + a docs-honesty check**, which are the only lenses with signal here. This is a
+documented right-sizing, not a skipped gate.
+
+## Scope
+
+- **#183** — SPEC-0073 pre-push hook `timeout` 10s → 60s (cold-cache first-run `npx` headroom).
+  SessionEnd `--mini` hook timeout unchanged (10s). SPEC-0073 stays `shipped` (already shipped in
+  v0.6.0; this is a follow-up fix). No spec-status flips; 42 specs shipped, unchanged.
+
+## Mechanical checks (on `b16b671` + the release edits)
+
+- `node scripts/preflight-release.mjs` → **11/11 RELEASE-READY** (see below).
+- `node scripts/verify-goldens.mjs` → **102 byte-identical** (confirmed in preflight + #183's Codex review).
+- Dep delta: **none**. `package.json` + `package-lock.json` change only the version to 0.6.1.
+- CI green on `b16b671` (the merged #183 head).
+
+## EM risk pass
+
+- **Semver**: PATCH correct — no new capability, no break, additive-safe config change.
+- **Rollback**: trivial — pin `@0.6.0`; the only difference is a hook timeout value, no persistent
+  state or format involved.
+- **Blast radius**: the changed constant feeds only `PRE_PUSH_SPEC` (the adopter auto-attach hook).
+  A larger timeout can only *reduce* first-run receipt misses; it never blocks or gates a push
+  (SPEC-0073 R2, unchanged). SessionEnd path provably untouched (separate constant, its test still
+  asserts 10 — verified in #183's Codex review, REVIEW-OK).
+
+## Docs-honesty check (the one changelog claim)
+
+The v0.6.1 changelog states the timeout was 10s, is now 60s, is in **seconds**, and the SessionEnd
+hook is unchanged — all verified against `src/hook/settings.ts` in #183 (Codex REVIEW-OK, and the
+"seconds" unit confirmed against the official Claude Code hooks docs). No over-claim.
+
+## Verdict
+
+Mechanical gates green; the change is a bounded, logic-free config fix with byte-identical output
+and a trivial rollback. The panel is right-sized to the gates with signal, all of which pass.
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Release v0.6.1 — ready to dispatch

Patch release. Merge this, then run `release-publish.yml` (OIDC, no token). This PR does not publish.

### What ships (one fix since v0.6.0)

- **Pre-push hook timeout 10s → 60s** (#183, SPEC-0073). The auto-attach hook's `timeout` was
  copied from the SessionEnd `--mini` hook (10s), too tight for its first `npx -y aireceipts-cli`
  run on a cold npm cache (downloads incl. the `@resvg/resvg-js` native dep before it can write
  the ref) — so the first push in a fresh clone could silently miss its receipt. 60s is still
  bounded (the push is never gated on the receipt — SPEC-0073 R2). SessionEnd hook unchanged (10s).

No rendered-output change (goldens byte-identical). No dependency changes. No spec-status flips
(SPEC-0073 already shipped in v0.6.0).

### Gates & review

- **Release-manager verdict: GO** (`docs/releases/0.6.1-verdict.md`), right-sized for a logic-free
  config/docs patch (mechanical gates + EM risk pass + docs-honesty check).
- **Preflight 11/11**; Codex release-commit review REVIEW-OK (docs/version-only, versions match,
  changelog honest, no secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
