### PR TITLE
chore: release v0.7.0 — telemetry on by default in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.6.1):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.7.0):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.7.0 — 2026-07-08
+
+Minor: **telemetry now defaults to enabled in CI**, reversing the v0.6.x CI-default-off behavior.
+Automated CI runs (e.g. the `pr-check` action) are now counted by default, so CI adoption shows up
+in the data. CI is no longer special-cased — the `isCI` field still distinguishes CI from human
+runs. **Both kill switches still win everywhere**: set `AIRECEIPTS_TELEMETRY=off` (or `0`/`false`)
+or `DO_NOT_TRACK=1` to disable telemetry in CI or anywhere; an empty/malformed connection string
+also disables. Telemetry payloads remain content-free (no transcript, prompts, file paths, repo
+names, or dollar amounts — invariant I4). See SPEC-0002's 2026-07-08 amendment and `docs/telemetry.md`.
+
 ## v0.6.1 — 2026-07-08
 
 Patch: the agent auto-attach hook (SPEC-0073) shipped with a 10s `timeout` — too tight for its

--- a/docs/releases/0.7.0-verdict.md
+++ b/docs/releases/0.7.0-verdict.md
@@ -1,0 +1,61 @@
+# Release verdict — v0.7.0
+
+- **Candidate version:** 0.7.0 (minor)
+- **Content SHA:** `2343ae7` (HEAD of `main` after #185)
+- **Changelog range:** `v0.6.1..2343ae7` — one commit (#185).
+- **Bump rationale:** MINOR — a user-visible behavior change (telemetry now collects in CI where it
+  previously defaulted off). No API/format break; goldens byte-identical.
+- **Date:** 2026-07-08 (UTC)
+
+## Right-sizing (why not the full 4-persona panel)
+
+Small, self-contained behavior change: remove the CI-default-off gate in
+`src/telemetry/config.ts` + its tests + the SPEC-0002/docs text. No rendered output changes
+(Designer empty — goldens byte-identical), no new user-facing command or surface (PM story is the
+one changelog line, verified below). Verdict scoped to the **mechanical gates + EM risk pass + a
+docs-honesty/privacy check** — the lenses with signal. Documented right-sizing, not a skipped gate.
+
+## Scope
+
+- **#185** — reverse the 2026-07-05 CI-default-off amendment; telemetry defaults ENABLED in CI.
+  Kill switches (`AIRECEIPTS_TELEMETRY=off|0|false`, `DO_NOT_TRACK=1`) and empty/malformed
+  connection string still disable. `isCI` event field unchanged. SPEC-0002 amended in place
+  (already `shipped`); no spec-status flips; 42 specs shipped, unchanged.
+
+## Mechanical checks (on `2343ae7` + release edits)
+
+- `node scripts/preflight-release.mjs` → **11/11 RELEASE-READY**.
+- `node scripts/verify-goldens.mjs` → **102 byte-identical** (no render change).
+- `npx vitest run src/telemetry/` → 142 tests green (the flipped CI precedence table).
+- Deps: **none**. package.json + lock change only the version.
+- CI green on `2343ae7`.
+
+## EM risk pass
+
+- **Semver**: MINOR correct — additive behavior change, no break.
+- **Rollback**: pin `@0.6.1` to restore CI-default-off; no persistent state or format involved.
+- **Blast radius (the real risk, called out)**: this broadens telemetry collection to **every
+  adopter's CI**, not just AltimateAI's — automated CI runs now send content-free telemetry unless
+  a kill switch is set. Consent basis unchanged: first-run notice + the two kill switches (I4).
+  Payloads remain content-free (no transcript, prompt, path, repo name, or dollar amount), so no
+  new privacy surface beyond volume/CI-origin. Accepted by the maintainer as a deliberate decision.
+
+## Docs-honesty / privacy check
+
+Changelog + SPEC-0002 + docs/telemetry.md all state telemetry is now ON by default in CI, name the
+kill-switch-to-disable path, and preserve the I4 content-free guarantee. The old CI-default-off
+text is struck through + marked SUPERSEDED (no active stale claim). Verified by Codex on #185
+(REVIEW-OK) and a follow-up stale-text re-check (REVIEW-OK).
+
+## Open risks / follow-ups (non-blocking)
+
+1. Telemetry is content-free — it will show CI `pr-check` volume + verdict buckets, never per-repo
+   attribution of receipts. Not a defect; a property of I4.
+2. Takes effect for dogfood repos only after publish (they run `@latest`).
+
+## Verdict
+
+Mechanical gates green; behavior change is bounded, reversible, and honestly documented; the
+broadened-collection blast radius is a deliberate maintainer decision recorded above.
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## Release v0.7.0 — telemetry on by default in CI

Minor release. Merge, then run `release-publish.yml` (OIDC, no token). This PR does not publish.

### What ships (one change since v0.6.1)
- **Telemetry defaults to enabled in CI** (#185) — reverses the v0.6.x CI-default-off. Automated CI
  runs (e.g. the `pr-check` action) are now counted by default. Kill switches
  (`AIRECEIPTS_TELEMETRY=off|0|false`, `DO_NOT_TRACK=1`) and empty/malformed connection string
  still disable; the `isCI` field still distinguishes CI from human runs. Payloads stay
  content-free (I4).

**Blast radius:** broadens telemetry collection to every adopter's CI, not just AltimateAI's —
deliberate maintainer decision (recorded in the verdict). Consent basis unchanged (first-run notice
+ kill switches). No per-repo attribution (payloads are content-free).

### Gates & review
- **Verdict: GO** (`docs/releases/0.7.0-verdict.md`), right-sized for a small reversible behavior change.
- **Preflight 11/11**; 142 telemetry tests green; goldens byte-identical; Codex release-commit review REVIEW-OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
