### PR TITLE
docs: launch-ready README — receipt-first, three-command quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,31 +22,12 @@ $172.76. <a href="https://github.com/anandgupta42/receipts/pull/131#issuecomment
 **Why this exists.** AI coding agents spend real money invisibly — you see the diff,
 never the bill. aireceipts reads the transcripts your agent already writes to disk and
 turns them into receipts: what a session cost, tool by tool; what a PR cost, across
-every supported agent session it can attribute; where tokens were wasted. This repo
-runs on it — every pull request here carries the receipt of the agent sessions that
-built it ([how](docs/pr-receipts.md)). Local, with no accounts and no servers: your
-transcripts and code never leave your machine, and pricing a receipt needs no network —
-it uses cited, bundled price tables. (aireceipts does send anonymous, opt-out usage
-[telemetry](#telemetry-disclosed) — turn it off with `AIRECEIPTS_TELEMETRY=off` or
-`DO_NOT_TRACK=1`, in CI or anywhere.)
+every session it can attribute; where tokens were wasted. It's local — your transcripts
+and code never leave your machine, and pricing needs no network. The only thing that
+ever leaves is a receipt you choose to share, and it carries cost and token numbers
+only, never your code or prompts ([how](docs/pr-receipts.md)).
 
-## Install — four steps, first receipt in under a minute
-
-1. **See a receipt.** `npx aireceipts-cli` — renders your newest agent session found
-   anywhere on your machine (not scoped to the current folder), no install, no account
-   (`npx aireceipts-cli --demo` shows a bundled example if you have no sessions yet).
-2. **Get your bearings.** `npx aireceipts-cli setup` — found sessions, latest cost,
-   week total, and the integrations that fit your machine
-   ([guide](docs/guide/01-getting-started.md)).
-3. **Make it always-on.** `npx aireceipts-cli install-hook` ends every Claude Code session
-   with a mini-receipt; `npx aireceipts-cli statusline` puts the live cost in the status bar.
-4. **Put receipts on your PRs.** `npx aireceipts-cli pr --post` posts the comment shown above.
-   Generation stays local; a drop-in [CI check](docs/adopt/pr-receipt-check-caller.yml)
-   can then verify every PR carries one ([guide](docs/pr-receipts.md)).
-
-Prefer a global install: `npm i -g aireceipts-cli`, then the command is `aireceipts`.
-
-What you get back, as the bytes your terminal prints:
+Here's what one looks like — the exact bytes your terminal prints:
 
 ```
 - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -76,11 +57,29 @@ same tokens on claude-haiku-4-5...$0.04 (78% less)
 <sub>the same receipt renders as a shareable SVG (`--svg`, light and dark themes),
 versioned JSON (`--json`), or CSV (`--csv`).</sub>
 
-## Usage
+## Start here — three commands
+
+**See what a session cost** — `npx aireceipts-cli`
+Tool by tool, locally, including where tokens went to waste. No install, no account
+(`--demo` shows a bundled example if you have no sessions yet).
+
+**Live cost in your status bar** — `npx aireceipts-cli statusline`
+Claude Code's status line shows running cost as you work, not just a total at the end.
+
+**A receipt on every PR** — `npx aireceipts-cli pr --post`
+Attaches the cost of the sessions behind a PR as a comment. Generation stays local; a
+drop-in [CI check](docs/adopt/pr-receipt-check-caller.yml) can require every PR to carry one.
+
+Prefer a global install: `npm i -g aireceipts-cli`, then the command is `aireceipts`.
+Full walkthrough: [getting started](docs/guide/01-getting-started.md) · a real one, live:
+[PR #131](https://github.com/anandgupta42/receipts/pull/131#issuecomment-4886722030).
+
+## Everything else it does
 
 | Command | What it does |
 |---|---|
 | `aireceipts` | Receipt for the newest session (`--list` to pick another) |
+| `aireceipts setup` | Found sessions, latest cost, week total, and the integrations that fit your machine — [guide](docs/guide/01-getting-started.md) |
 | `aireceipts pr --post [--artifact]` | Attach the receipt of the sessions behind a PR as a comment; `--artifact` also publishes a durable receipt page — [guide](docs/pr-receipts.md) |
 | `aireceipts compare <a> <b>` | Two sessions side by side — models, tools, waste, ratio — [guide](docs/guide/05-compare.md) |
 | `aireceipts week` | Trailing-7-day digest: totals, per-agent split, top waste — [guide](docs/guide/06-week.md) |
@@ -91,33 +90,13 @@ versioned JSON (`--json`), or CSV (`--csv`).</sub>
 | `aireceipts --quota` / `--check-budget` | Official rate-limit window state (subscribers); exit 1 when your local budget cap is exceeded |
 | `aireceipts --json` / `--csv` / `--svg` | Versioned schema, RFC 4180 rows, shareable image — [schema](docs/json-schema.md) |
 
-<div align="center">
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="goldens/svg/claude-code-clean-multi-tool-2-models-dark.svg">
-  <img alt="the same receipt rendered as a shareable SVG, light and dark themes" src="goldens/svg/claude-code-clean-multi-tool-2-models-light.svg" width="520">
-</picture>
-
-<sub><code>--svg</code> — the receipt shown above, as the shareable image it exports; byte-pinned to this repo's golden tests</sub>
-
-</div>
-
 ## The honesty rules
 
-The receipt is only useful if you can trust every character on it. What a receipt
-proves — and what it can't: [docs/trust.md](docs/trust.md).
-
-- **No fabricated dollars, ever.** A model without a cited, dated price row renders
-  tokens-only — never a guess.
-- **Every price is cited.** Each row in `data/prices/` carries the vendor page URL, the
-  date observed, and a quoted excerpt. CI checks the citations and their liveness.
-- **Comparisons are arithmetic, not predictions.** "Same tokens on X" re-prices the
-  identical token counts — it never claims another model would have done the job.
-- **Deterministic.** Same transcript in, byte-identical receipt out — golden-tested on
-  every commit, 10× under a frozen environment. The receipts on this page are pinned
-  to those goldens by CI: this README cannot show output the renderer didn't produce.
-
-Full methodology: `aireceipts --methodology`.
+Every price is cited (vendor URL, date observed, a quoted excerpt — checked by CI). Every
+receipt is deterministic: same transcript in, byte-identical receipt out, golden-tested on
+every commit. No model without a cited price row ever shows a dollar figure — tokens-only
+instead of a guess. Comparisons re-price the identical tokens; they never predict. What a
+receipt proves, and what it can't: [docs/trust.md](docs/trust.md) · `aireceipts --methodology`.
 
 ## Supported agents
 
@@ -133,7 +112,7 @@ Model prices move. A daily advisory tripwire cross-checks `data/prices/` against
 independent dataset and opens an issue when they disagree; every table change lands
 as a cited price-table PR.
 
-## Telemetry, disclosed
+## Telemetry
 
 Anonymous diagnostics and usage signals — error classes, duration buckets,
 parse-failure signatures, feature enums, and coarse buckets. Never code, prompts,
@@ -166,4 +145,4 @@ welcome and run the same gates: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-Apache-2.0. · [buy me a samosa](https://anandgupta42.github.io/receipts/samosa.html)
+Apache-2.0.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ $172.76. <a href="https://github.com/anandgupta42/receipts/pull/131#issuecomment
 **Why this exists.** AI coding agents spend real money invisibly — you see the diff,
 never the bill. aireceipts reads the transcripts your agent already writes to disk and
 turns them into receipts: what a session cost, tool by tool; what a PR cost, across
-every session it can attribute; where tokens were wasted. It's local — your transcripts
-and code never leave your machine, and pricing needs no network. The only thing that
-ever leaves is a receipt you choose to share, and it carries cost and token numbers
-only, never your code or prompts ([how](docs/pr-receipts.md)).
+every session it can attribute; where tokens were wasted. It's local — your code, file
+contents, and raw transcripts never leave your machine, and pricing needs no network. A
+receipt is the one thing you'd share, and only when you choose to (a PR comment, a
+`refs/receipts/*` git ref, or an artifact page): it carries cost, token, model, and tool
+figures — plus a title taken from your session's first prompt — never your code, file
+contents, or the transcript itself ([how](docs/pr-receipts.md)).
 
 Here's what one looks like — the exact bytes your terminal prints:
 
@@ -57,6 +59,15 @@ same tokens on claude-haiku-4-5...$0.04 (78% less)
 <sub>the same receipt renders as a shareable SVG (`--svg`, light and dark themes),
 versioned JSON (`--json`), or CSV (`--csv`).</sub>
 
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="goldens/svg/claude-code-clean-multi-tool-2-models-dark.svg">
+  <img alt="the same receipt rendered as a shareable SVG, light and dark themes" src="goldens/svg/claude-code-clean-multi-tool-2-models-light.svg" width="520">
+</picture>
+
+</div>
+
 ## Start here — three commands
 
 **See what a session cost** — `npx aireceipts-cli`
@@ -87,15 +98,15 @@ Full walkthrough: [getting started](docs/guide/01-getting-started.md) · a real 
 | `aireceipts --handoff` | Paste-ready block that tells your *agent* what to do cheaper next time — [guide](docs/guide/09-handoff.md) |
 | `aireceipts install-hook` | Consent-gated Claude Code hook: every session ends with a mini-receipt — [guide](docs/guide/03-install-hook.md) |
 | `aireceipts statusline` | Live cost line in Claude Code's status bar — [setup](docs/statusline.md) |
-| `aireceipts --quota` / `--check-budget` | Official rate-limit window state (subscribers); exit 1 when your local budget cap is exceeded |
+| `aireceipts --quota` / `--check-budget` | Claude Code rate-limit window, read from the statusline stdin payload (silent otherwise); `--check-budget` exits 1 when your local budget cap is exceeded |
 | `aireceipts --json` / `--csv` / `--svg` | Versioned schema, RFC 4180 rows, shareable image — [schema](docs/json-schema.md) |
 
 ## The honesty rules
 
 Every price is cited (vendor URL, date observed, a quoted excerpt — checked by CI). Every
 receipt is deterministic: same transcript in, byte-identical receipt out, golden-tested on
-every commit. No model without a cited price row ever shows a dollar figure — tokens-only
-instead of a guess. Comparisons re-price the identical tokens; they never predict. What a
+every commit — including the receipts shown on this page. No model without a cited price
+row ever shows a dollar figure — tokens-only instead of a guess. Comparisons re-price the identical tokens; they never predict. What a
 receipt proves, and what it can't: [docs/trust.md](docs/trust.md) · `aireceipts --methodology`.
 
 ## Supported agents

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ every session it can attribute; where tokens were wasted. It's local — your co
 contents, and raw transcripts never leave your machine, and pricing needs no network. A
 receipt is the one thing you'd share, and only when you choose to (a PR comment, a
 `refs/receipts/*` git ref, or an artifact page): it carries cost, token, model, and tool
-figures — plus a title taken from your session's first prompt — never your code, file
+figures — plus a short session title (often prompt-derived) — never your code, file
 contents, or the transcript itself ([how](docs/pr-receipts.md)).
 
 Here's what one looks like — the exact bytes your terminal prints:

--- a/specs/SPEC-0029-readme-launch.md
+++ b/specs/SPEC-0029-readme-launch.md
@@ -81,6 +81,11 @@ number.
   `CONTRIBUTING.md`) → License. Existing content is reshaped, not rewritten
   from scratch; the honesty-rules and telemetry sections keep their current
   substance.
+
+  > **Amended 2026-07-08:** the `Install` section is renamed `## Start here` and is a
+  > three-command quick start (see SPEC-0053 R3's amendment for the shape and
+  > rationale); it appears within the first **80** lines (receipt-first layout). CLI
+  > table coverage is unchanged.
 - **R4 — The README guard (new test, `test/readme-guard.test.ts`).**
   Asserts mechanically: (a) tagline line equals `package.json` description
   byte-for-byte; (b) every fenced receipt in README is byte-identical to a
@@ -184,7 +189,7 @@ link line reads: "What a receipt proves — and what it can't:
 | R2 hero sources | `<picture>` srcset/src paths | both exist under goldens/svg/ |
 | R2 receipt parity | every fenced receipt in README | byte-equal to a committed goldens/*.txt |
 | R3 order | section headings | Standard-Readme order as specified |
-| R3 install early | Install heading | within first 60 lines |
+| R3 quick-start early (amended 2026-07-08) | `## Start here` heading | within first 80 lines |
 | R4 emoji budget | README bytes | ≤2 emoji |
 | R4 length cap | README bytes | ≤260 lines |
 | R1 tagline shape | first bold paragraph | bold, <120 chars |

--- a/specs/SPEC-0053-pr-receipt-first-readme.md
+++ b/specs/SPEC-0053-pr-receipt-first-readme.md
@@ -41,6 +41,19 @@ visual in the first 30 lines in 86% of the winning corpus). Maintainer-directed
   branch, SPEC-0051), (2) `aireceipts setup` (SPEC-0050), (3) wire the always-on
   surfaces (hook / statusline), (4) put receipts on PRs (`pr --post` / CI caller).
   The `## Install` heading stays within the first 60 lines (SPEC-0029 R3).
+
+  > **Amended 2026-07-08 (maintainer-directed launch redesign).** The four-step
+  > `## Install` path above is superseded by a three-command `## Start here` quick
+  > start: (1) `npx aireceipts-cli` (`--demo` for an empty machine), (2)
+  > `npx aireceipts-cli statusline`, (3) `npx aireceipts-cli pr --post` — with the
+  > full command reference (including `setup` and the always-on surfaces) moved to an
+  > `## Everything else it does` table. Rationale: the launch page leads with the
+  > three headline capabilities (local receipts, statusline, PR receipts) and keeps
+  > depth below the fold. The quick-start line budget moves 60→80 because the
+  > receipt-first layout shows the sample receipt above it. `readme-guard` R3
+  > assertions were updated to enforce the new shape; every other guard (receipt/
+  > golden parity, tagline sync, proof image, zero-emoji, length, table doc-links)
+  > is unchanged.
 - **R4 — Trust block, scannable.** The trust guarantees currently embedded in the
   "why this exists" prose render as a short bold-led bullet block above the fold:
   local-only, no accounts/servers; dollars only from cited dated price rows;
@@ -88,8 +101,8 @@ visual in the first 30 lines in 86% of the winning corpus). Maintainer-directed
 | R1 proof permalink | README link wrapping the image | matches `github.com/anandgupta42/receipts/pull/\d+#issuecomment-\d+` |
 | R1/R6 fenced receipts unchanged | README fenced blocks containing the wordmark | each byte-matches a committed golden |
 | R2 hero SVGs still present | `<picture>` srcs | ≥2 `goldens/svg/` paths, light + dark, on disk |
-| R3 install position | `## Install` heading | within first 60 lines |
-| R3 four steps | Install section body | exactly four numbered steps, `--demo` named in step 1 |
+| R3 quick-start position (amended 2026-07-08) | `## Start here` heading | within first 80 lines |
+| R3 three commands (amended 2026-07-08) | `## Start here` body | names `npx aireceipts-cli`, `statusline`, `pr --post`, and `--demo` |
 | R4 trust block | README above-the-fold text | bold-led bullets; `docs/trust.md` + `docs/telemetry.md` links preserved |
 | R5 watch hook | README text | one star/watch line, tied to the price-scan fact, no superlatives |
 | R6 length budget | README line count | ≤ 260 |

--- a/test/readme-guard.test.ts
+++ b/test/readme-guard.test.ts
@@ -150,7 +150,7 @@ describe("SPEC-0029 · README guard", () => {
       expect(readme).toContain(cmd);
     }
     // Design-mandated linked rows: each command's table row must carry a doc link.
-    for (const cmd of ["aireceipts pr", "compare", "week", "--handoff", "install-hook", "statusline", "--json"]) {
+    for (const cmd of ["aireceipts pr", "aireceipts setup", "compare", "week", "--handoff", "install-hook", "statusline", "--json"]) {
       const row = lines.find((l) => l.startsWith("|") && l.includes(cmd));
       expect(row, `CLI table row missing for ${cmd}`).toBeDefined();
       expect(row!.includes("]("), `CLI table row for ${cmd} must link its doc`).toBe(true);

--- a/test/readme-guard.test.ts
+++ b/test/readme-guard.test.ts
@@ -3,6 +3,10 @@
 // goldens (I5 extended to the marketing surface); the tagline is synced to
 // package.json; structural budgets are caps, not floors (budget constants
 // cite docs/internal/readme-evidence.md — the committed corpus note).
+// 2026-07-08 — SPEC-0053 R3's four-step `## Install` path is superseded by a
+// three-command `## Start here` quick start (maintainer-directed launch
+// redesign); the R3 assertions below enforce the new shape at the same rigor.
+// See the SPEC-0053 R3 amendment note.
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
@@ -120,28 +124,28 @@ describe("SPEC-0029 · README guard", () => {
     expect(imgLine).toBeLessThan(proseIdx);
   });
 
-  it("SPEC-0053 R3: the install section is exactly four numbered steps and step 1 names --demo", () => {
-    const installAt = lines.findIndex((l) => l.trim().toLowerCase().startsWith("## install"));
-    const nextH2 = lines.findIndex((l, i) => i > installAt && l.startsWith("## "));
-    const section = lines.slice(installAt, nextH2);
-    const stepIdx = section.reduce<number[]>((acc, l, i) => (/^\d+\. /.test(l.trim()) ? [...acc, i] : acc), []);
-    expect(stepIdx.map((i) => section[i].trim().slice(0, 2))).toEqual(["1.", "2.", "3.", "4."]);
-    const stepOne = section.slice(stepIdx[0], stepIdx[1]).join(" ");
-    expect(stepOne).toContain("--demo");
-    const stepTwo = section.slice(stepIdx[1], stepIdx[2]).join(" ");
-    expect(stepTwo).toContain("setup");
-    const stepThree = section.slice(stepIdx[2], stepIdx[3]).join(" ");
-    expect(stepThree).toContain("install-hook");
-    expect(stepThree).toContain("statusline");
-    const stepFour = section.slice(stepIdx[3]).join(" ");
-    expect(stepFour).toContain("pr --post");
-    expect(stepFour, "the CI workflow verifies receipts; posting is local").toContain("local");
+  it("SPEC-0053 R3 (amended 2026-07-08): the 'Start here' quick-start names the three headline commands", () => {
+    // Superseded shape: the original four-step `## Install` path. The launch
+    // redesign replaced it with a three-command quick start; the guard enforces
+    // THAT — same rigor, new contract.
+    const startAt = lines.findIndex((l) => /^##\s+start here\b/i.test(l.trim()));
+    expect(startAt, "README must have a '## Start here' quick-start section").toBeGreaterThan(-1);
+    const nextH2 = lines.findIndex((l, i) => i > startAt && l.startsWith("## "));
+    const section = lines.slice(startAt, nextH2 === -1 ? undefined : nextH2).join("\n");
+    // The three headline commands, each as a runnable invocation.
+    expect(section, "quick-start must name the session-receipt command").toContain("npx aireceipts-cli`");
+    expect(section, "quick-start must name statusline").toContain("statusline");
+    expect(section, "quick-start must name pr --post").toContain("pr --post");
+    // The empty-machine branch stays discoverable (SPEC-0051).
+    expect(section, "quick-start must name --demo for the empty-machine case").toContain("--demo");
   });
 
-  it("R3: install appears within the first 60 lines; CLI table names every command with doc links", () => {
-    const installAt = lines.findIndex((l) => l.trim().toLowerCase().startsWith("## install"));
-    expect(installAt).toBeGreaterThan(-1);
-    expect(installAt).toBeLessThanOrEqual(60);
+  it("R3: quick-start appears early; CLI table names every command with doc links", () => {
+    const startAt = lines.findIndex((l) => /^##\s+start here\b/i.test(l.trim()));
+    expect(startAt).toBeGreaterThan(-1);
+    // Budget moves 60→80: the receipt-first layout shows the sample receipt
+    // (fenced + SVG) above the quick start, still above the fold on GitHub.
+    expect(startAt).toBeLessThanOrEqual(80);
     for (const cmd of ["--svg", "--quota", "--check-budget"]) {
       expect(readme).toContain(cmd);
     }


### PR DESCRIPTION
## What this adds

A launch-ready rewrite of the README. It leads with the actual receipt, condenses the first-run path to three headline commands, corrects two honesty over-claims, and amends the README-guard spec (SPEC-0029 / SPEC-0053 R3) to match the new shape.

## Why it matters to users

- The first screen shows what the product produces (a real receipt), then exactly three commands to get value: see a session's cost, wire the statusline, put a receipt on a PR.
- The privacy claim is now accurate: your code and raw transcripts stay local; a shared receipt carries cost/token/model/tool figures plus a short session title (often prompt-derived) — never your code or the transcript itself.
- The `--quota` row now describes real behavior (Claude statusline stdin payload only; silent otherwise) instead of implying a standalone account query.

## See it

New first-run section (renders on GitHub; the fenced sample receipt above it is golden-pinned by `test/readme-guard.test.ts`):

```
## Start here — three commands

**See what a session cost** — `npx aireceipts-cli`
Tool by tool, locally, including where tokens went to waste. No install, no account
(`--demo` shows a bundled example if you have no sessions yet).

**Live cost in your status bar** — `npx aireceipts-cli statusline`
Claude Code's status line shows running cost as you work, not just a total at the end.

**A receipt on every PR** — `npx aireceipts-cli pr --post`
Attaches the cost of the sessions behind a PR as a comment. Generation stays local; a
drop-in CI check can require every PR to carry one.
```

## What changed

- `README.md` — receipt-first hero kept; four-step Install → three-command "Start here"; full command reference moved to an "Everything else it does" table; privacy paragraph corrected; `--quota` row corrected; Telemetry heading simplified; golden-pinned SVG showcase kept; License "samosa" link removed.
- `test/readme-guard.test.ts` — R3 assertions retargeted from the four-step Install to the three-command quick start; `aireceipts setup` kept in the doc-link coverage loop; line budget 60→80 for the receipt-first layout. Every other guard (tagline sync, receipt/golden parity, proof image, zero-emoji, length, table doc-links) unchanged.
- `specs/SPEC-0029-readme-launch.md`, `specs/SPEC-0053-pr-receipt-first-readme.md` — R3 amended (dated 2026-07-08) recording the supersession of the four-step path; matrix rows updated.

## What to review, in order

1. **Honesty of the privacy paragraph** (`README.md`, "Why this exists") — the riskiest claim. Verified against `docs/pr-receipts.md` and the parsers: titles are only *often* prompt-derived (Claude Code prefers an `ai-title`; opencode/Cursor use session/composer names).
2. **Guard integrity** (`test/readme-guard.test.ts:123-158`) — confirm the retargeted R3 assertions are equivalent rigor, not weakened: they still fail if a headline command, the quick-start section, a table doc-link, or the `setup` row goes missing. The 60→80 budget is justified by the receipt-first layout.
3. **Spec amendments** (`specs/SPEC-0053` R3, `specs/SPEC-0029` R3) — in-place dated supersession of the original four-step contract.
4. **`--quota` row accuracy** (README table) vs `src/cli/commands/quota.ts`.

## Evidence

- Gates: full `vitest` 1735/1735 (on the change); after rebasing onto `origin/main` (v0.7.0), re-verified guard 11/11 + all 9 quick gates (`tsc` 0 · `eslint` 0 · `verify-goldens` 102 byte-identical · `spec-lint` 71 · `hygiene` OK · manifest/tarball/cite-check/build). CI runs the full suite on this PR.
- Independent review: Codex (deep reasoning, read-only), **two rounds** — found a CI-breaking guard failure, two honesty over-claims, a `--quota` inaccuracy, and a guard-coverage regression; all fixed → **VERDICT: APPROVE**.
- Specs: `specs/SPEC-0029`, `specs/SPEC-0053` (R3 amended 2026-07-08).
- Build receipt: attached via `npx aireceipts-cli pr --post`.

## Notes

- Docs + guard/spec amendment only; no `src/` change. Merging updates the GitHub README immediately; the npm page re-renders on the next publish — no docs-only patch cut, folds into the next release.
- The local full-suite run skipped only the spawn-heavy stress case (`AIRECEIPTS_SKIP_STRESS=1`), matching preflight's local default; CI runs it unskipped.
