### PR TITLE
feat: telemetry on by default in CI (reverse SPEC-0002 CI default-off)

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -8,7 +8,7 @@
 - **Never sent**: transcript content, prompts, file paths, repo names, hostnames, usernames, session IDs, dollar amounts, raw model strings, raw counts, or raw timestamps.
 - **Pseudonymous install identity**: when telemetry is enabled, a random install id is stored locally and sent only as a salted sha256 hash so events from the same install can be counted over time. Delete `~/.aireceipts/state.json` to reset it.
 - **Disable anytime**: `AIRECEIPTS_TELEMETRY=off` (or `0`/`false`) or `DO_NOT_TRACK=1`. Either one results in **zero network calls** and prevents install-id creation on a fresh install.
-- **Off by default in CI**: when `CI` or `GITHUB_ACTIONS` is set, telemetry defaults to disabled — no separate opt-out needed. Set `AIRECEIPTS_TELEMETRY=on` to opt a CI environment back in; the kill switches above still win over that.
+- **On by default in CI too**: `CI`/`GITHUB_ACTIONS` environments are treated the same as any other — telemetry is enabled by default there. Use a kill switch (`AIRECEIPTS_TELEMETRY=off` or `DO_NOT_TRACK=1`) to disable it in CI. (Before v0.7.0 it defaulted off in CI; reversed — see SPEC-0002.)
 - **Inspect before you decide**: `aireceipts --telemetry-show` prints exactly what the current run would send, and sends nothing.
 - **Bounded and fail-safe**: sending is capped at 300ms and can never throw, hang the CLI, or change its exit code.
 
@@ -27,7 +27,7 @@ Every field below is validated against a `.strict()` zod schema before it is que
 | `agentType` | enum | `claude-code` \| `codex` \| `cursor` \| `gemini` \| `opencode` \| `unknown` | Which agent format was parsed, if known. |
 | `durationBucket` | enum | `<100ms` \| `100-500ms` \| `500ms-2s` \| `2-10s` \| `>10s` | Coarse bucket; never raw milliseconds. |
 | `ok` | boolean | | Whether the command returned exit code 0. |
-| `isCI` | boolean | | True when `CI` or `GITHUB_ACTIONS` is set and not false. Note: telemetry is disabled by default in CI (see Kill switches below), so this field is `true` only on the runs where `AIRECEIPTS_TELEMETRY=on` explicitly re-enabled it. |
+| `isCI` | boolean | | True when `CI` or `GITHUB_ACTIONS` is set and not false. Telemetry is enabled by default in CI, so this field distinguishes CI runs from human runs in the data. |
 | `installHash` | string | 64-hex sha256 or `unavailable` | Salted hash of the random local install id; raw id never leaves disk. |
 | `runOrdinalBucket` | enum | `1` \| `2-3` \| `4-10` \| `11-50` \| `>50` \| `unavailable` | Lifetime run ordinal bucket; never the raw count. |
 | `handoffFormat` | enum (optional) | `text` \| `json` | SPEC-0042: emission mode, present only on handoff-command runs — never content. |
@@ -167,15 +167,20 @@ AIRECEIPTS_TELEMETRY=off aireceipts ...
 DO_NOT_TRACK=1 aireceipts ...
 ```
 
-### CI default-off
+### CI behavior (on by default)
 
-Telemetry also defaults to disabled whenever `CI` or `GITHUB_ACTIONS` is set (the same detection used for the `isCI` field above) — a fleet of automated runs should not silently dwarf human usage in the data, and CI shouldn't need a separate manual opt-out. This is a default, not a third kill switch: an explicit override re-enables it —
+Telemetry is **enabled by default in CI**, the same as any other environment — `CI` and
+`GITHUB_ACTIONS` are not special-cased. Automated CI runs are counted; the `isCI` field (above)
+records whether a run was in CI so CI vs. human usage stays distinguishable in the data. To turn
+telemetry **off** in a CI environment, use a kill switch:
 
 ```bash
-AIRECEIPTS_TELEMETRY=on aireceipts ...   # re-enables telemetry even when CI/GITHUB_ACTIONS is set
+AIRECEIPTS_TELEMETRY=off aireceipts ...   # or DO_NOT_TRACK=1 — disables telemetry in CI or anywhere
 ```
 
-Precedence is: `AIRECEIPTS_TELEMETRY=off`/`DO_NOT_TRACK=1` (always win) → CI default-off (unless explicitly overridden with `on`) → the connection-string checks below. Outside CI, behavior is unchanged.
+Precedence is: `AIRECEIPTS_TELEMETRY=off`/`DO_NOT_TRACK=1` (always win) → the connection-string
+checks below. (Before v0.7.0, telemetry defaulted **off** in CI; that default was reversed — see
+SPEC-0002's 2026-07-08 amendment.)
 
 ## Inspecting what would be sent
 

--- a/specs/SPEC-0002-diagnostics-telemetry.md
+++ b/specs/SPEC-0002-diagnostics-telemetry.md
@@ -104,15 +104,21 @@ minimized (commandClass enum {receipt, compare, other}, no raw commands) to be u
 as usage analytics. **S3 (value):** parse_failure is the format-drift sensor the
 maintenance loop needs; cli_error is table-stakes for an npx tool. **S4:** spec-lint green.
 
-**2026-07-05 · Amendment (maintainer decision):** R4 is extended — telemetry also
-defaults to disabled when running in CI (`CI`/`GITHUB_ACTIONS` env detected, same
-signal as SPEC-0043's `isCI` field), unless explicitly re-enabled with
-`AIRECEIPTS_TELEMETRY=on`. This is a default, not a third kill switch: `off`/`0`/`false`
-and `DO_NOT_TRACK=1` still disable unconditionally and win over `on` even in CI. Rationale:
-a fleet of automated runs shouldn't silently dwarf human usage in the data, and CI
-shouldn't need a separate manual opt-out. Implemented in `src/telemetry/config.ts`
-(`ciDefaultOffActive`); `docs/telemetry.md` kill-switches section updated;
-`config.test.ts` covers the full precedence table (CI+unset→off, CI+on→on, CI+off→off,
-CI+DO_NOT_TRACK→off even combined with `on`, non-CI unchanged). No change to the `isCI`
-event field itself, which still reports raw CI-env presence independent of whether
-telemetry is enabled (see `src/telemetry/index.ts#noteRunStart`).
+**2026-07-05 · Amendment — ⚠️ SUPERSEDED by the 2026-07-08 amendment below (CI now
+defaults ON). Kept for history; this paragraph no longer describes current behavior.**
+~~R4 is extended — telemetry also defaults to disabled when running in CI
+(`CI`/`GITHUB_ACTIONS` env detected), unless explicitly re-enabled with
+`AIRECEIPTS_TELEMETRY=on`. Rationale: a fleet of automated runs shouldn't silently dwarf
+human usage in the data.~~ (Reversed 2026-07-08 — see below.)
+
+**2026-07-08 · Amendment (maintainer decision — SUPERSEDES the 2026-07-05 CI default):**
+the CI default-off is **reversed**. Telemetry now defaults to **enabled in CI**, the same
+as any other environment, so automated CI runs are counted by default (the maintainer wants
+that adoption signal). CI is no longer a special case in `resolveTelemetryConfig` — the
+`ciDefaultOffActive` gate is removed. The two kill switches (`AIRECEIPTS_TELEMETRY=off|0|false`,
+`DO_NOT_TRACK=1`) still win everywhere, in CI or not, and an empty/malformed connection string
+still disables. The `isCI` event field is unchanged and still records CI-env presence, so CI vs.
+human usage remains distinguishable in the data. `config.test.ts` updated: CI+unset→**on**,
+CI+off→off, CI+DO_NOT_TRACK→off, non-CI unchanged. Note: this broadens what CI environments send
+(every adopter's CI, unless they set a kill switch); the first-run notice + kill switches remain
+the consent mechanism.

--- a/src/telemetry/config.test.ts
+++ b/src/telemetry/config.test.ts
@@ -20,24 +20,24 @@ describe("R4: kill switches disable telemetry", () => {
   });
 });
 
-describe("CI default-off (2026-07-05 amendment): explicit on beats CI, kill switches beat everything", () => {
+describe("CI default-on (2026-07-08 amendment): CI is enabled by default like any env; kill switches beat everything", () => {
   it.each([
     ["CI unset, AIRECEIPTS_TELEMETRY unset", {}, true],
-    ["CI=true, AIRECEIPTS_TELEMETRY unset", { CI: "true" }, false],
+    ["CI=true, AIRECEIPTS_TELEMETRY unset (now on by default)", { CI: "true" }, true],
     ["CI=true, AIRECEIPTS_TELEMETRY=on", { CI: "true", AIRECEIPTS_TELEMETRY: "on" }, true],
-    ["CI=true, AIRECEIPTS_TELEMETRY=off", { CI: "true", AIRECEIPTS_TELEMETRY: "off" }, false],
-    ["CI=true, DO_NOT_TRACK=1, AIRECEIPTS_TELEMETRY=on", { CI: "true", DO_NOT_TRACK: "1", AIRECEIPTS_TELEMETRY: "on" }, false],
-    ["GITHUB_ACTIONS=1, AIRECEIPTS_TELEMETRY unset", { GITHUB_ACTIONS: "1" }, false],
+    ["CI=true, AIRECEIPTS_TELEMETRY=off (kill switch wins)", { CI: "true", AIRECEIPTS_TELEMETRY: "off" }, false],
+    ["CI=true, DO_NOT_TRACK=1 (kill switch wins)", { CI: "true", DO_NOT_TRACK: "1" }, false],
+    ["GITHUB_ACTIONS=1, AIRECEIPTS_TELEMETRY unset (now on by default)", { GITHUB_ACTIONS: "1" }, true],
     ["CI=false, AIRECEIPTS_TELEMETRY unset (not CI)", { CI: "false" }, true],
   ] as const)("%s -> enabled=%s", (_label, env, expectedEnabled) => {
     const config = resolveTelemetryConfig({ ...env, AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN });
     expect(config.enabled).toBe(expectedEnabled);
   });
 
-  it("non-CI runs are unaffected by the amendment — off/on/unset behave exactly as before", () => {
-    expect(resolveTelemetryConfig({ AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN }).enabled).toBe(true);
-    expect(resolveTelemetryConfig({ AIRECEIPTS_TELEMETRY: "off", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN }).enabled).toBe(false);
-    expect(resolveTelemetryConfig({ AIRECEIPTS_TELEMETRY: "on", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN }).enabled).toBe(true);
+  it("kill switches still disable telemetry in CI", () => {
+    expect(resolveTelemetryConfig({ CI: "true", AIRECEIPTS_TELEMETRY: "off", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN }).enabled).toBe(false);
+    expect(resolveTelemetryConfig({ CI: "true", DO_NOT_TRACK: "1", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN }).enabled).toBe(false);
+    expect(resolveTelemetryConfig({ GITHUB_ACTIONS: "1", AIRECEIPTS_TELEMETRY: "0", AIRECEIPTS_TELEMETRY_CONNECTION: VALID_CONN }).enabled).toBe(false);
   });
 });
 

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -1,5 +1,3 @@
-import { isCiEnv } from "./helpers.js";
-
 /**
  * Kill-switch and connection-string resolution (SPEC-0002 R4, and the
  * connection-string-honesty success criterion). Resolved at call time from
@@ -9,14 +7,14 @@ import { isCiEnv } from "./helpers.js";
  * do) are always honored, mirroring `parse/cursor.ts`'s `CURSOR_DB_PATH`
  * resolve-at-call-time convention.
  *
- * Amendment (2026-07-05, maintainer decision): telemetry also defaults to
- * disabled when running in CI (same `CI`/`GITHUB_ACTIONS` detection as the
- * `isCI` event field — see `helpers.ts#isCiEnv`), so a fleet of automated
- * runs doesn't silently dwarf human usage in the data. This is a *default*,
- * not a third kill switch: an explicit `AIRECEIPTS_TELEMETRY=on` re-enables
- * it in CI for orgs that intentionally want that signal. The two real kill
- * switches (`AIRECEIPTS_TELEMETRY=off|0|false`, `DO_NOT_TRACK=1`) are
- * checked first and always win, in CI or not, even if `on` is also set.
+ * Amendment (2026-07-08, maintainer decision): telemetry defaults to
+ * ENABLED in CI, same as any other environment — the earlier 2026-07-05
+ * CI-default-off amendment is reversed so automated CI runs are counted by
+ * default. CI is no longer a special case here; the `isCI` event field still
+ * records whether a run was in CI (see `helpers.ts#isCiEnv`) so CI vs. human
+ * usage stays distinguishable in the data. The two kill switches
+ * (`AIRECEIPTS_TELEMETRY=off|0|false`, `DO_NOT_TRACK=1`) still win everywhere,
+ * in CI or not, and an empty/malformed connection string still disables it.
  */
 
 /**
@@ -59,19 +57,6 @@ function killSwitchActive(env: NodeJS.ProcessEnv): boolean {
   return env.DO_NOT_TRACK === "1";
 }
 
-/**
- * CI default-off (2026-07-05 amendment): active when running in CI and the
- * user hasn't explicitly opted back in with `AIRECEIPTS_TELEMETRY=on`.
- * Checked only after {@link killSwitchActive} — `off`/`DO_NOT_TRACK` always
- * win regardless of CI.
- */
-function ciDefaultOffActive(env: NodeJS.ProcessEnv): boolean {
-  if (explicitTelemetryValue(env) === "on") {
-    return false;
-  }
-  return isCiEnv(env);
-}
-
 function resolveConnectionString(env: NodeJS.ProcessEnv): string {
   return env.AIRECEIPTS_TELEMETRY_CONNECTION !== undefined ? env.AIRECEIPTS_TELEMETRY_CONNECTION : DEFAULT_CONNECTION_STRING;
 }
@@ -111,9 +96,6 @@ function parseConnectionString(raw: string): { instrumentationKey: string; inges
  */
 export function resolveTelemetryConfig(env: NodeJS.ProcessEnv = process.env): TelemetryConfig {
   if (killSwitchActive(env)) {
-    return { enabled: false, instrumentationKey: undefined, ingestionEndpoint: undefined };
-  }
-  if (ciDefaultOffActive(env)) {
     return { enabled: false, instrumentationKey: undefined, ingestionEndpoint: undefined };
   }
   const parsed = parseConnectionString(resolveConnectionString(env));


### PR DESCRIPTION
## Telemetry on by default in CI (reverse the SPEC-0002 CI default-off)

Maintainer decision (2026-07-08): reverse the 2026-07-05 CI-default-off amendment so telemetry
defaults to **enabled in CI**, the same as any other environment. Automated CI runs are now
counted by default.

### Changes
- `src/telemetry/config.ts`: remove the `ciDefaultOffActive` gate (+ the now-unused `isCiEnv`
  import). `resolveTelemetryConfig` no longer special-cases CI; enablement is kill-switches →
  connection-string only. Kill switches (`AIRECEIPTS_TELEMETRY=off|0|false`, `DO_NOT_TRACK=1`)
  still win everywhere; empty/malformed connection string still disables.
- `isCI` event field unchanged (`helpers.ts#isCiEnv`) — still records CI-env presence, so CI vs.
  human usage stays distinguishable in the data.
- `config.test.ts`: CI cases flipped (CI+unset → **on**; CI+off / CI+DO_NOT_TRACK → off).
- `SPEC-0002`: 2026-07-08 amendment superseding the 2026-07-05 one (old block struck through +
  marked SUPERSEDED). `docs/telemetry.md`: "CI behavior (on by default)" + kill-switch-to-disable.

### Blast radius (called out honestly)
This broadens what CI environments send — **every adopter's CI** now emits content-free telemetry
unless they set a kill switch, not just AltimateAI's. The first-run notice + kill switches remain
the consent mechanism (I4). Telemetry payloads stay content-free (no repo name, PR number, or
dollar amount) — so this does **not** enable per-repo attribution of receipts.

### Gates
tsc / eslint / vitest (142 telemetry tests) / spec-lint (71) green; goldens byte-identical (no
rendered-output change). Codex diff review: REVIEW-OK (kill switches still win; no stale
"off in CI" claim remains active in docs/specs).

Note: takes effect for the dogfood repos once published to `@latest` (they run `npx …@latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
