### PR TITLE
fix: keep node: import specifiers in the bundled CLI

### DIFF
--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -11,6 +11,12 @@ const fixturesDir = path.join(repoRoot, "test", "fixtures");
 const cliPath = path.join(repoRoot, "dist", "cli.js");
 const tempDirs: string[] = [];
 
+// node:sqlite loads unflagged from Node 22.13 (src/parse/sqlite.ts); older
+// runtimes legitimately use the sqlite3-CLI fallback, so the in-process
+// regression test below skips there instead of failing.
+const [nodeMajor = 0, nodeMinor = 0] = process.versions.node.split(".").map(Number);
+const hasNodeSqlite = nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 13);
+
 interface RunOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
@@ -537,6 +543,40 @@ describe("built CLI e2e", () => {
     expectSuccess(textResult);
     expect(textResult.stdout).toContain("no price table matched");
     expect(textResult.stdout).not.toContain("$");
+  });
+
+  // Regression pair for tsup's removeNodeProtocol default: it rewrote
+  // `import("node:sqlite")` to `import("sqlite")` in dist (ERR_MODULE_NOT_FOUND
+  // at runtime), silently forcing every sqlite read onto a per-query
+  // sqlite3-CLI spawn (~4x slower end-to-end on sqlite-heavy machines). Unit
+  // tests import src and can never catch this — only the built artifact shows it.
+  it("keeps the node:sqlite import specifier intact in the built artifact", async () => {
+    const distFiles = await readdir(path.join(repoRoot, "dist"), { recursive: true });
+    const sources = await Promise.all(
+      distFiles
+        .filter((file) => file.endsWith(".js"))
+        .map((file) => readFile(path.join(repoRoot, "dist", file), "utf8")),
+    );
+    expect(sources.some((source) => source.includes('import("node:sqlite")'))).toBe(true);
+    expect(sources.some((source) => source.includes('import("sqlite")'))).toBe(false);
+  });
+
+  it.skipIf(!hasNodeSqlite)("reads opencode sessions in-process with no sqlite3 binary on PATH", async () => {
+    const home = await makeHome();
+    await stageOpenCodeDb(home, "clean-multi-vendor.db");
+    // An empty PATH dir makes the sqlite3-CLI fallback unreachable, so this
+    // passes only when the built CLI's node:sqlite import actually resolves.
+    const emptyPathDir = path.join(home, "empty-path-dir");
+    await mkdir(emptyPathDir, { recursive: true });
+
+    const listed = readJson<ListRowJson[]>(
+      await runProcess(process.execPath, [cliPath, "--list", "--json"], {
+        env: { ...cliEnv(home), PATH: emptyPathDir },
+      }),
+    );
+
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.source).toBe("opencode");
   });
 
   it("keeps output flag precedence stable: SVG beats CSV/JSON, and CSV beats JSON", async () => {

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { copyFile, mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -11,11 +11,13 @@ const fixturesDir = path.join(repoRoot, "test", "fixtures");
 const cliPath = path.join(repoRoot, "dist", "cli.js");
 const tempDirs: string[] = [];
 
-// node:sqlite loads unflagged from Node 22.13 (src/parse/sqlite.ts); older
-// runtimes legitimately use the sqlite3-CLI fallback, so the in-process
-// regression test below skips there instead of failing.
-const [nodeMajor = 0, nodeMinor = 0] = process.versions.node.split(".").map(Number);
-const hasNodeSqlite = nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 13);
+// Probe whether THIS runtime loads node:sqlite unflagged (22.13+/23.4+, and
+// not disabled via NODE_OPTIONS) by asking a child process that runs exactly
+// like the spawned CLI does. Runtimes without it legitimately use the
+// sqlite3-CLI fallback, so the in-process regression test below skips there
+// instead of failing — a version gate would misclassify 23.0–23.3.
+const hasNodeSqlite =
+  spawnSync(process.execPath, ["-e", 'require("node:sqlite")'], { encoding: "utf8" }).status === 0;
 
 interface RunOptions {
   cwd?: string;
@@ -557,8 +559,8 @@ describe("built CLI e2e", () => {
         .filter((file) => file.endsWith(".js"))
         .map((file) => readFile(path.join(repoRoot, "dist", file), "utf8")),
     );
-    expect(sources.some((source) => source.includes('import("node:sqlite")'))).toBe(true);
-    expect(sources.some((source) => source.includes('import("sqlite")'))).toBe(false);
+    expect(sources.some((source) => /import\(["']node:sqlite["']\)/.test(source))).toBe(true);
+    expect(sources.some((source) => /import\(["']sqlite["']\)/.test(source))).toBe(false);
   });
 
   it.skipIf(!hasNodeSqlite)("reads opencode sessions in-process with no sqlite3 binary on PATH", async () => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -18,6 +18,13 @@ export default defineConfig({
   // built cli.js) consumes them at runtime. A bundled end-user CLI ships JS only.
   sourcemap: false,
   dts: false,
+  // tsup defaults removeNodeProtocol to true (legacy-Node compat), rewriting
+  // `import("node:sqlite")` to `import("sqlite")` in dist — ERR_MODULE_NOT_FOUND
+  // at runtime, which silently forced every sqlite read onto the per-query
+  // sqlite3-CLI spawn fallback (measured ~4x slower end-to-end on sqlite-heavy
+  // machines). `node:sqlite` is only addressable WITH the prefix, and engines
+  // require Node >=20 where the prefix is always supported — never strip it.
+  removeNodeProtocol: false,
   banner: {
     js: "#!/usr/bin/env node",
   },


### PR DESCRIPTION
## What

tsup's `removeNodeProtocol` default (true) rewrote `import("node:sqlite")` to `import("sqlite")` in `dist/` — `ERR_MODULE_NOT_FOUND` at runtime, silently degrading every sqlite read (opencode, Cursor) in the **published CLI** to a per-query `sqlite3`-binary spawn. The in-process fast path (`src/parse/sqlite.ts`) was unreachable in every npm install; only src-based unit tests ever exercised it.

**Fix:** `removeNodeProtocol: false` in `tsup.config.ts`. `node:sqlite` is only addressable *with* the prefix, and `engines` requires Node >=20 where the prefix is always supported — stripping is pure downside.

## Evidence

- CPU profile of `aireceipts statusline` on a sqlite-heavy machine: 3.08s of a 4.0s run inside `spawnSync` (`sqlite3` per query).
- Same invocation with the specifier restored: **4.0s → 1.15s** (~3.5x).
- Node ≥22.13 also drops the `sqlite3`-binary requirement for opencode/Cursor reads entirely (the fallback stays for older runtimes).

## Regression tests (built artifact — unit tests structurally can't catch this)

1. **Artifact:** every `dist/**/*.js` keeps `import("node:sqlite")`; the stripped `import("sqlite")` signature must not appear.
2. **Behavioral:** the built CLI lists an opencode fixture with `PATH` pinned to an empty dir (CLI fallback unreachable) — passes only if the in-process import resolves. Skips (not fails) on runtimes without unflagged `node:sqlite`, detected by a child-process capability probe rather than a version table (Node 23.0–23.3 gotcha, `NODE_OPTIONS` respected).

**Negative control:** both tests verified to fail with `removeNodeProtocol: true` and pass with the fix.

Full verification block green, unmasked: tsc / eslint / vitest (1750) / goldens / determinism ×10 / spec-lint / hygiene — all `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)