### PR TITLE
docs: fix stale "auto-off in CI" telemetry claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ built it ([how](docs/pr-receipts.md)). Local, with no accounts and no servers: y
 transcripts and code never leave your machine, and pricing a receipt needs no network —
 it uses cited, bundled price tables. (aireceipts does send anonymous, opt-out usage
 [telemetry](#telemetry-disclosed) — turn it off with `AIRECEIPTS_TELEMETRY=off` or
-`DO_NOT_TRACK=1`; it is auto-off in CI.)
+`DO_NOT_TRACK=1`, in CI or anywhere.)
 
 ## Install — four steps, first receipt in under a minute
 


### PR DESCRIPTION
v0.7.0 reversed the CI default-off (telemetry now defaults **on** in CI), but the README intro still said telemetry "is auto-off in CI" — a now-false claim on the most-read surface (I3). Corrected to match `docs/telemetry.md` and SPEC-0002 2026-07-08 amendment: turn it off with `AIRECEIPTS_TELEMETRY=off` or `DO_NOT_TRACK=1`, in CI or anywhere. Docs-only, one line. Codex: REVIEW-OK. Refreshes the GitHub README on merge; npm copy folds into the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)