### PR TITLE
docs: SPEC-0075 terminal statusline (approved) + SPEC-0074 tombstone

### DIFF
--- a/specs/SPEC-0074-opencode-statusline-plugin.md
+++ b/specs/SPEC-0074-opencode-statusline-plugin.md
@@ -1,0 +1,199 @@
+---
+id: SPEC-0074
+title: "opencode statusline plugin — surface the line via session.idle → state file"
+status: rejected
+milestone: M5
+depends: [SPEC-0007, SPEC-0062, SPEC-0050]
+---
+
+# SPEC-0074: opencode statusline plugin
+
+## Purpose
+
+`aireceipts statusline` already renders a correct line for opencode sessions in
+disk-fallback mode (`[aireceipts · <opencode label>]`, SPEC-0062 R1) — the CLI side is
+done. What's missing is a way to *surface* it inside an opencode workflow the way Claude
+Code's `statusLine` config does. opencode has **no** stable native footer/statusline render
+hook yet (open feature requests: opencode #8619 `ui.statusLine`, #18969 `ui.footer`, #23539
+status-bar widgets), so an in-TUI footer render is not available. It **does** have a stable
+plugin system: a plugin receives `$` (Bun shell) and an `event` catch-all hook, loaded via
+`tui.json`'s `plugin` array. This spec ships a thin opencode plugin that, on
+`session.idle`, runs the already-working CLI and writes the one line to a **state file** an
+external statusline surface (tmux / shell / starship) displays — the same file-exposure
+pattern the community `opencode-subagent-statusline` package uses. Serves **I1** (the plugin
+adds zero network — it only invokes the deterministic CLI), **I2/I3** (nothing new is
+computed; the line is the CLI's existing honest output — tokens-only when unpriced, never a
+fabricated `$`), and **I5** (the shipped plugin snippet is generated from a tested helper so
+it can't drift). Research-derived; see the conversation's Codex/opencode capability audit.
+
+## Requirements
+
+- **R1 — thin `session.idle` plugin.** Ship an opencode plugin (source in-repo,
+  distributed through the integration recipe, R4) that subscribes the `event` hook and, on
+  `event.type === "session.idle"`, runs `aireceipts statusline` via Bun `$` and writes
+  stdout's single line to a state file. The plugin carries **no** parse/pricing/policy logic
+  — the existing opencode recipe rule (`src/setup/integrations.ts:124` — "No parser,
+  pricing, or receipt policy logic belongs in the assistant wrapper"). The invocation is
+  **disk-fallback** (no stdin), because stdin mode is Claude-Code-only
+  (`src/cli/commands/statusline.ts:65` hardcodes `loadById("claude-code", …)`); disk-fallback
+  already produces the `[aireceipts · <opencode label>]` line for the newest opencode session
+  (`loadFromDisk`, `statusline.ts:73`).
+- **R2 — state-file contract.** Write is **atomic** (temp file + rename, the repo's existing
+  pattern per SPEC-0062 R4). Default path is `$XDG_RUNTIME_DIR/aireceipts/opencode-status.txt`
+  when `XDG_RUNTIME_DIR` is set, else the OS temp dir; overridable via
+  `AIRECEIPTS_OPENCODE_STATUS_FILE`. The file is a **cache of one line** (last-writer-wins,
+  never a ledger). **Fail-safe:** a non-zero CLI exit, empty stdout, or write error leaves any
+  previous file untouched and the hook returns cleanly — the plugin never overwrites a good
+  line with a blank/fabricated one, and never throws into opencode's event loop (I2/I3
+  honesty: silence over a wrong line).
+- **R3 — one-paste consumer wiring.** Docs ship copy-paste snippets for the two common
+  surfaces that read the file: tmux (`status-right` running `cat`/a tiny reader) and a
+  shell/starship prompt segment. This is the kill-criterion mitigation (below): a file nobody
+  reads is dead weight, so the consumer setup cost must be a single paste.
+- **R4 — recipe + setup parity.** The `codex`-sibling opencode recipe in
+  `src/setup/integrations.ts` (currently `.opencode/commands/receipt.md`, lines 102–128) gains
+  the plugin file, the `tui.json` `plugin` entry, and the R3 wiring snippet, surfaced through
+  `integrations`/`setup` output. `docs/guide/15-integrations.md` and a new
+  `docs/statusline.md` section document it in the **same PR** (the SPEC-0043/0062 docs-parity
+  rule). The docs state plainly: this is **not** an in-TUI footer render — it is a state file
+  an external surface displays — and it reflects the **newest** opencode session (R-limitation
+  in Non-goals).
+- **R5 — tested pure helper (no drift).** The plugin's non-Bun logic — resolve the state-file
+  path (env → `XDG_RUNTIME_DIR` → tmp), atomic write, and the fail-safe "don't overwrite on
+  empty/failed output" rule — lives in an importable helper covered by vitest without an
+  opencode runtime. The shipped plugin snippet is **generated from / asserted byte-equal to**
+  that helper's source in a test, so the recipe can't drift from the tested logic (same
+  discipline that gates the other integration snippets).
+- **R6 — no new network, telemetry unchanged.** The plugin invokes the CLI and nothing else;
+  the CLI already records `integration_surface_rendered` with the `statusline` enum
+  (`statusline.ts:161`). No new telemetry event and no new network path ship with this spec
+  (I1/I4; SPEC-0043 rule — schema changes only alongside the code that needs them). The plugin
+  is offline-pure beyond the single local CLI spawn.
+
+## Scenarios
+
+- **Given** opencode with the plugin loaded and a priced opencode session, **When** the agent
+  goes idle, **Then** `$XDG_RUNTIME_DIR/aireceipts/opencode-status.txt` contains one line,
+  `[aireceipts · <opencode label>] $X.XX · …`, and a wired tmux/shell surface shows it.
+- **Given** an unpriced opencode session, **When** the hook runs, **Then** the file holds the
+  tokens-only line (no `$` bytes) — the CLI's existing I2 behavior, unchanged by the plugin.
+- **Given** the `aireceipts` binary is absent / exits non-zero / prints nothing, **When** the
+  hook runs, **Then** the prior file is left intact, no exception escapes into opencode, and
+  the next successful idle repairs it.
+- **Given** `AIRECEIPTS_OPENCODE_STATUS_FILE=/custom/path`, **When** the hook runs, **Then**
+  the line is written there atomically (temp + rename).
+- **Given** no external surface is wired to read the file, **When** the hook runs, **Then**
+  the line is still written (the plugin's job) but nothing displays — documented, and the R3
+  snippets exist precisely to close this gap.
+
+## Non-goals
+
+- **In-TUI native footer/statusline render.** Blocked on opencode `ui.statusLine`/`ui.footer`
+  (#8619/#18969/#23539, open). Documented follow-on: drop the CLI line into that hook the
+  moment it ships; until then the state file is the surface.
+- **Setting the terminal title.** Unverified whether a server-side opencode plugin's `$`
+  reaches the user's TTY (opencode's client/server split); not promised until proven. If
+  verified later, it's an additive R, not a rewrite.
+- **npm-publishing the plugin as a standalone package.** A release/packaging call (the
+  maintainer's four buttons); v1 ships source + recipe. `tui.json` can also load a published
+  package name later without changing the plugin logic.
+- **Multi-session concurrency correctness.** Disk-fallback is newest-wins; with two concurrent
+  opencode sessions the line reflects the most-recently-active, not necessarily "this" TUI. A
+  session-scoped read needs opencode-path support in statusline stdin mode
+  (`statusline.ts:65`), a separate spec. v1 documents the single-session assumption.
+- **Codex parity.** Codex exposes no plugin or command-backed status-line surface (openai/codex
+  #17827, open) — there is no viable mechanism to spec, so Codex is explicitly out of scope
+  here.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R2 atomic write | helper given a line + target path | temp file created then renamed; final file = the line |
+| R2 default path | `XDG_RUNTIME_DIR` set / unset | `$XDG_RUNTIME_DIR/aireceipts/…` / OS-tmp path |
+| R2 env override | `AIRECEIPTS_OPENCODE_STATUS_FILE=…` | write goes to the override path |
+| R2 fail-safe empty | helper given empty/whitespace output, prior file present | prior file unchanged, no throw |
+| R2 fail-safe write error | target dir unwritable | no throw; prior file (if any) intact |
+| R1 disk-fallback line | priced opencode session | line starts `[aireceipts · <opencode label>] `, has `$` |
+| R1 unpriced I2 | unpriced opencode session | tokens-only line, zero `$` bytes |
+| R5 snippet parity | shipped plugin snippet vs helper source | byte-equal (drift test fails otherwise) |
+| R4 recipe present | `integrations`/`setup` opencode output | includes plugin + `tui.json` entry + R3 wiring |
+| R6 no network | plugin logic path | no network call; only the local CLI spawn |
+
+## Success criteria
+
+- [ ] R1–R6 implemented: the plugin surfaces the CLI line on `session.idle` into an
+      atomically-written, env-overridable, fail-safe state file; the pure helper is
+      vitest-covered and the shipped snippet is asserted equal to it.
+- [ ] `docs/statusline.md` opencode section + `docs/guide/15-integrations.md` + the
+      `integrations`/`setup` opencode recipe updated in the same PR, stating plainly it is a
+      state-file surface (not an in-TUI footer) reflecting the newest opencode session.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`,
+      `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
+      `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked (`echo $?`).
+
+## Validation
+
+*2026-07-09 — S1 self, S2 Codex (independent), S3 worth gate, S4 lint.*
+
+- **S1 (self):** every rendered value is the CLI's existing honest output (I2 tokens-only
+  when unpriced; no new fabricated `$`). But the self-audit missed the correctness hole S2
+  found — the design assumed disk-fallback is opencode-scoped when it is not.
+- **S2 (Codex) — findings, mostly accepted:**
+  1. *Accepted (High, correctness — kills the premise).* Disk-fallback is **not**
+     opencode-scoped: `loadFromDisk` (`statusline.ts:73`) takes `sessions[0]` from an unfiltered,
+     globally recency-sorted `listSessions()` (`load.ts:11`). So "newest opencode session" is
+     false — it renders the globally-newest agent's line, mislabeled. Correct scoping needs a
+     **CLI change** (an `--agent opencode` filter, or opencode-path support in stdin mode past
+     the `claude-code` hardcode at `statusline.ts:65`) — so "the CLI side is already done" is
+     wrong. The plugin cannot fix this from opencode's side.
+  2. *Accepted (worth — decisive).* Smaller non-feature fix: tmux/starship can invoke
+     `aireceipts statusline </dev/null` **directly** on their own refresh — no plugin, no state
+     file, no `session.idle` hook, no producer/consumer split. It has the *same* global-newest
+     limitation, so the plugin buys nothing on correctness and only adds machinery.
+  3. *Accepted.* "No network" was misleading — the spawned CLI records
+     `integration_surface_rendered` (`statusline.ts:161`); reworded would be needed.
+  4. *Accepted.* R5 (byte-equal shipped snippet vs helper) is machinery without user value and
+     is incoherent once the plugin wrapper holds Bun/event code the pure helper lacks.
+  5. *Accepted.* Scope creep — state-file API + atomic writer + env contract + generated-source
+     + two prompt integrations + three doc surfaces far exceed "surface the line."
+  6. *Confirmed true & useful:* opencode parsing does exist (`src/parse/opencode.ts:462`), so a
+     line *can* render — but per finding 1 it isn't reliably the opencode one.
+- **S3 — worth answers.** *Who/how often:* the cohort is opencode ∩ aireceipts ∩ tmux/starship
+  ∩ willing-to-configure-both-a-plugin-and-a-consumer — unmeasured, and telemetry can't correlate
+  statusline renders to agent source (I4 has no repo/agent-attribution dim). *One-off vs
+  recurring:* recurring in principle, but the surface is out-of-band (tmux/shell), not opencode's
+  own footer, so it isn't the "same status line" the request imagined. *Do-nothing:* fine —
+  opencode receipts already work; `aireceipts statusline </dev/null` already prints a line today.
+  *Smaller fix:* a **doc snippet** (tmux `status-right` / starship command running the CLI
+  directly) delivers ~80% with zero code. *Steelman the cut:* a plugin that requires configuring
+  a producer *and* a separate consumer doubles setup for a line that still shows the wrong session
+  and renders outside opencode — the doc dominates it. *Kill-criterion dry-run:* no evidence of
+  demand; cheapest experiment is shipping the doc and seeing if anyone asks for in-TUI.
+
+  **Verdict: cut.** The plugin as drafted is parked. The genuinely worth-building residue is a
+  separate, smaller spec: an **opencode-scoped statusline** (`--agent <label>` filter or a
+  session-path input) so *any* surface — tmux today, opencode's `ui.statusLine` when it ships —
+  can show the *correct* opencode session. That's a CLI capability with lasting value; this
+  plugin is not.
+- **S4:** `node scripts/spec-lint.mjs` — pass.
+
+## Tombstone
+
+*Rejected 2026-07-09 (S3: cut).* **Tried:** an opencode plugin hooking `session.idle` to run
+`aireceipts statusline` and write the line to an atomically-written state file for an external
+tmux/shell surface to display — the "doable-now" path, since opencode has no native
+`ui.statusLine`/`ui.footer` hook yet (#8619/#18969/#23539).
+
+**Why rejected:** (1) *Correctness* — disk-fallback renders the globally-newest session, not the
+opencode one (`statusline.ts:73` + `load.ts:11`), so the plugin surfaces a possibly-mislabeled
+line and cannot fix that without a CLI-side scoping flag. (2) *Worth* — a doc snippet
+(`aireceipts statusline </dev/null` in `tmux status-right` or a starship command) delivers the
+same out-of-band line today with zero code; the plugin only adds a producer/consumer split that
+likely deters adoption.
+
+**What would change the answer:** opencode ships a native command-backed `ui.statusLine`/`ui.footer`
+hook (then aireceipts drops the line into the real footer, in-band, and a thin plugin is
+justified) — *and/or* a small separate spec adds opencode-scoping to `statusline` so the line is
+provably the opencode session. Absent both, the honest interim is the doc, not this plugin.

--- a/specs/SPEC-0075-terminal-statusline.md
+++ b/specs/SPEC-0075-terminal-statusline.md
@@ -47,8 +47,15 @@ R6, R7. The `node:sqlite` fix PR precedes stage 1.*
   matching; Codex/opencode: their summaries' `cwd` field, measured present 652/652
   and 1/1). Matching = normalized equality or path-prefix (a pane deep in the repo
   matches the repo-root session; normalization is platform-aware: case-folded drive
-  letters, `\`→`/`; prefix means whole path segments — `/repo` never matches
-  `/repo-old`). **Confirm-on-load:** because the CC encoding collides (`/my-repo`
+  letters, `\`→`/`, lexical `.`/`..` resolution; prefix means whole path segments —
+  `/repo` never matches `/repo-old`). **Home-shadow guard** (found by real-data
+  visual e2e during the stage-1 build): a session recorded at the user's home
+  directory or above (an agent launched from `~` or `/`) matches its **exact** path
+  only — it never ancestor-matches, because one `~`-launched session is an ancestor
+  of every path on the machine and would permanently shadow the placeholder.
+  Ancestor matching stays for project roots below home and outside it (`/srv/app`
+  still matches `/srv/app/sub`); a monorepo rooted exactly at `$HOME` needs the
+  exact path — a deliberate, documented trade. **Confirm-on-load:** because the CC encoding collides (`/my-repo`
   and `/my/repo` both encode to `-my-repo`), a candidate matched by directory name
   is confirmed against the loaded session's own `cwd` field (`src/parse/types.ts:126`
   — the SPEC-0019 attribution field PR receipts already rely on); disagreement → not
@@ -137,6 +144,9 @@ tmux-only (timer surfaces tolerate latency; wrong data is never tolerated).
   placeholder renders, never the colliding project's dollars.
 - **Given** no session ever ran in `/repo`, **When** `--cwd /repo` renders, **Then**
   the neutral placeholder — never another project's line.
+- **Given** only a session launched from `~`, **When** `--cwd /repo` renders, **Then**
+  the placeholder (home-or-above sessions match their exact path only); **When**
+  `--cwd ~` renders, **Then** that session's line (exact match still allowed).
 - **Given** a usable stdin payload **and** `--cwd`, **When** the line renders,
   **Then** stdin wins (native behavior, unchanged).
 - **Given** `statusline.json` `{"items":["brand","cost","burn"]}` and no `--format`,
@@ -176,6 +186,7 @@ tmux-only (timer surfaces tolerate latency; wrong data is never tolerated).
 | R1 CC encoded match | CC project dir `-my-repo`, `--cwd /my/repo`, loaded cwd `/my/repo` | matches |
 | R1 collision guarded | CC project dir `-my-repo`, `--cwd /my-repo`, loaded cwd `/my/repo` | no match, placeholder |
 | R1 no match | `--cwd /never-used` | neutral placeholder, exit 0 |
+| R1 home-shadow guard | only a `~`-launched session exists, `--cwd /never-used` | placeholder (home session never ancestor-matches) |
 | R1 cursor excluded | only a Cursor session for the cwd | placeholder (never matched) |
 | R1 unscoped unchanged | no `--cwd`, no stdin | today's global-newest line, byte-identical |
 | R2 config renders | `statusline.json` items `brand,cost` | exactly those, in order |

--- a/specs/SPEC-0075-terminal-statusline.md
+++ b/specs/SPEC-0075-terminal-statusline.md
@@ -1,0 +1,260 @@
+---
+id: SPEC-0075
+title: "Terminal-surface statusline — cwd-scoped, configurable, agent-agnostic (tmux first)"
+status: approved
+milestone: M5
+depends: [SPEC-0007, SPEC-0062, SPEC-0071]
+---
+
+# SPEC-0075: Terminal-surface statusline
+
+## Purpose
+
+Claude Code renders `aireceipts statusline` natively (SPEC-0007); Codex and opencode
+cannot — neither exposes a command-backed status surface (openai/codex #17827 open;
+sst/opencode #8619/#18969 open; SPEC-0074's tombstone records the rejected plugin
+detour). The agent-agnostic answer is to render at the **terminal** level: a surface
+that can run a command and display one line (tmux's status bar first) shows the line
+for every adapter at once, no per-agent hooks. Feasibility was measured on a heavy
+reference corpus (1.7 GB Claude Code, 2,557 sessions total): the CLI took ~4.0s, and
+CPU-profiling traced 3.08s to a **bundling defect** — tsup emits `import("sqlite")`
+(the `node:` prefix stripped) in `dist/`, the import throws `ERR_MODULE_NOT_FOUND`,
+and `src/parse/sqlite.ts`'s catch silently degrades every sqlite read to a
+`spawnSync("sqlite3", …)` per query. Hand-patching the prefix took the same
+invocation to **1.1s**. That fix ships first as its own `fix:` PR (it speeds every
+command for every npx user on Node ≥22.5, where `node:sqlite` exists; Node 20/21
+keeps the CLI fallback); **this spec assumes it and builds the surface on top**,
+staged: cwd-scoped selection + the tmux recipe first, then config/more surfaces.
+Serves **I2/I3** (scoping can only *omit* or *verify* — nothing new is computed, and
+a line is never attributed to a cwd the session's own data doesn't confirm), **I5**
+(default output pinned; the native stdin path untouched), **I1** (no daemon, no
+watcher — each render is one process with reads bounded to the scoped project).
+
+## Requirements
+
+*Staged build (SPEC-0062 precedent): stage 1 = R1, R3a, R5, R8; stage 2 = R2, R3b,
+R6, R7. The `node:sqlite` fix PR precedes stage 1.*
+
+- **R1 — `--cwd <path>` scoped selection (stage 1).** `aireceipts statusline --cwd
+  <path>` selects the newest session **attributed to that path** instead of the
+  globally newest (`loadFromDisk` today returns `sessions[0]` from the unfiltered
+  recency-sorted `listSessions()` — `src/cli/commands/statusline.ts:73` — which is the
+  wrong session whenever another agent ran more recently anywhere on the machine).
+  Discovery in `--cwd` mode is **scoped, not post-filtered**: adapters are queried
+  for the one project (Claude Code: only the project dir whose name equals the
+  **encoded** `--cwd` — encoding via the documented `/`→`-` scheme is deterministic;
+  the lossy *decode* direction from `src/aggregate/project.ts:14` is never used for
+  matching; Codex/opencode: their summaries' `cwd` field, measured present 652/652
+  and 1/1). Matching = normalized equality or path-prefix (a pane deep in the repo
+  matches the repo-root session; normalization is platform-aware: case-folded drive
+  letters, `\`→`/`; prefix means whole path segments — `/repo` never matches
+  `/repo-old`). **Confirm-on-load:** because the CC encoding collides (`/my-repo`
+  and `/my/repo` both encode to `-my-repo`), a candidate matched by directory name
+  is confirmed against the loaded session's own `cwd` field (`src/parse/types.ts:126`
+  — the SPEC-0019 attribution field PR receipts already rely on); disagreement → not
+  a match. No match → the existing neutral no-session placeholder — **never** a
+  silent fall-back to another project's session (I2/I3: a wrong line is worse than
+  none). Unscoped invocations keep today's global-newest behavior byte-for-byte.
+  Cursor sessions carry neither `cwd` (0/41 measured) nor a decodable path and are
+  never matched — documented.
+- **R2 — persistent item config, Codex-parity (stage 2).**
+  `~/.aireceipts/statusline.json` (under `AIRECEIPTS_HOME`, the existing
+  `budget.json` convention) holds `{"items": ["brand", "cost", …]}` — an ordered
+  list from the SPEC-0062 segment vocabulary, mirroring Codex's `[tui].status_line`
+  ergonomics. Precedence: explicit `--format` > config file > `DEFAULT_FORMAT`. An
+  explicit `--format` keeps SPEC-0062's fail-fast (exit 1, list on stderr); an
+  **invalid config file** (unknown item, bad JSON, wrong shape) degrades to
+  `DEFAULT_FORMAT` with one stderr note — a broken dotfile must never blank a status
+  bar that polls unattended ("layout never breaks", SPEC-0007). The config applies
+  wherever the statusline renders (native included — user-authored config shaping
+  the user's own line is the `budget.json` pattern; I5's goldens pin the *default*).
+  Config selects **which** honest segments render, in what order; it cannot inject
+  text, color, or values outside the vocabulary (I2/I3).
+- **R3a — tmux recipe (stage 1).** `docs/statusline.md` + the guide ship a
+  copy-paste tmux recipe: `status-right` polling
+  `aireceipts statusline --cwd "#{pane_current_path}"` on `status-interval`. tmux is
+  the **flagship** surface because it is the only one visible *while* an agent owns
+  the terminal — a prompt segment or title only refreshes between commands.
+  Coloring/width stay the surface's job (tmux `#[fg=…]`); aireceipts output stays
+  plain text (SPEC-0071 R6 stands).
+- **R3b — prompt-engine + title recipes (stage 2).** starship + raw zsh/bash
+  per-prompt snippets and an OSC terminal-title precmd, each passing `$PWD` to
+  `--cwd`. Because prompt latency budgets (starship's 500ms default
+  `command_timeout`) sit below Node's ~1s floor, the prompt snippets use an
+  async-cached pattern — print the last cached line, kick a fire-and-forget refresh
+  for the next prompt; the cache write is atomic and **keyed by cwd** (no
+  cross-pane bleed), and the recipe states both the one-prompt staleness and the
+  between-commands-only visibility plainly.
+- **R4 — the contract, not a catalog.** The docs state the general contract — any
+  surface that can run a command and display one line of stdout works; pass your
+  pane/prompt cwd to `--cwd` — so screen/oh-my-posh/fish/pwsh/iTerm2 users derive
+  their own wiring without aireceipts owning every tool. Claude Code guidance is
+  explicit: the native `statusLine` hook stays the recommended surface (richer —
+  `context`/`quota*` are stdin-payload-only and structurally absent from any
+  disk-fallback render; and faster — `loadById` reads one file, no discovery). The
+  terminal surface is additive for CC users, primary for Codex/opencode.
+- **R5 — native path untouched (stage 1).** The stdin mode (`loadFromStdinPayload`,
+  `statusline.ts:59`) is not modified; `--cwd` only replaces the *disk-fallback*
+  selector, and a usable stdin payload wins over `--cwd` (the host knows its own
+  session better than any path heuristic). Existing statusline tests keep passing
+  unloosened; the default line's bytes are unchanged (I5).
+- **R6 — poll-safe telemetry (stage 2).** A `--cwd` invocation is a polled surface:
+  it records the SPEC-0043 local counter but **skips the network flush** (a 15s tmux
+  poll must not emit ~5,760 events/day — amplification, and the flush costs ~0.4s
+  latency per render). The `integration_surface_rendered` schema gains a `scoped`
+  boolean and a `configFile` boolean (strict schema, fixtures, `docs/telemetry.md`
+  in the same PR; booleans only — never the path or the format string), emitted on
+  the non-polled invocations that do flush.
+- **R7 — cross-platform proof, not assertion (stage 2).** The cwd
+  normalizer/matcher is pure and unit-tested for POSIX and Windows shapes
+  (drive-letter case, backslashes, trailing separators, segment-prefix semantics),
+  and a `windows-latest` CI job runs those tests plus `statusline --cwd`
+  end-to-end on a fixture corpus. Windows recipes = starship/oh-my-posh/pwsh prompt
+  + Windows Terminal OSC title (tmux documented as WSL-only). On Node ≥22.5 the
+  `node:sqlite` fix removes the `sqlite3.exe` requirement for opencode/Cursor reads;
+  Node 20/21 keeps the documented CLI fallback.
+- **R8 — measured latency budget (stage 1).** On the reference heavy corpus
+  (machine + corpus stats recorded in Validation), `statusline --cwd` end-to-end
+  (process spawn to line) stays **≤ 1.5s worst-case** — with the bundling fix
+  (measured 1.1–1.2s unscoped) plus scoped discovery (skips the ~0.5s Cursor sqlite
+  read and the cross-agent scan) the expectation is ≲ 1s; 1.5s is the pass/fail
+  line and the kill criterion's trigger. CI asserts the *in-process* scoped pipeline
+  under the existing 200ms-budget pattern (`test/cli/statusline.test.ts:194`); the
+  wall-clock number is recorded in Validation, not CI-flaked.
+
+**Kill criterion:** if scoped end-to-end can't hold ≤ 1.5s on the reference corpus,
+or cwd matching produces wrong-session lines in real multi-worktree use despite
+confirm-on-load, stage 2's prompt-engine recipes are cut and the feature ships
+tmux-only (timer surfaces tolerate latency; wrong data is never tolerated).
+
+## Scenarios
+
+- **Given** a Codex session in `/repo` and a newer Claude Code session elsewhere,
+  **When** tmux runs `aireceipts statusline --cwd /repo`, **Then** the line is the
+  Codex session's (`[aireceipts · Codex] …`), not the newer foreign one.
+- **Given** sessions in `/my/repo` and a `--cwd /my-repo` (encoding collision),
+  **When** the CC candidate's loaded `cwd` says `/my/repo`, **Then** no match — the
+  placeholder renders, never the colliding project's dollars.
+- **Given** no session ever ran in `/repo`, **When** `--cwd /repo` renders, **Then**
+  the neutral placeholder — never another project's line.
+- **Given** a usable stdin payload **and** `--cwd`, **When** the line renders,
+  **Then** stdin wins (native behavior, unchanged).
+- **Given** `statusline.json` `{"items":["brand","cost","burn"]}` and no `--format`,
+  **When** the line renders, **Then** exactly those segments in that order.
+- **Given** a corrupt `statusline.json`, **When** the line renders, **Then** the
+  default format renders, one stderr note, exit 0.
+- **Given** a tmux poll every 15s for a working day, **When** telemetry state is
+  inspected, **Then** local counters advanced and no per-poll network flush occurred.
+- **Given** a Windows path `C:\repo\sub` and a Codex session with `cwd` `c:/repo`,
+  **When** matching runs, **Then** it matches (case-folded drive, normalized
+  separators, segment-prefix rule).
+
+## Non-goals
+
+- **The `node:sqlite` bundling fix itself** — ships first as a standalone `fix:` PR
+  with a built-artifact regression test (asserting `import("node:sqlite")` survives
+  bundling); this spec depends on but does not contain it.
+- **Any daemon, watcher, or background service** — each render is one process (I1);
+  the async-prompt pattern is a per-prompt fire-and-forget, not a resident process.
+- **In-agent TUI rendering for Codex/opencode** — no surface exists (codex #17827,
+  opencode #8619/#18969); revisit the moment either ships a command-backed hook.
+- **`context`/`quota*` segments outside CC-native** — stdin-payload-only facts;
+  rendering them from disk would be fabrication (I2/I3).
+- **Cursor scoping** — no `cwd` on Cursor sessions (0/41); unpriced anyway; never
+  matched, documented.
+- **Per-surface config blocks / an interactive `--configure` picker** — `--format`
+  covers per-surface divergence; a picker is v2 polish.
+- **Colors/ANSI from aireceipts** — the surface owns presentation (SPEC-0071 R6).
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 scoped pick | Codex session cwd `/repo`, newer CC session elsewhere, `--cwd /repo` | Codex line renders |
+| R1 prefix match | session cwd `/repo`, `--cwd /repo/sub/dir` | matches |
+| R1 sibling rejected | session cwd `/repo`, `--cwd /repo-old` | no match (segment-prefix, not string-prefix) |
+| R1 CC encoded match | CC project dir `-my-repo`, `--cwd /my/repo`, loaded cwd `/my/repo` | matches |
+| R1 collision guarded | CC project dir `-my-repo`, `--cwd /my-repo`, loaded cwd `/my/repo` | no match, placeholder |
+| R1 no match | `--cwd /never-used` | neutral placeholder, exit 0 |
+| R1 cursor excluded | only a Cursor session for the cwd | placeholder (never matched) |
+| R1 unscoped unchanged | no `--cwd`, no stdin | today's global-newest line, byte-identical |
+| R2 config renders | `statusline.json` items `brand,cost` | exactly those, in order |
+| R2 precedence | config file + explicit `--format tokens` | `--format` wins |
+| R2 corrupt file | invalid JSON / unknown item / wrong shape | default format, stderr note, exit 0 |
+| R2 AIRECEIPTS_HOME | config under overridden home | honored (existing convention) |
+| R2 flag fail-fast | `--format bogus` (config valid) | exit 1, list on stderr, empty stdout |
+| R3a recipe present | `docs/statusline.md` after stage 1 | tmux snippet exists, passes `#{pane_current_path}` to `--cwd` |
+| R3b recipes present | docs after stage 2 | starship-async (atomic, cwd-keyed cache; staleness + visibility notes) and OSC-title snippets |
+| R4 contract + CC guidance | docs after the PR | run-a-command contract stated; CC-native recommended with the ctx/quota reason |
+| R5 native untouched | stdin payload invocation, before/after | byte-identical line; existing tests unloosened |
+| R5 stdin + `--cwd` | usable payload and a `--cwd` flag | stdin wins |
+| R6 poll no-flush | `--cwd` invocation | local counter advanced, no network flush |
+| R6 telemetry booleans | non-polled scoped/config runs | `scoped`/`configFile` present, strict schema passes |
+| R7 win paths | `C:\repo\sub` vs `c:/repo` | match (unit, runs in windows-latest CI) |
+| R7 posix paths | trailing `/`, literal-hyphen dirs | match rules hold |
+| R8 in-process budget | scoped pipeline on children fixture | within the 200ms in-process budget |
+
+## Success criteria
+
+- [ ] Stage 1 (R1, R3a, R5, R8) shipped after the `fix:` PR; stage 2 (R2, R3b, R6,
+      R7) on the same spec.
+- [ ] tmux recipe verified live on macOS/Linux showing the scoped line; wall-clock
+      ≤ 1.5s recorded in Validation on the reference corpus.
+- [ ] `docs/statusline.md`, the guide page, `docs/telemetry.md`, and the
+      `integrations` recipe updated in the same PR as the code they describe.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs`,
+      `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
+      `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked
+      (`echo $?`).
+
+## Validation
+
+*2026-07-09 — S1 self (Fable), S2 Codex (independent, read-only), S3 worth gate,
+S4 lint. Feasibility evidence: profiled CLI 4.0s → 3.08s in `spawnSync sqlite3`;
+`dist/chunk-*.js` emits `import("sqlite")` (prefix stripped) vs source's
+`import("node:sqlite")`; hand-patched chunk re-timed at 1.1–1.2s; per-adapter cold
+discovery: claude-code 84ms/1,863, codex 54ms/652, cursor ~0.5s/41, opencode 6ms/1;
+worst-case pricing pipeline (136 MB Codex session) 0.66s; cwd coverage: codex
+652/652, opencode 1/1, claude-code 0/1,863 (path-encoded), cursor 0/41.*
+
+- **S1:** every rendered value is an existing SPEC-0007/0062/0071 value — this spec
+  adds *selection and placement*, no new numbers; scoping can only omit (placeholder)
+  or verify (confirm-on-load), so I2/I3 are structurally preserved; I5 pinned by the
+  unscoped-unchanged and native-untouched matrix rows.
+- **S2 (Codex) — accepted, fixed in this draft:** `node:sqlite` absent on Node
+  20/21 → fix-PR claim scoped to Node ≥22.5, fallback documented (R7); CC `-`→`/`
+  *decode* is lossy (`/my-repo` ≡ `/my/repo`) → matching now uses the lossless
+  *encode* direction plus confirm-on-load against the session's own `cwd`
+  (SPEC-0019 field), collision scenario + matrix row added; "scoping skips the scan"
+  was asserted, not specified → R1 now requires scoped discovery, not
+  post-filtering, and "one process, one read" reworded; per-poll telemetry flush
+  amplification (~5,760 events/day) + 0.4s latency → R6 makes `--cwd` polls
+  local-count-only; starship/title are invisible while an agent owns the terminal →
+  tmux promoted to flagship (R3a, stage 1), prompt recipes staged with visibility +
+  staleness disclosed (R3b); missing matrix rows (sibling prefix, collision,
+  literal hyphen, `AIRECEIPTS_HOME`, stdin+`--cwd`, unscoped-unchanged, poll
+  no-flush) → added; 8 Rs too many → staged build, stage 1 = R1/R3a/R5/R8.
+- **S2 — noted, overridden with reasons:** *"R2 config contradicts I5/R5"* — I5's
+  goldens pin *default* output; a user-authored config shaping the user's own line
+  is the established `budget.json` pattern, and stdin-mode precedence is unchanged;
+  R2 kept (maintainer explicitly picked configurability, 2026-07-09 session) but
+  moved to stage 2 — adopting Codex's risk-ordering while keeping the picked scope
+  (the SPEC-0062 precedent). *"Reject; tmux-only v1"* — stage 1 *is* effectively
+  tmux-only; the staged spec preserves the approved scope without a second
+  approval round.
+- **S3 — worth:** *Who/how often:* the maintainer's own multi-agent workflow
+  (Codex + opencode + Claude Code, requested interactively 2026-07-09) and any
+  multi-agent user with a terminal surface — recurring, every working session;
+  Codex/opencode users currently have **no** statusline at all. *Do-nothing:* the
+  4s-per-render bundling bug persists for every npx user (the fix-PR alone is worth
+  shipping regardless of this spec), and Codex/opencode users keep flying blind
+  between receipts. *Smaller fix:* the unscoped doc snippet — rejected because
+  global-newest shows the wrong session's dollars on multi-agent machines, the
+  exact dishonesty aireceipts exists to avoid. *Steelman the cut:* the live-visible
+  cohort is tmux users, and prompt surfaces are stale-by-one-prompt — countered by
+  staging (tmux first) and by the kill criterion cutting stage 2 if the pattern
+  proves fiddly. *Kill-criterion dry-run:* the 1.1s measured post-fix baseline says
+  ≤1.5s scoped is realistic; if not, tmux-only survives. **Verdict: build now,
+  staged (fix-PR → stage 1 → stage 2).**
+- **S4:** `node scripts/spec-lint.mjs` — pass.


### PR DESCRIPTION
## What

Two spec-system artifacts from the terminal-statusline investigation (maintainer-approved 2026-07-09):

### SPEC-0075 — terminal-surface statusline (`status: approved`)

The agent-agnostic answer to "statusline for Codex/opencode": render at the **terminal** level (tmux first), since neither agent exposes a command-backed status surface (openai/codex#17827, sst/opencode#8619/#18969 all open). Staged scope:

- **Stage 1:** `--cwd` scoped session selection (encode-direction matching + confirm-on-load — never another project's dollars), tmux recipe, native Claude Code path untouched, measured ≤1.5s budget.
- **Stage 2:** Codex-parity `statusline.json` item config, starship/OSC-title recipes (async-cached, staleness disclosed), poll-safe telemetry (no per-poll network flush), `windows-latest` CI.

Gated on the `node:sqlite` bundling fix (#214) — profiler evidence in the spec's Validation record (4.0s → 1.15s), plus the full S1–S4 record: Codex adversarial review (6 findings accepted, 2 overruled with reasons) and the worth gate.

### SPEC-0074 — opencode statusline plugin (`status: rejected`, tombstone)

The `session.idle` plugin detour, killed by its own validation: disk-fallback selects the *globally* newest session (wrong-session lines a plugin can't fix from opencode's side), and a doc snippet dominates the remaining value. Reasoning preserved per the spec-system rule — rejected specs are never deleted.

`spec-lint`: 73 specs OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)