### PR TITLE
chore: faster ship gates — readme-guard in --quick, worktree bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 dist/
 *.log
 coverage/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,14 @@ npx tsc --noEmit && npx eslint . --max-warnings 0 && npx vitest run \
 All must exit 0 before a PR merges. `AGENTS.md` is the operating manual if you
 want the full picture (invariants, file ownership, verification commands).
 
+**One command, before you push:** `npm run ship-check -- --title "<your PR title>"`
+runs every fast gate CI enforces in one shot — `preflight --quick` (build, tsc,
+eslint, goldens, spec-lint, hygiene, and the README guard) plus the PR-title lint —
+so a mechanical failure never bounces off CI or a reviewer. Run it (and fix what it
+finds) *before* asking for review, not after. Working in a git worktree? Run
+`npm run setup:worktree` once first — it links the main checkout's `node_modules`
+(without it, `vitest` and `verify-goldens` fail spuriously) and fetches `origin/main`.
+
 If your session built the change, attach its receipt before opening the PR:
 `npx aireceipts-cli pr --post` (see `docs/pr-receipts.md`). Humans without a
 session to attach can skip this.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "preflight": "node scripts/preflight-release.mjs",
     "prepublishOnly": "tsup",
     "setup:hooks": "git config core.hooksPath .githooks && npm run build",
+    "setup:worktree": "node scripts/worktree-setup.mjs",
+    "ship-check": "node scripts/ship-check.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/scripts/preflight-release.mjs
+++ b/scripts/preflight-release.mjs
@@ -150,6 +150,7 @@ async function main() {
     "verify-goldens",
     "spec-lint",
     "hygiene",
+    "readme-guard (fast)",
     "vitest run (full suite, incl. install+run e2e)",
     "determinism-check ×10",
   ];
@@ -201,6 +202,14 @@ async function main() {
         return record(results, "determinism-check ×10", () =>
           sh("node", ["scripts/determinism-check.mjs", "--runs=10", "--", "node", "scripts/verify-goldens.mjs"]));
       }),
+    );
+  } else {
+    // The full suite (above) already covers the README guard. In --quick we run
+    // just that one fast, deterministic test, so a README or spec change can't
+    // pass the pre-push gate while breaking CI's readme-guard (SPEC-0029/0053).
+    concurrent.push(
+      record(results, "readme-guard (fast)", () =>
+        sh("npx", ["vitest", "run", "test/readme-guard.test.ts"])),
     );
   }
 

--- a/scripts/ship-check.mjs
+++ b/scripts/ship-check.mjs
@@ -19,7 +19,14 @@ import { fileURLToPath } from "node:url";
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const argv = process.argv.slice(2);
 const ti = argv.indexOf("--title");
-const title = ti >= 0 ? argv[ti + 1] : undefined;
+const hasTitle = ti >= 0;
+const title = hasTitle ? argv[ti + 1] : undefined;
+// A requested check must never be silently skipped: `--title` with no (or an
+// empty) value is a hard error, not a fall-through to "skipping PR-title lint".
+if (hasTitle && (title === undefined || title === "")) {
+  console.error('ship-check: --title needs a non-empty value, e.g. --title "docs: add X"');
+  process.exit(1);
+}
 
 function step(name, cmd, args) {
   process.stdout.write(`\n▶ ${name}\n`);
@@ -31,7 +38,7 @@ function step(name, cmd, args) {
 }
 
 step("preflight --quick", "node", ["scripts/preflight-release.mjs", "--quick"]);
-if (title) {
+if (hasTitle) {
   step("pr-title lint", "node", ["scripts/hygiene.mjs", "--title", title]);
 } else {
   console.log('\n(no --title given — skipping the PR-title lint; pass --title "<PR title>" to check it before you open the PR)');

--- a/scripts/ship-check.mjs
+++ b/scripts/ship-check.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// The one command to run before you push a PR:
+//
+//   npm run ship-check -- --title "<your PR title>"
+//
+// Runs every FAST gate CI enforces, locally, in one shot: `preflight --quick`
+// (manifest, build, tarball, tsc, eslint, cite-check, verify-goldens, spec-lint,
+// hygiene, and the README guard) plus — when --title is given — the same
+// PR-title lint CI runs. Green here means green on CI's fast checks, so a
+// mechanical failure never bounces off CI or a reviewer.
+//
+// This is NOT release-valid on its own (it skips the full vitest suite +
+// determinism ×10, like preflight --quick). Run `npm run preflight` before a
+// release; run this before a PR.
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const argv = process.argv.slice(2);
+const ti = argv.indexOf("--title");
+const title = ti >= 0 ? argv[ti + 1] : undefined;
+
+function step(name, cmd, args) {
+  process.stdout.write(`\n▶ ${name}\n`);
+  const res = spawnSync(cmd, args, { cwd: ROOT, stdio: "inherit" });
+  if (res.status !== 0) {
+    console.error(`\nship-check: FAILED at "${name}" — fix it before pushing.`);
+    process.exit(1);
+  }
+}
+
+step("preflight --quick", "node", ["scripts/preflight-release.mjs", "--quick"]);
+if (title) {
+  step("pr-title lint", "node", ["scripts/hygiene.mjs", "--title", title]);
+} else {
+  console.log('\n(no --title given — skipping the PR-title lint; pass --title "<PR title>" to check it before you open the PR)');
+}
+console.log("\nship-check: OK — safe to push.");

--- a/scripts/worktree-setup.mjs
+++ b/scripts/worktree-setup.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// One-shot bootstrap for a git worktree of this repo.
+//
+//   npm run setup:worktree
+//
+// Two things a fresh worktree lacks that make gates fail confusingly:
+//   1. No node_modules. npm/npx resolve up-tree to the main checkout's copy, so
+//      tsc/eslint/tsup work — but scripts with a hardcoded `node_modules/…` path
+//      (verify-goldens.mjs wants node_modules/typescript/bin/tsc) and `vitest`
+//      do NOT, and fail spuriously. We symlink the main checkout's node_modules.
+//   2. A stale local main. We fetch origin/main so a branch forks from current.
+//
+// Idempotent: safe to re-run. No-op in the main checkout.
+import { execFileSync } from "node:child_process";
+import { existsSync, lstatSync, symlinkSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const run = (cmd, args) => execFileSync(cmd, args, { encoding: "utf8" }).trim();
+
+// Absolute path to the shared .git dir → its parent is the main checkout root.
+const gitCommonDir = run("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+const mainRoot = dirname(gitCommonDir);
+const toplevel = run("git", ["rev-parse", "--show-toplevel"]);
+
+if (mainRoot === toplevel) {
+  console.log("This is the main checkout, not a linked worktree — nothing to link.");
+} else {
+  const localModules = join(toplevel, "node_modules");
+  const mainModules = join(mainRoot, "node_modules");
+  if (existsSync(localModules) || isSymlink(localModules)) {
+    console.log(`node_modules already present (${localModules}) — leaving it.`);
+  } else if (!existsSync(mainModules)) {
+    console.error(`Main checkout has no node_modules (${mainModules}). Run 'npm install' there first.`);
+    process.exit(1);
+  } else {
+    symlinkSync(mainModules, localModules);
+    console.log(`Linked node_modules → ${mainModules}`);
+  }
+}
+
+try {
+  run("git", ["fetch", "origin", "main"]);
+  console.log("Fetched origin/main (branch from it: git checkout -b <name> origin/main).");
+} catch (e) {
+  console.warn(`Could not fetch origin/main: ${e.message}`);
+}
+
+function isSymlink(p) {
+  try {
+    return lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What this adds

Developer-experience tooling so the pre-PR loop catches **mechanical** failures locally instead of in CI or in review — the friction that made a small change slow to land. Retro-driven: every delay last time was a fast check that ran too late (README guard surfaced in review; PR-title length surfaced as a CI round; `verify-goldens` failed for lack of a worktree `node_modules`).

## See it

`preflight --quick` now runs the README guard (10 checks, was 9), and `ship-check` bundles it with the PR-title lint:

```
▶ preflight --quick
✓ manifest: publish-shape contract
✓ build → dist/cli.js + shebang
✓ tarball: lean + complete
✓ spec-lint
✓ hygiene
✓ verify-goldens
✓ readme-guard (fast)
✓ tsc --noEmit
✓ eslint --max-warnings 0
✓ cite-check (all price tables, liveness enforced)
preflight: 10 quick checks passed — NOT release-valid (...)
▶ pr-title lint
hygiene: OK, including PR title.
ship-check: OK — safe to push.
```

## What changed

- `scripts/preflight-release.mjs` — the `readme-guard` test now runs in `--quick` (else-branch; full mode still covers it via the full suite, so it's not double-run). A README/spec change can no longer pass the pre-push gate while breaking CI's guard.
- `scripts/worktree-setup.mjs` (new) + `npm run setup:worktree` — symlink the main checkout's `node_modules` into a worktree (without it, `vitest`/`verify-goldens` fail spuriously) and fetch `origin/main`. Idempotent; no-op in the main checkout.
- `scripts/ship-check.mjs` (new) + `npm run ship-check [-- --title "…"]` — one command = `preflight --quick` + the PR-title lint. Green here means green on CI's fast checks.
- `.gitignore` — `node_modules/` → `node_modules` so the worktree symlink is ignored.
- `package.json` — the two new scripts.
- `CONTRIBUTING.md` — document `setup:worktree` and `ship-check`, and "run the gates before review."

## What to review, in order

1. **`scripts/worktree-setup.mjs`** — the riskiest new logic: main-root derivation from `git rev-parse --path-format=absolute --git-common-dir`, the `mainRoot === toplevel` no-op guard, idempotency, and the non-fatal fetch.
2. **`scripts/preflight-release.mjs`** — `readme-guard (fast)` added to `--quick` only; confirm it's not double-run in full mode and the gate-count/summary still hold (10 quick / 11 full).
3. **`scripts/ship-check.mjs`** — `--title` with no/empty value is a hard error (not a silent skip); exit codes propagate.
4. **`.gitignore`** broadening (directory-only → any `node_modules` entry).

## Evidence

- Gates: `preflight --quick` = 10 checks incl. the new `readme-guard`; `tsc` 0, `eslint` 0. Dev-only scripts — no `src/` change, so the full vitest suite is unaffected (CI runs it).
- Independent review: Codex (read-only), **two rounds** — approved after fixing a silent `--title`-with-no-value skip in `ship-check`. **VERDICT: APPROVE**.
- No SPEC: maintainer-directed DX/tooling with no product/`src` behavior change (CONTRIBUTING allows small in-scope direct PRs; Codex concurred).
- Build receipt: attached via `npx aireceipts-cli pr --post`.

## Notes

- Internal/contributor tooling only — no user-facing product change, so no telemetry or docs-parity applies.
- Motivation and the full friction list are recorded from a retro on the previous (README) PR's 24-minute landing.
