### PR TITLE
feat: SPEC-0064 — surface npm-native pr-check in integrations github

### DIFF
--- a/src/setup/integrations.ts
+++ b/src/setup/integrations.ts
@@ -21,6 +21,23 @@ const ASSISTANT_INSTRUCTION = [
   "Never guess cost. If aireceipts reports tokens-only, preserve that.",
 ].join("\n");
 
+const NPM_NATIVE_PR_CHECK_CALLER_YAML = [
+  "# npm-native, no reusable-workflow `uses:` — no org Actions-policy gate; for trusted",
+  "# same-repo/internal PRs (fork PRs get a read-only token).",
+  "name: aireceipts",
+  "on: [pull_request]",
+  "permissions:",
+  "  contents: read",
+  "  pull-requests: write",
+  "jobs:",
+  "  check:",
+  "    runs-on: ubuntu-latest",
+  "    steps:",
+  "      - run: npx -y aireceipts-cli@latest pr-check",
+  "        env:",
+  "          GH_TOKEN: ${{ github.token }}",
+].join("\n");
+
 export const INTEGRATION_RECIPES: readonly IntegrationRecipe[] = [
   {
     target: "claude-code",
@@ -140,6 +157,14 @@ export const INTEGRATION_RECIPES: readonly IntegrationRecipe[] = [
       "jobs:",
       "  check:",
       "    uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest",
+      "```",
+      "",
+      "ALTERNATIVE: self-contained npm-native pr-check",
+      "",
+      "Use this workflow content instead when org Actions policy blocks external reusable workflows:",
+      "",
+      "```yaml",
+      NPM_NATIVE_PR_CHECK_CALLER_YAML,
       "```",
       "",
       "# .claude/settings.json",

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -374,6 +374,12 @@ describe("built CLI e2e", () => {
     expect(opencode.stdout).toContain(".opencode/commands/receipt.md");
     expect(opencode.stdout).toContain("npx aireceipts-cli pr --post");
 
+    const github = await runCli(["integrations", "github"], home);
+    expectSuccess(github);
+    expect(github.stdout).toContain("uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest");
+    expect(github.stdout).toContain("ALTERNATIVE: self-contained npm-native pr-check");
+    expect(github.stdout).toContain("npx -y aireceipts-cli@latest pr-check");
+
     const unknown = await runCli(["integrations", "unknown"], home);
     expect(unknown.code).toBe(1);
     expect(unknown.stderr).toContain('unknown integration target "unknown"');

--- a/test/setup/integrations.test.ts
+++ b/test/setup/integrations.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { INTEGRATION_RECIPES, INTEGRATION_TARGETS, integrationRecipe } from "../../src/setup/integrations.js";
 import { integrationsToJson, renderIntegrationMatrix, renderIntegrationRecipe } from "../../src/setup/render.js";
@@ -32,6 +33,11 @@ describe("SPEC-0050 integration recipes", () => {
     const github = integrationRecipe("github");
     expect(github).toBeDefined();
     const rendered = renderIntegrationRecipe(github!);
+    const npmNativeWorkflow = readFileSync("docs/adopt/pr-check-caller.yml", "utf8").trimEnd();
+    expect(rendered.indexOf("uses: anandgupta42/receipts/.github/workflows/pr-receipt-check.yml@latest")).toBeLessThan(
+      rendered.indexOf("ALTERNATIVE: self-contained npm-native pr-check"),
+    );
+    expect(rendered).toContain(["```yaml", npmNativeWorkflow, "```"].join("\n"));
     expect(rendered).toContain("notice-only");
     expect(rendered).toContain("CI never generates receipts");
   });


### PR DESCRIPTION
## What

`aireceipts integrations github` now prints the SPEC-0064 self-contained npm-native `pr-check` workflow as a labeled **ALTERNATIVE** after the existing reusable-workflow snippet.

## Why

Orgs whose Actions policy blocks external reusable workflows hit a dead end on the only snippet the CLI offered — while the workaround (built specifically for them, `docs/adopt/pr-check-caller.yml`) shipped in this repo with no in-CLI pointer to it. A day-1 user should not need to already know the docs to find it.

## How

- YAML inlined as a const — no runtime `docs/` read (`docs/` is not in the npm `files` list, so a runtime read would break the published package)
- test pins byte-parity between the inlined YAML and `docs/adopt/pr-check-caller.yml` so they cannot drift
- test pins ordering (reusable workflow first, ALTERNATIVE second); e2e test checks the built CLI prints it

No new spec: this is a message-surface completion of shipped SPEC-0064 (the recipe surface it extends is the day-1 kit's). Flagging explicitly — happy to split into a spec if the maintainer disagrees.

## Verification

tsc 0 · eslint 0 · vitest 0 (134 files / 1735 tests) · verify-goldens 0 · determinism-check(10) 0 · spec-lint 0 · hygiene 0. Codex review: ACCEPT, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
