### PR TITLE
chore: release v0.7.1 — Claude Code cost fix (message-id dedupe)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.7.0):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.7.1):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,

--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@
 [![CI](https://github.com/anandgupta42/receipts/actions/workflows/ci.yml/badge.svg)](https://github.com/anandgupta42/receipts/actions/workflows/ci.yml) [![npm](https://img.shields.io/npm/v/aireceipts-cli.svg)](https://www.npmjs.com/package/aireceipts-cli) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/anandgupta42/receipts/badge)](https://scorecard.dev/viewer/?uri=github.com/anandgupta42/receipts) [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 <a href="https://github.com/anandgupta42/receipts/pull/131#issuecomment-4886722030">
-  <img alt="a real aireceipts receipt comment on a merged pull request of this repo: 6 sessions, two Claude models and five Codex helpers, $172.76 total" src="docs/assets/pr-receipt-comment.png" width="480">
+  <img alt="a real aireceipts receipt comment on a merged pull request of this repo: 6 sessions, two Claude models and five Codex helpers, $172.76 as posted — corrected to $71.31 by the v0.7.1 parser fix" src="docs/assets/pr-receipt-comment.png" width="480">
 </a>
 
 <sub>not a mockup — a receipt comment on a merged PR of this repo, posted by
-<code>aireceipts pr --post</code>: 6 sessions, two Claude models, five Codex helpers,
-$172.76. <a href="https://github.com/anandgupta42/receipts/pull/131#issuecomment-4886722030">Read it live.</a></sub>
+<code>aireceipts pr --post</code>: 6 sessions, two Claude models, five Codex helpers.
+Shown as posted ($172.76); a v0.7.1 parser fix found Claude Code dollars were
+over-counted and the live comment now carries the exact correction ($71.31).
+<a href="https://github.com/anandgupta42/receipts/pull/131#issuecomment-4886722030">Read it live.</a></sub>
 
 </div>
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.7.1 — 2026-07-09
+
+Patch: **Claude Code receipts were over-reporting cost by ~2.5–3× and are now correct.**
+Claude Code writes one `assistant` transcript record per content block of a response, and
+every record of that response repeats the same `message.id` and a byte-identical `usage`
+snapshot. The adapter had counted each record as its own billed turn, multiplying a
+response's tokens by its block count. Turns are now deduped by `message.id` — the first
+record of a response books its usage once, later records only add their tool calls — so
+`turnCount` and every `$` reflect real billed responses (PR #196). **After upgrading, every
+Claude Code receipt you render shows lower dollars and fewer turns than 0.7.0 showed for
+the same session**: a real local session dropped from $102.97 to $36.69 (2.81×), and one PR
+slice from $5.17 to $1.61. This was a silent **over**-report — the first known arithmetic
+case of a receipt exceeding the true floor rather than under-reporting it. Codex, opencode,
+and Cursor are unaffected (Codex reconciles against the rollout's own cumulative total and
+was re-verified correct to the cent). Synthetic-fixture output is byte-identical (goldens
+unchanged); the summary-cache version was bumped (2 → 3) so stale inflated totals recompute
+on the next run. Receipts posted on this repo's own past PRs carry per-session correction
+blocks with exact recomputed figures. Full audit and evidence: PR #196,
+`docs/cost-model.md`, and the 2026-07-08 addendum in
+`docs/internal/cost-attribution-evidence.md`.
+
 ## v0.7.0 — 2026-07-08
 
 Minor: **telemetry now defaults to enabled in CI**, reversing the v0.6.x CI-default-off behavior.

--- a/docs/internal/cost-attribution-evidence.md
+++ b/docs/internal/cost-attribution-evidence.md
@@ -65,8 +65,9 @@ cell stays correct-or-flagged as the code changes.
 Found by replaying every receipt posted on this repo's closed PRs against the
 local transcripts that produced them.
 
-**Finding (A-class, OVER-report — the first confirmed violation of "the
-receipt is a floor"):** Claude Code writes one `assistant` JSONL record per
+**Finding (A-class, OVER-report — the first confirmed *arithmetic* violation
+of "the receipt is a floor"; PR #87's earlier over-credit was an
+attribution-scope error, not a token-arithmetic one):** Claude Code writes one `assistant` JSONL record per
 content block of a response. Every record of the same response repeats the same
 `message.id` and a byte-identical `usage` snapshot. The adapter counted each
 record as its own billed turn, multiplying the response's usage by its block

--- a/docs/releases/0.7.1-verdict.md
+++ b/docs/releases/0.7.1-verdict.md
@@ -1,0 +1,81 @@
+# Release verdict — v0.7.1
+
+- **Candidate version:** 0.7.1 (patch)
+- **Content SHA:** `bb97c25` (HEAD of `main` after #196)
+- **Changelog range:** `v0.7.0..bb97c25` — one commit (#196).
+- **Bump rationale:** PATCH — a pure correctness fix. The `--json` shape is unchanged
+  (`SCHEMA_VERSION` stays 1); goldens are byte-identical; correcting a wrongly computed
+  number is a bug fix even though real receipts drop ~2.5–3×.
+- **Date:** 2026-07-09 (UTC)
+
+## Scope
+
+- **#196** — Claude Code turns deduped by `message.id`. The adapter had counted every
+  `assistant` JSONL record as a billed turn; Claude Code writes one record per content
+  block, each repeating the same `message.id` and a byte-identical `usage` snapshot, so
+  cost was multiplied by the block count (~1.4–3.5×, median 2.14×, measured over this
+  repo's own 100 posted Claude Code session figures). First confirmed *arithmetic*
+  violation of "the receipt is a floor". Codex re-verified correct to the cent
+  (delta sum == rollout cumulative envelope). No spec-status flips (#196 was not
+  spec-driven; it is recorded in `docs/internal/cost-attribution-evidence.md`).
+
+## Panel votes (separate agent contexts)
+
+- **Engineering Manager — GO.** PATCH correct (shape unchanged, values were wrong);
+  rollback clean — the summary-cache version guard is symmetric (`3 ≠ 2` on downgrade →
+  discard + rebuild, atomic tmp+rename writes); zero dependency delta; blast radius
+  audited — every other adapter already counted `turns.length` (Claude Code was the lone
+  per-record outlier), PR slicing recomputes indices fresh and merely coarsens to the
+  correct billed-response unit, waste/costShape/benchmark consumers get more accurate;
+  no open P0 touching this path (#170 CSV formula-injection pre-existing/unrelated);
+  CI green on the exact SHA. Insisted the changelog state the drop loudly (honored).
+- **Product Manager + docs panel — GO.** Methodology blockquote verified verbatim-equal
+  to `METHODOLOGY` (programmatic diff: MATCH); cost-model.md's four step→file mappings
+  and the Codex reconciliation claim verified against the code; evidence-doc arithmetic
+  consistent. Two required follow-ups, both landed in this release prep: (1) version
+  bump + the changelog entry below; (2) the README hero ($172.76, PR #131) relabeled
+  "as posted / corrected to $71.31" — the live comment already carries the exact
+  correction block. Optional polish (also landed): "first *arithmetic* floor violation"
+  wording. Draft changelog adopted as written.
+- **QA / adversarial — GO** (run by the lead after the QA agent hit a session limit;
+  probes preserved in the session scratchpad `qa/`). Hostile fixtures against the
+  changed path, driven through `loadById` + `attributeByTool`:
+  - same id with **differing** usage snapshots → first booked once, no crash;
+  - first record usage-less, later record carries usage → attached once;
+  - **non-contiguous** same-id records → merge correctly across interleaved messages;
+  - `fork-context-ref` **between** two records of one id → map reset, fresh turn, no
+    stale merge;
+  - hostile id types (numeric, `null`, empty string, string content, missing model/ts)
+    → no crash; non-string ids merge via Map identity; two *distinct* responses both
+    carrying `null`/`""` ids would merge (an under-count → floor direction, not an
+    over-report; not a real Claude Code shape — real records either carry a `msg_*`
+    string or omit the field);
+  - scale: 50,000 records over 5,000 ids parse + price in ~1.4 s, no memory blowup;
+  - hand-computed token totals match `--json`-path output exactly;
+  - largest real transcript (3,867 usage records) → exactly 1,443 turns = the audit's
+    distinct-id count. **No I2 violation found.**
+- **Designer — right-sized to empty** (0.7.0 precedent): zero rendered-output change,
+  102 goldens byte-identical, determinism ×10 — there is no new face to look at. The
+  README hero relabel is text-only and was reviewed by the PM lens.
+
+## Mechanical checks (on `bb97c25` + release edits)
+
+- Gate battery: `tsc` 0, `eslint --max-warnings 0` 0, `vitest` 135 files / 1,738 tests
+  green, `verify-goldens` 102 byte-identical, `determinism-check ×10` OK,
+  `spec-lint` 71 OK, `hygiene` OK.
+- `node scripts/preflight-release.mjs` → **11/11 RELEASE-READY** (includes packed-tarball
+  install+run e2e and live cite-check).
+- `npm publish --dry-run` → 72 files, 122.7 kB; file list inspected — dist + data/prices
+  + docs-lite only; no fixtures, transcripts, .env, or internal docs.
+- gitleaks full-history (527 commits) → no leaks.
+- CI green on `bb97c25` (all required checks `success`; advisory `prices` skipped as scheduled).
+
+## Open risks (accepted)
+
+- Real user receipts drop ~2.5–3× on upgrade; mitigated by the loud changelog entry, the
+  in-product `--methodology` disclosure, the README hero relabel, and per-session
+  correction blocks on all 82 of this repo's own past receipt comments.
+- The README hero PNG still shows the as-posted figure; the caption now says exactly
+  that. Regenerating the screenshot is cosmetic follow-up, not a correctness issue.
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",


### PR DESCRIPTION
Release prep for **v0.7.1** — a patch release containing only #196 (Claude Code turns deduped by `message.id`; cost was over-reported ~2.5–3×).

- `package.json`/lock → 0.7.1 (tag-matches-manifest guard)
- `docs/CHANGELOG.md` v0.7.1 entry — states the drop loudly: **every Claude Code receipt shows lower dollars and fewer turns after upgrading**
- `docs/releases/0.7.1-verdict.md` — release-manager verdict: EM/PM/QA all **GO**, Designer right-sized to empty (goldens byte-identical); mechanical gates 11/11 RELEASE-READY, `npm publish --dry-run` file list inspected, gitleaks full-history clean. `VERDICT: GO` on content SHA `bb97c25`.
- `README.md` hero relabeled: $172.76 shown **as posted**, corrected to **$71.31** by this fix (the live PR #131 comment carries the exact correction block) — the PM panel's required follow-up
- evidence doc: "first *arithmetic* floor violation" wording (PR #87 was an attribution-scope error)
- `AGENTS.md` inventory → v0.7.1 (release-skill-only edit)

After merge: dispatch `release-publish.yml` on `main` (publishes with OIDC provenance, then `tag-and-release` mints `v0.7.1` + the GitHub Release from the changelog section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)