### PR TITLE
feat: statusline --cwd scoped selection + tmux recipe (SPEC-0075 stage 1)

### DIFF
--- a/docs/guide/07-statusline.md
+++ b/docs/guide/07-statusline.md
@@ -34,6 +34,10 @@ no daemon, one disk read per invocation.
 If `aireceipts` isn't on your `PATH`, put the absolute path (the output of `which
 aireceipts`) in the `command` field.
 
+Using tmux too? The [terminal-surfaces recipe](../statusline.md#terminal-surfaces)
+shows how to put the right session in each pane with `statusline --cwd`, while
+keeping Claude Code's richer native stdin hook as the primary setup.
+
 ## What the line shows
 
 The default line is the segment set `brand,cost,burn,tokens,context,waste,quota5h`

--- a/docs/statusline.md
+++ b/docs/statusline.md
@@ -34,8 +34,11 @@ Any terminal surface that can run a command and display one line of stdout can
 show an aireceipts statusline. Pass that surface's pane or prompt working
 directory to `--cwd`; aireceipts selects the newest session attributed to that
 path (or an ancestor of it) and prints the neutral placeholder when none match.
-It never falls back to another project's newest session. Cursor sessions never
-match in this mode because Cursor's session data carries no cwd.
+It never falls back to another project's newest session, and a session launched
+from your home directory (or above it) only ever matches that exact path — it is
+not treated as an ancestor of everything, so one `~`-launched session can't
+shadow every pane on the machine. Cursor sessions never match in this mode
+because Cursor's session data carries no cwd.
 
 For tmux, add this to `~/.tmux.conf`:
 

--- a/docs/statusline.md
+++ b/docs/statusline.md
@@ -28,6 +28,30 @@ If `aireceipts` isn't on your `PATH`, use an absolute path to the binary
 instead of `aireceipts` in the `command` field (for example, the output of
 `which aireceipts`).
 
+## Terminal surfaces
+
+Any terminal surface that can run a command and display one line of stdout can
+show an aireceipts statusline. Pass that surface's pane or prompt working
+directory to `--cwd`; aireceipts selects the newest session attributed to that
+path (or an ancestor of it) and prints the neutral placeholder when none match.
+It never falls back to another project's newest session. Cursor sessions never
+match in this mode because Cursor's session data carries no cwd.
+
+For tmux, add this to `~/.tmux.conf`:
+
+```tmux
+set -g status-right '#(aireceipts statusline --cwd "#{pane_current_path}")'
+```
+
+tmux refreshes `#(...)` commands on `status-interval`; lower that setting if you
+want a fresher line, keeping in mind that each refresh runs the command again.
+
+For Claude Code, its native `statusLine` stdin hook above remains the recommended
+surface. It is faster because the payload points directly at the active
+transcript, and it is richer: `context`, `quota5h`, `quota7d`, and `quotaEta`
+depend on stdin data. Terminal surfaces are additive when you also want a line
+in tmux or another shell UI.
+
 ## Output
 
 ```

--- a/goldens/cli/help.txt
+++ b/goldens/cli/help.txt
@@ -49,7 +49,7 @@ Usage:
   aireceipts --mini [selector]          6-line mini-receipt (newest session)
   aireceipts install-hook               add a Claude Code SessionEnd auto-receipt hook
   aireceipts uninstall-hook             remove that hook
-  aireceipts statusline [--format <s>]  one-line summary for Claude Code's statusLine
+  aireceipts statusline [--format <s>] [--cwd <path>]  one-line summary for Claude Code's statusLine
   aireceipts --help                     show this help
   aireceipts --version                  print the installed version
 

--- a/site/docs/07-statusline.html
+++ b/site/docs/07-statusline.html
@@ -357,6 +357,8 @@ footer{
 
 <p>If <code>aireceipts</code> isn't on your <code>PATH</code>, put the absolute path (the output of <code>which aireceipts</code>) in the <code>command</code> field.</p>
 
+<p>Using tmux too? The <a href="statusline.html#terminal-surfaces">terminal-surfaces recipe</a> shows how to put the right session in each pane with <code>statusline --cwd</code>, while keeping Claude Code's richer native stdin hook as the primary setup.</p>
+
 <h2 id="what-the-line-shows">What the line shows</h2>
 
 <p>The default line is the segment set <code>brand,cost,burn,tokens,context,waste,quota5h</code> — cost, burn rate, tokens, context fullness, a waste flag, and your rate-limit window:</p>

--- a/site/docs/statusline.html
+++ b/site/docs/statusline.html
@@ -351,6 +351,18 @@ footer{
 
 <p>If <code>aireceipts</code> isn't on your <code>PATH</code>, use an absolute path to the binary instead of <code>aireceipts</code> in the <code>command</code> field (for example, the output of <code>which aireceipts</code>).</p>
 
+<h2 id="terminal-surfaces">Terminal surfaces</h2>
+
+<p>Any terminal surface that can run a command and display one line of stdout can show an aireceipts statusline. Pass that surface's pane or prompt working directory to <code>--cwd</code>; aireceipts selects the newest session attributed to that path (or an ancestor of it) and prints the neutral placeholder when none match. It never falls back to another project's newest session. Cursor sessions never match in this mode because Cursor's session data carries no cwd.</p>
+
+<p>For tmux, add this to <code>~/.tmux.conf</code>:</p>
+
+<pre class="doc-code"><code class="language-tmux">set -g status-right '#(aireceipts statusline --cwd &quot;#{pane_current_path}&quot;)'</code></pre>
+
+<p>tmux refreshes <code>#(...)</code> commands on <code>status-interval</code>; lower that setting if you want a fresher line, keeping in mind that each refresh runs the command again.</p>
+
+<p>For Claude Code, its native <code>statusLine</code> stdin hook above remains the recommended surface. It is faster because the payload points directly at the active transcript, and it is richer: <code>context</code>, <code>quota5h</code>, <code>quota7d</code>, and <code>quotaEta</code> depend on stdin data. Terminal surfaces are additive when you also want a line in tmux or another shell UI.</p>
+
 <h2 id="output">Output</h2>
 
 <pre class="doc-code"><code>[aireceipts] $4.20 · $9/hr · 128k · ctx 42% · 5h 24% ↺2h13m

--- a/site/docs/statusline.html
+++ b/site/docs/statusline.html
@@ -353,7 +353,7 @@ footer{
 
 <h2 id="terminal-surfaces">Terminal surfaces</h2>
 
-<p>Any terminal surface that can run a command and display one line of stdout can show an aireceipts statusline. Pass that surface's pane or prompt working directory to <code>--cwd</code>; aireceipts selects the newest session attributed to that path (or an ancestor of it) and prints the neutral placeholder when none match. It never falls back to another project's newest session. Cursor sessions never match in this mode because Cursor's session data carries no cwd.</p>
+<p>Any terminal surface that can run a command and display one line of stdout can show an aireceipts statusline. Pass that surface's pane or prompt working directory to <code>--cwd</code>; aireceipts selects the newest session attributed to that path (or an ancestor of it) and prints the neutral placeholder when none match. It never falls back to another project's newest session, and a session launched from your home directory (or above it) only ever matches that exact path — it is not treated as an ancestor of everything, so one <code>~</code>-launched session can't shadow every pane on the machine. Cursor sessions never match in this mode because Cursor's session data carries no cwd.</p>
 
 <p>For tmux, add this to <code>~/.tmux.conf</code>:</p>
 

--- a/src/cli/commands/statusline.ts
+++ b/src/cli/commands/statusline.ts
@@ -84,10 +84,19 @@ export async function loadFromDisk(
 }
 
 /**
+ * SPEC-0075 R1 — the cap on full-transcript loads while walking scoped
+ * candidates newest-first. A collision-heavy Claude Code project dir could
+ * otherwise trigger an unbounded sequence of full parses in a status bar that
+ * polls; past the cap the line renders the neutral placeholder — bounded work
+ * and an honest omission, never a wrong session and never a latency blowup.
+ */
+export const MAX_SCOPED_LOAD_ATTEMPTS = 8;
+
+/**
  * SPEC-0075 R1 — load the newest cwd-scoped candidate. Claude Code directory
  * names are lossy, so its candidate must be confirmed against the cwd parsed
  * from the full transcript; a collision or unreadable candidate falls through
- * to the next-most-recent row.
+ * to the next-most-recent row, and the walk stops at MAX_SCOPED_LOAD_ATTEMPTS.
  */
 export async function loadFromCwd(
   requestedCwd: string,
@@ -95,7 +104,7 @@ export async function loadFromCwd(
   loadSessionFn: (summary: SessionSummary) => Promise<Session | null> = loadSession,
 ): Promise<Session | null> {
   const sessions = await listSessionsFn(requestedCwd);
-  for (const summary of sessions) {
+  for (const summary of sessions.slice(0, MAX_SCOPED_LOAD_ATTEMPTS)) {
     const session = await loadSessionFn(summary);
     if (!session) {
       continue;

--- a/src/cli/commands/statusline.ts
+++ b/src/cli/commands/statusline.ts
@@ -6,8 +6,9 @@
 // renders through the segments engine — the default line IS the format
 // `brand,cost,tokens,waste,quota5h`, and `--format` selects any other segment
 // list (unknown names fail fast, exit 1).
-import { listSessions, loadById, loadSession } from "../../index.js";
+import { listSessions, listSessionsForCwd, loadById, loadSession } from "../../index.js";
 import type { Session, SessionSummary } from "../../parse/types.js";
+import { cwdMatches } from "../../parse/cwdScope.js";
 import { buildReceiptModel } from "../../receipt/model.js";
 import { attachSubagentRollup } from "../../receipt/subagents.js";
 import { buildMiniSummary } from "../../receipt/mini.js";
@@ -82,9 +83,38 @@ export async function loadFromDisk(
   return loadSessionFn(summary);
 }
 
+/**
+ * SPEC-0075 R1 — load the newest cwd-scoped candidate. Claude Code directory
+ * names are lossy, so its candidate must be confirmed against the cwd parsed
+ * from the full transcript; a collision or unreadable candidate falls through
+ * to the next-most-recent row.
+ */
+export async function loadFromCwd(
+  requestedCwd: string,
+  listSessionsFn: (cwd: string) => Promise<SessionSummary[]> = listSessionsForCwd,
+  loadSessionFn: (summary: SessionSummary) => Promise<Session | null> = loadSession,
+): Promise<Session | null> {
+  const sessions = await listSessionsFn(requestedCwd);
+  for (const summary of sessions) {
+    const session = await loadSessionFn(summary);
+    if (!session) {
+      continue;
+    }
+    if (summary.source === "claude-code" && (typeof session.cwd !== "string" || !cwdMatches(session.cwd, requestedCwd))) {
+      continue;
+    }
+    return session;
+  }
+  return null;
+}
+
 export interface RunStatuslineOptions {
   /** SPEC-0062 R3 — explicit `--format` segment spec; absent → `DEFAULT_FORMAT`. */
   format?: string;
+  /** SPEC-0075 R1 — requested cwd for scoped disk fallback; stdin still wins. */
+  cwd?: string;
+  /** Injectable scoped loader seam for fixture-only statusline tests. */
+  loadFromCwdFn?: (cwd: string) => Promise<Session | null>;
   /** Error sink for the fail-fast unknown-segment path; defaults to `process.stderr`. */
   writeError?: (s: string) => void;
   /** Clock + state-file seams for the `quotaEta` segment (tests). */
@@ -95,10 +125,10 @@ export interface RunStatuslineOptions {
 /**
  * R3/R4 (SPEC-0007) + SPEC-0062: stdin mode first, then disk fallback, then a
  * neutral no-session placeholder (never an error, always exit 0 — except a
- * malformed `--format`, which is a caller mistake and fails fast with exit 1,
- * segment list on stderr, nothing on stdout). `write` is the output seam — the
- * command passes `ctx.stdout` so output routes through the context; it defaults
- * to `process.stdout` for the direct-call tests.
+ * malformed `--format` or empty `--cwd`, which is a caller mistake and fails
+ * fast with exit 1, one line on stderr, and nothing on stdout). `write` is the
+ * output seam — the command passes `ctx.stdout` so output routes through the
+ * context; it defaults to `process.stdout` for the direct-call tests.
  */
 export async function runStatusline(
   stdin: NodeJS.ReadStream = process.stdin,
@@ -120,6 +150,15 @@ export async function runStatusline(
     writeError(`unknown statusline segment "${parsed.unknown}" (valid: ${SEGMENT_NAMES.join(", ")})\n`);
     return 1;
   }
+  if (opts.cwd !== undefined && !opts.cwd.trim()) {
+    const writeError =
+      opts.writeError ??
+      ((s: string) => {
+        process.stderr.write(s);
+      });
+    writeError("--cwd requires a non-empty path\n");
+    return 1;
+  }
   const raw = await readStdin(stdin);
   const payload = parsePayload(raw);
   let inputMode: InputModeValue = raw.trim() ? "stdin_payload" : "none";
@@ -128,7 +167,7 @@ export async function runStatusline(
   if (session) {
     payloadValid = true;
   } else {
-    const diskSession = await loadFromDiskFn();
+    const diskSession = opts.cwd !== undefined ? await (opts.loadFromCwdFn ?? loadFromCwd)(opts.cwd) : await loadFromDiskFn();
     if (diskSession) {
       inputMode = "disk_fallback";
       session = diskSession;
@@ -159,7 +198,7 @@ function run(ctx: CommandContext): Promise<number> {
     loadFromDisk,
     (s) => ctx.stdout.write(s),
     (info) => ctx.telemetry.recordIntegrationSurfaceRendered({ integration: "statusline", ...info }),
-    { format: ctx.options.format, writeError: (s) => ctx.stderr.write(s) },
+    { format: ctx.options.format, cwd: ctx.options.cwd, writeError: (s) => ctx.stderr.write(s) },
   );
 }
 
@@ -170,6 +209,6 @@ export const command: CommandDef = {
   run,
   help: {
     order: 180,
-    lines: ["  aireceipts statusline [--format <s>]  one-line summary for Claude Code's statusLine"],
+    lines: ["  aireceipts statusline [--format <s>] [--cwd <path>]  one-line summary for Claude Code's statusLine"],
   },
 };

--- a/src/cli/commands/statusline.ts
+++ b/src/cli/commands/statusline.ts
@@ -6,9 +6,10 @@
 // renders through the segments engine — the default line IS the format
 // `brand,cost,tokens,waste,quota5h`, and `--format` selects any other segment
 // list (unknown names fail fast, exit 1).
+import * as os from "node:os";
 import { listSessions, listSessionsForCwd, loadById, loadSession } from "../../index.js";
 import type { Session, SessionSummary } from "../../parse/types.js";
-import { cwdMatches } from "../../parse/cwdScope.js";
+import { cwdMatchesForAttribution } from "../../parse/cwdScope.js";
 import { buildReceiptModel } from "../../receipt/model.js";
 import { attachSubagentRollup } from "../../receipt/subagents.js";
 import { buildMiniSummary } from "../../receipt/mini.js";
@@ -102,6 +103,7 @@ export async function loadFromCwd(
   requestedCwd: string,
   listSessionsFn: (cwd: string) => Promise<SessionSummary[]> = listSessionsForCwd,
   loadSessionFn: (summary: SessionSummary) => Promise<Session | null> = loadSession,
+  homeDir: string = os.homedir(),
 ): Promise<Session | null> {
   const sessions = await listSessionsFn(requestedCwd);
   for (const summary of sessions.slice(0, MAX_SCOPED_LOAD_ATTEMPTS)) {
@@ -109,7 +111,10 @@ export async function loadFromCwd(
     if (!session) {
       continue;
     }
-    if (summary.source === "claude-code" && (typeof session.cwd !== "string" || !cwdMatches(session.cwd, requestedCwd))) {
+    if (
+      summary.source === "claude-code" &&
+      (typeof session.cwd !== "string" || !cwdMatchesForAttribution(session.cwd, requestedCwd, homeDir))
+    ) {
       continue;
     }
     return session;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,7 +10,7 @@ import { parseOptions } from "./options.js";
 import { loadCommands, selectCommand } from "./registry.js";
 import { createContext } from "./context.js";
 
-export { readStdin, loadFromStdinPayload, loadFromDisk, loadFromCwd, runStatusline } from "./commands/statusline.js";
+export { readStdin, loadFromStdinPayload, loadFromDisk, loadFromCwd, MAX_SCOPED_LOAD_ATTEMPTS, runStatusline } from "./commands/statusline.js";
 export { recentWasteAggregates } from "./commands/handoff.js";
 
 /** CLI entrypoint: parse → discover/select → first-run notice → run → telemetry record → bounded flush (SPEC-0002 wiring). */

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,7 +10,7 @@ import { parseOptions } from "./options.js";
 import { loadCommands, selectCommand } from "./registry.js";
 import { createContext } from "./context.js";
 
-export { readStdin, loadFromStdinPayload, loadFromDisk, runStatusline } from "./commands/statusline.js";
+export { readStdin, loadFromStdinPayload, loadFromDisk, loadFromCwd, runStatusline } from "./commands/statusline.js";
 export { recentWasteAggregates } from "./commands/handoff.js";
 
 /** CLI entrypoint: parse → discover/select → first-run notice → run → telemetry record → bounded flush (SPEC-0002 wiring). */

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -221,8 +221,11 @@ export function parseOptions(argv: string[]): CliOptions {
       format = arg.slice("--format=".length);
     } else if (arg === "--cwd") {
       // A bare `--cwd` must fail fast downstream rather than silently falling
-      // back to global discovery (SPEC-0075 R1) — normalize to "".
-      cwd = argv[++i] ?? "";
+      // back to global discovery (SPEC-0075 R1) — normalize to "". A following
+      // flag (`--cwd --help`) is another spelling of "no value": don't consume
+      // it as the path (a path may still start with `-` via `--cwd=<path>`).
+      const next = argv[i + 1];
+      cwd = next !== undefined && !next.startsWith("-") ? argv[++i] : "";
     } else if (arg.startsWith("--cwd=")) {
       cwd = arg.slice("--cwd=".length);
     } else if (arg === "--svg") {

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -74,6 +74,8 @@ export interface CliOptions {
   readonly details: boolean;
   /** SPEC-0062 R3: `aireceipts statusline --format "<segments>"` — comma-separated segment names. */
   readonly format?: string;
+  /** SPEC-0075 R1: `aireceipts statusline --cwd <path>` — scope disk fallback to one cwd. */
+  readonly cwd?: string;
   /** SPEC-0070 R1: `aireceipts pr --samosa` opts the tip link back onto the PR comment + artifact (off by default). */
   readonly samosa: boolean;
 }
@@ -117,6 +119,7 @@ export function parseOptions(argv: string[]): CliOptions {
   let limit: number | undefined;
   let outDir: string | undefined;
   let format: string | undefined;
+  let cwd: string | undefined;
   let samosa = false;
   const positional: string[] = [];
 
@@ -216,6 +219,12 @@ export function parseOptions(argv: string[]): CliOptions {
       format = argv[++i] ?? "";
     } else if (arg.startsWith("--format=")) {
       format = arg.slice("--format=".length);
+    } else if (arg === "--cwd") {
+      // A bare `--cwd` must fail fast downstream rather than silently falling
+      // back to global discovery (SPEC-0075 R1) — normalize to "".
+      cwd = argv[++i] ?? "";
+    } else if (arg.startsWith("--cwd=")) {
+      cwd = arg.slice("--cwd=".length);
     } else if (arg === "--svg") {
       svg = true;
     } else if (arg === "--png") {
@@ -278,6 +287,7 @@ export function parseOptions(argv: string[]): CliOptions {
     demo,
     details,
     format,
+    cwd,
     samosa,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,17 @@ export { GeminiAdapter } from "./parse/gemini.js";
 export { OpenCodeAdapter } from "./parse/opencode.js";
 
 export { adapterFor, adapters, agentIds, detectedAdapters } from "./parse/registry.js";
-export { anyDetected, listSessions, listFullSessions, loadById, loadSession, newestSession, rootsHint, selectSummary } from "./parse/load.js";
+export {
+  anyDetected,
+  listSessions,
+  listSessionsForCwd,
+  listFullSessions,
+  loadById,
+  loadSession,
+  newestSession,
+  rootsHint,
+  selectSummary,
+} from "./parse/load.js";
 
 export type { PriceRow, PriceSource, PriceTable, ResolvedPrice } from "./pricing/types.js";
 export { defaultDataDir, loadPriceTable } from "./pricing/priceTable.js";

--- a/src/parse/claudeCode.ts
+++ b/src/parse/claudeCode.ts
@@ -405,7 +405,12 @@ export class ClaudeCodeAdapter implements SessionAdapter {
   }
 
   async listSessions(options: ListSessionsOptions = {}): Promise<SessionSummary[]> {
-    const all = await listFiles(this.root, (name) => name.endsWith(".jsonl"));
+    // SPEC-0075 R1 — scoped callers provide exact encoded project directories;
+    // the default remains the single adapter root, preserving global discovery.
+    const discoveryRoots = options.roots ?? [this.root];
+    const all = (
+      await Promise.all([...new Set(discoveryRoots)].map((root) => listFiles(root, (name) => name.endsWith(".jsonl"))))
+    ).flat();
     // R1c: subagent transcripts are excluded from top-level selection — they roll
     // up into their parent's receipt, never appear as standalone sessions.
     // SPEC-0041 R1: the exclusion covers ANY `.jsonl` under `subagents/`, not

--- a/src/parse/cwdScope.ts
+++ b/src/parse/cwdScope.ts
@@ -64,6 +64,30 @@ export function cwdMatches(sessionCwd: string, requestedCwd: string): boolean {
   return session !== "" && requested.startsWith(`${session}/`);
 }
 
+/**
+ * SPEC-0075 R1 — the attribution rule scoped discovery actually applies.
+ * `cwdMatches` plus one policy guard: a session recorded at the user's home
+ * directory or above (an agent launched from `~` or `/`) never ancestor-matches
+ * — it matches its exact path only. Without this, one home-launched session is
+ * an ancestor of every path on the machine and permanently shadows the
+ * no-session placeholder (observed on real data: a `~`-launched Codex session
+ * rendered for a path no agent ever touched). `homeDir` is a parameter so the
+ * rule stays a pure string decision.
+ */
+export function cwdMatchesForAttribution(sessionCwd: string, requestedCwd: string, homeDir: string): boolean {
+  const session = normalizeCwd(sessionCwd);
+  const requested = normalizeCwd(requestedCwd);
+  if (session === requested) {
+    return true;
+  }
+  if (!cwdMatches(sessionCwd, requestedCwd)) {
+    return false;
+  }
+  const home = normalizeCwd(homeDir);
+  const homeOrAbove = home !== "" && (session === home || home.startsWith(`${session}/`) || session === "/");
+  return !homeOrAbove;
+}
+
 /** Claude Code replaces every non-ASCII-alphanumeric cwd character with `-`. */
 export function encodeClaudeProjectCwd(cwd: string): string {
   return cwd.replace(/[^A-Za-z0-9]/g, "-");

--- a/src/parse/cwdScope.ts
+++ b/src/parse/cwdScope.ts
@@ -1,0 +1,59 @@
+// SPEC-0075 R1 — shared path matching and Claude Code project-directory
+// encoding for cwd-scoped statusline discovery. These are string operations,
+// not filesystem resolution: the transcript's recorded cwd is the authority.
+
+/** Normalize only the cross-platform spelling differences relevant to cwd attribution. */
+export function normalizeCwd(cwd: string): string {
+  const withForwardSlashes = cwd.replace(/\\/g, "/");
+  const withoutTrailingSlashes = withForwardSlashes.replace(/\/+$/, "") || (withForwardSlashes.startsWith("/") ? "/" : "");
+  return withoutTrailingSlashes.replace(/^([A-Z]):(?=\/|$)/, (_, drive: string) => `${drive.toLowerCase()}:`);
+}
+
+/** True when the session cwd is the requested cwd or one of its whole-segment ancestors. */
+export function cwdMatches(sessionCwd: string, requestedCwd: string): boolean {
+  const session = normalizeCwd(sessionCwd);
+  const requested = normalizeCwd(requestedCwd);
+  if (session === requested) {
+    return true;
+  }
+  if (session === "/") {
+    return requested.startsWith("/");
+  }
+  return session !== "" && requested.startsWith(`${session}/`);
+}
+
+/** Claude Code replaces every non-ASCII-alphanumeric cwd character with `-`. */
+export function encodeClaudeProjectCwd(cwd: string): string {
+  return cwd.replace(/[^A-Za-z0-9]/g, "-");
+}
+
+/**
+ * Encoded Claude Code project-directory names for the requested cwd and each
+ * path ancestor. Ancestors are computed before encoding because encoding is
+ * lossy (`/my-repo` and `/my/repo` collide).
+ */
+export function claudeProjectDirectoryNames(requestedCwd: string): string[] {
+  const cwd = normalizeCwd(requestedCwd);
+  if (!cwd) {
+    return [];
+  }
+
+  const parts = cwd.split("/").filter(Boolean);
+  const ancestors: string[] = [];
+  if (cwd.startsWith("/")) {
+    ancestors.push("/");
+    let current = "";
+    for (const part of parts) {
+      current += `/${part}`;
+      ancestors.push(current);
+    }
+  } else {
+    let current = "";
+    for (const part of parts) {
+      current = current ? `${current}/${part}` : part;
+      ancestors.push(current);
+    }
+  }
+
+  return [...new Set(ancestors.map(encodeClaudeProjectCwd))];
+}

--- a/src/parse/cwdScope.ts
+++ b/src/parse/cwdScope.ts
@@ -83,8 +83,13 @@ export function cwdMatchesForAttribution(sessionCwd: string, requestedCwd: strin
   if (!cwdMatches(sessionCwd, requestedCwd)) {
     return false;
   }
+  if (session === "/") {
+    // A root-recorded session shadows everything regardless of whether the
+    // home directory is even known — never an ancestor match.
+    return false;
+  }
   const home = normalizeCwd(homeDir);
-  const homeOrAbove = home !== "" && (session === home || home.startsWith(`${session}/`) || session === "/");
+  const homeOrAbove = home !== "" && (session === home || home.startsWith(`${session}/`));
   return !homeOrAbove;
 }
 

--- a/src/parse/cwdScope.ts
+++ b/src/parse/cwdScope.ts
@@ -11,11 +11,17 @@
  */
 export function normalizeCwd(cwd: string): string {
   const withForwardSlashes = cwd.replace(/\\/g, "/");
-  const isAbsolute = withForwardSlashes.startsWith("/");
-  const isUnc = withForwardSlashes.startsWith("//");
+  // A `X:` drive prefix is a root boundary: it folds to lowercase and can
+  // never be popped by `..` (`C:/../Other` resolves to `c:/Other`, not a
+  // relative `Other` that would match an unrelated session).
+  const driveMatch = /^([A-Za-z]):(?=\/|$)/.exec(withForwardSlashes);
+  const drive = driveMatch ? `${driveMatch[1].toLowerCase()}:` : "";
+  const rest = drive ? withForwardSlashes.slice(2) : withForwardSlashes;
+  const isAbsolute = drive !== "" || rest.startsWith("/");
+  const isUnc = drive === "" && rest.startsWith("//");
 
   const resolved: string[] = [];
-  for (const segment of withForwardSlashes.split("/")) {
+  for (const segment of rest.split("/")) {
     if (segment === "" || segment === ".") {
       continue;
     }
@@ -33,10 +39,12 @@ export function normalizeCwd(cwd: string): string {
     resolved.push(segment);
   }
 
+  if (drive) {
+    return resolved.length > 0 ? `${drive}/${resolved.join("/")}` : drive;
+  }
   const prefix = isUnc ? "//" : isAbsolute ? "/" : "";
   const joined = prefix + resolved.join("/");
-  const normalized = joined === "" ? "" : joined === "//" ? "/" : joined;
-  return normalized.replace(/^([A-Z]):(?=\/|$)/, (_, drive: string) => `${drive.toLowerCase()}:`);
+  return joined === "" ? "" : joined === "//" ? "/" : joined;
 }
 
 /** True when the session cwd is the requested cwd or one of its whole-segment ancestors. */

--- a/src/parse/cwdScope.ts
+++ b/src/parse/cwdScope.ts
@@ -1,6 +1,10 @@
 // SPEC-0075 R1 — shared path matching and Claude Code project-directory
 // encoding for cwd-scoped statusline discovery. These are string operations,
 // not filesystem resolution: the transcript's recorded cwd is the authority.
+// `.`/`..` resolve lexically to wherever the requested path actually points
+// (defense for hand-typed --cwd values; real surfaces pass resolved paths),
+// and a root — `/`, a drive `x:`, a UNC `//server` prefix — matches its own
+// subtree, per the whole-segment ancestor rule.
 
 /**
  * Normalize the cross-platform spelling differences relevant to cwd

--- a/src/parse/cwdScope.ts
+++ b/src/parse/cwdScope.ts
@@ -2,11 +2,41 @@
 // encoding for cwd-scoped statusline discovery. These are string operations,
 // not filesystem resolution: the transcript's recorded cwd is the authority.
 
-/** Normalize only the cross-platform spelling differences relevant to cwd attribution. */
+/**
+ * Normalize the cross-platform spelling differences relevant to cwd
+ * attribution, resolving `.`/`..` segments lexically so a traversal like
+ * `/repo/../other` can never match `/repo`'s sessions (I2/I3 — the match must
+ * hold for the path actually requested, not a spelling of a different one).
+ * A UNC-style leading `//` is preserved; duplicate interior slashes collapse.
+ */
 export function normalizeCwd(cwd: string): string {
   const withForwardSlashes = cwd.replace(/\\/g, "/");
-  const withoutTrailingSlashes = withForwardSlashes.replace(/\/+$/, "") || (withForwardSlashes.startsWith("/") ? "/" : "");
-  return withoutTrailingSlashes.replace(/^([A-Z]):(?=\/|$)/, (_, drive: string) => `${drive.toLowerCase()}:`);
+  const isAbsolute = withForwardSlashes.startsWith("/");
+  const isUnc = withForwardSlashes.startsWith("//");
+
+  const resolved: string[] = [];
+  for (const segment of withForwardSlashes.split("/")) {
+    if (segment === "" || segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      // Lexical parent: drop the last real segment; at an absolute root,
+      // `..` stays at the root; for relative paths it is preserved so the
+      // (unresolvable) prefix still never equals an unrelated absolute path.
+      if (resolved.length > 0 && resolved[resolved.length - 1] !== "..") {
+        resolved.pop();
+      } else if (!isAbsolute) {
+        resolved.push("..");
+      }
+      continue;
+    }
+    resolved.push(segment);
+  }
+
+  const prefix = isUnc ? "//" : isAbsolute ? "/" : "";
+  const joined = prefix + resolved.join("/");
+  const normalized = joined === "" ? "" : joined === "//" ? "/" : joined;
+  return normalized.replace(/^([A-Z]):(?=\/|$)/, (_, drive: string) => `${drive.toLowerCase()}:`);
 }
 
 /** True when the session cwd is the requested cwd or one of its whole-segment ancestors. */
@@ -30,7 +60,9 @@ export function encodeClaudeProjectCwd(cwd: string): string {
 /**
  * Encoded Claude Code project-directory names for the requested cwd and each
  * path ancestor. Ancestors are computed before encoding because encoding is
- * lossy (`/my-repo` and `/my/repo` collide).
+ * lossy (`/my-repo` and `/my/repo` collide), and by slicing the normalized
+ * string (not rebuilding from segments) so a UNC `//server/share` keeps both
+ * leading slashes — its encoded name is `--server-share`, never `-server-share`.
  */
 export function claudeProjectDirectoryNames(requestedCwd: string): string[] {
   const cwd = normalizeCwd(requestedCwd);
@@ -38,22 +70,17 @@ export function claudeProjectDirectoryNames(requestedCwd: string): string[] {
     return [];
   }
 
-  const parts = cwd.split("/").filter(Boolean);
   const ancestors: string[] = [];
-  if (cwd.startsWith("/")) {
+  if (cwd.startsWith("/") && !cwd.startsWith("//")) {
     ancestors.push("/");
-    let current = "";
-    for (const part of parts) {
-      current += `/${part}`;
-      ancestors.push(current);
-    }
-  } else {
-    let current = "";
-    for (const part of parts) {
-      current = current ? `${current}/${part}` : part;
-      ancestors.push(current);
+  }
+  const start = cwd.startsWith("//") ? 2 : cwd.startsWith("/") ? 1 : 0;
+  for (let i = start; i < cwd.length; i++) {
+    if (cwd[i] === "/") {
+      ancestors.push(cwd.slice(0, i));
     }
   }
+  ancestors.push(cwd);
 
-  return [...new Set(ancestors.map(encodeClaudeProjectCwd))];
+  return [...new Set(ancestors.filter(Boolean).map(encodeClaudeProjectCwd))];
 }

--- a/src/parse/load.ts
+++ b/src/parse/load.ts
@@ -2,6 +2,8 @@ import { adapterFor, adapters, detectedAdapters } from "./registry.js";
 import type { AgentSource, Session, SessionSummary } from "./types.js";
 import { SummaryCache, completeSummariesWithCache } from "./summaryCache.js";
 import * as fs from "node:fs";
+import * as path from "node:path";
+import { claudeProjectDirectoryNames, cwdMatches } from "./cwdScope.js";
 
 function sortMostRecentFirst(sessions: SessionSummary[]): SessionSummary[] {
   return sessions.sort((a, b) => (b.endedAt ?? b.startedAt ?? 0) - (a.endedAt ?? a.startedAt ?? 0));
@@ -11,6 +13,35 @@ function sortMostRecentFirst(sessions: SessionSummary[]): SessionSummary[] {
 export async function listSessions(agent?: AgentSource): Promise<SessionSummary[]> {
   const pool = agent ? adapters().filter((a) => a.id === agent) : adapters();
   const lists = await Promise.all(pool.map((a) => a.listSessions().catch(() => [] as SessionSummary[])));
+  return sortMostRecentFirst(lists.flat());
+}
+
+/**
+ * SPEC-0075 R1 — lazy session candidates scoped to a requested cwd. Claude
+ * Code is constrained before enumeration to exact encoded ancestor project
+ * directories; cwd-bearing adapters filter their lazy rows; Cursor is never
+ * queried because its rows carry no cwd.
+ */
+export async function listSessionsForCwd(requestedCwd: string): Promise<SessionSummary[]> {
+  const pool = adapters().filter((adapter) => adapter.id !== "cursor");
+  const lists = await Promise.all(
+    pool.map(async (adapter) => {
+      try {
+        if (adapter.id === "claude-code") {
+          const root = adapter.roots()[0];
+          if (!root) {
+            return [];
+          }
+          const roots = claudeProjectDirectoryNames(requestedCwd).map((name) => path.join(root, name));
+          return adapter.listSessions({ roots });
+        }
+        const sessions = await adapter.listSessions();
+        return sessions.filter((session) => typeof session.cwd === "string" && cwdMatches(session.cwd, requestedCwd));
+      } catch {
+        return [] as SessionSummary[];
+      }
+    }),
+  );
   return sortMostRecentFirst(lists.flat());
 }
 

--- a/src/parse/load.ts
+++ b/src/parse/load.ts
@@ -2,8 +2,9 @@ import { adapterFor, adapters, detectedAdapters } from "./registry.js";
 import type { AgentSource, Session, SessionSummary } from "./types.js";
 import { SummaryCache, completeSummariesWithCache } from "./summaryCache.js";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
-import { claudeProjectDirectoryNames, cwdMatches } from "./cwdScope.js";
+import { claudeProjectDirectoryNames, cwdMatchesForAttribution } from "./cwdScope.js";
 
 function sortMostRecentFirst(sessions: SessionSummary[]): SessionSummary[] {
   return sessions.sort((a, b) => (b.endedAt ?? b.startedAt ?? 0) - (a.endedAt ?? a.startedAt ?? 0));
@@ -22,7 +23,7 @@ export async function listSessions(agent?: AgentSource): Promise<SessionSummary[
  * directories; cwd-bearing adapters filter their lazy rows; Cursor is never
  * queried because its rows carry no cwd.
  */
-export async function listSessionsForCwd(requestedCwd: string): Promise<SessionSummary[]> {
+export async function listSessionsForCwd(requestedCwd: string, homeDir: string = os.homedir()): Promise<SessionSummary[]> {
   const pool = adapters().filter((adapter) => adapter.id !== "cursor");
   const lists = await Promise.all(
     pool.map(async (adapter) => {
@@ -36,7 +37,9 @@ export async function listSessionsForCwd(requestedCwd: string): Promise<SessionS
           return adapter.listSessions({ roots });
         }
         const sessions = await adapter.listSessions();
-        return sessions.filter((session) => typeof session.cwd === "string" && cwdMatches(session.cwd, requestedCwd));
+        return sessions.filter(
+          (session) => typeof session.cwd === "string" && cwdMatchesForAttribution(session.cwd, requestedCwd, homeDir),
+        );
       } catch {
         return [] as SessionSummary[];
       }

--- a/src/parse/types.ts
+++ b/src/parse/types.ts
@@ -185,6 +185,11 @@ export interface ListSessionsOptions {
    * `listFullSessions()` so unchanged files hit the summary cache first.
    */
   full?: boolean;
+  /**
+   * SPEC-0075 R1 — optional discovery roots for adapters that can scope at the
+   * filesystem layer (Claude Code). Other adapters ignore this narrow seam.
+   */
+  roots?: readonly string[];
 }
 
 /** One fidelity failure: which named check tripped and the one-line evidence (SPEC-0028 R2). */

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { handoffJsonSchema, receiptJsonSchema } from "../../src/receipt/exportSchema.js";
-import { encodeClaudeProjectCwd } from "../../src/parse/cwdScope.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const fixturesDir = path.join(repoRoot, "test", "fixtures");
@@ -687,7 +686,10 @@ describe("built CLI e2e", () => {
   it("scopes statusline disk discovery to --cwd", async () => {
     const home = await makeHome();
     const sessionCwd = "/home/dev/webapp";
-    const projectDir = path.join(home, ".claude", "projects", encodeClaudeProjectCwd(sessionCwd));
+    // The literal encoded name, NOT encodeClaudeProjectCwd(sessionCwd): the
+    // fixture layout must pin Claude Code's real on-disk convention, so an
+    // encoder regression cannot silently reshape the fixture to keep matching.
+    const projectDir = path.join(home, ".claude", "projects", "-home-dev-webapp");
     await mkdir(projectDir, { recursive: true });
     await copyFile(path.join(fixturesDir, "claude-code", "clean-multi-tool-2-models.jsonl"), path.join(projectDir, "session.jsonl"));
 
@@ -702,6 +704,16 @@ describe("built CLI e2e", () => {
     const home = await makeHome();
 
     const result = await runCli(["statusline", "--cwd"], home);
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("--cwd requires a non-empty path\n");
+  });
+
+  it("does not consume a following flag as the --cwd value", async () => {
+    const home = await makeHome();
+
+    const result = await runCli(["statusline", "--cwd", "--format", "brand"], home);
 
     expect(result.code).toBe(1);
     expect(result.stdout).toBe("");

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { handoffJsonSchema, receiptJsonSchema } from "../../src/receipt/exportSchema.js";
+import { encodeClaudeProjectCwd } from "../../src/parse/cwdScope.js";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const fixturesDir = path.join(repoRoot, "test", "fixtures");
@@ -681,6 +682,30 @@ describe("built CLI e2e", () => {
     expect(result.stdout).toContain("$0.18");
     expect(result.stdout).toContain("147k");
     expect(result.stdout.endsWith("\n")).toBe(true);
+  });
+
+  it("scopes statusline disk discovery to --cwd", async () => {
+    const home = await makeHome();
+    const sessionCwd = "/home/dev/webapp";
+    const projectDir = path.join(home, ".claude", "projects", encodeClaudeProjectCwd(sessionCwd));
+    await mkdir(projectDir, { recursive: true });
+    await copyFile(path.join(fixturesDir, "claude-code", "clean-multi-tool-2-models.jsonl"), path.join(projectDir, "session.jsonl"));
+
+    const result = await runCli(["statusline", "--cwd", `${sessionCwd}/src`], home);
+
+    expect(result.code, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("[aireceipts · Claude Code]");
+  });
+
+  it("fails fast when statusline --cwd has no value", async () => {
+    const home = await makeHome();
+
+    const result = await runCli(["statusline", "--cwd"], home);
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("--cwd requires a non-empty path\n");
   });
 
   it("statusline falls back to the neutral empty state for malformed stdin and no fixture home", async () => {

--- a/test/cli/statusline-cwd.test.ts
+++ b/test/cli/statusline-cwd.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   claudeProjectDirectoryNames,
   cwdMatches,
+  cwdMatchesForAttribution,
   encodeClaudeProjectCwd,
   normalizeCwd,
 } from "../../src/parse/cwdScope.js";
@@ -56,6 +57,27 @@ describe("SPEC-0075 R1 cwd matching", () => {
     expect(normalizeCwd("C:/..")).toBe("c:");
     expect(cwdMatches("Other", "C:/../Other")).toBe(false);
     expect(cwdMatches("c:/Other", "C:/../Other")).toBe(true);
+  });
+});
+
+describe("SPEC-0075 R1 attribution policy (home-shadow guard)", () => {
+  const home = "/Users/dev";
+
+  it("never ancestor-matches a session recorded at the home directory or above", () => {
+    // Observed on real data: one `~`-launched Codex session is an ancestor of
+    // every path on the machine and would shadow the placeholder forever.
+    expect(cwdMatchesForAttribution(home, "/Users/dev/never-used", home)).toBe(false);
+    expect(cwdMatchesForAttribution("/Users", "/Users/dev/repo", home)).toBe(false);
+    expect(cwdMatchesForAttribution("/", "/Users/dev/repo", home)).toBe(false);
+  });
+
+  it("still exact-matches a home-directory session for a home-directory pane", () => {
+    expect(cwdMatchesForAttribution(home, home, home)).toBe(true);
+  });
+
+  it("keeps ancestor matching for real project roots below home and outside it", () => {
+    expect(cwdMatchesForAttribution("/Users/dev/repo", "/Users/dev/repo/sub", home)).toBe(true);
+    expect(cwdMatchesForAttribution("/srv/app", "/srv/app/sub", home)).toBe(true);
   });
 });
 

--- a/test/cli/statusline-cwd.test.ts
+++ b/test/cli/statusline-cwd.test.ts
@@ -79,6 +79,17 @@ describe("SPEC-0075 R1 attribution policy (home-shadow guard)", () => {
     expect(cwdMatchesForAttribution("/Users/dev/repo", "/Users/dev/repo/sub", home)).toBe(true);
     expect(cwdMatchesForAttribution("/srv/app", "/srv/app/sub", home)).toBe(true);
   });
+
+  it("blocks a root-recorded session even when the home directory is unknown", () => {
+    expect(cwdMatchesForAttribution("/", "/project", "")).toBe(false);
+    expect(cwdMatchesForAttribution("/", "/", "")).toBe(true);
+  });
+
+  it("normalizes the home argument itself (trailing slash, Windows drive fold)", () => {
+    expect(cwdMatchesForAttribution("/Users/dev", "/Users/dev/x", "/Users/dev/")).toBe(false);
+    expect(cwdMatchesForAttribution("c:/Users/dev", "c:/Users/dev/x", String.raw`C:\Users\dev`)).toBe(false);
+    expect(cwdMatchesForAttribution("c:/Users/dev/repo", "c:/Users/dev/repo/x", String.raw`C:\Users\dev`)).toBe(true);
+  });
 });
 
 describe("SPEC-0075 R1 Claude Code cwd encoding", () => {

--- a/test/cli/statusline-cwd.test.ts
+++ b/test/cli/statusline-cwd.test.ts
@@ -50,6 +50,13 @@ describe("SPEC-0075 R1 cwd matching", () => {
     expect(cwdMatches("repo", "/repo/sub")).toBe(false);
     expect(cwdMatches("../repo", "/repo")).toBe(false);
   });
+
+  it("treats a drive prefix as a root boundary that `..` can never pop", () => {
+    expect(normalizeCwd("C:/../Other")).toBe("c:/Other");
+    expect(normalizeCwd("C:/..")).toBe("c:");
+    expect(cwdMatches("Other", "C:/../Other")).toBe(false);
+    expect(cwdMatches("c:/Other", "C:/../Other")).toBe(true);
+  });
 });
 
 describe("SPEC-0075 R1 Claude Code cwd encoding", () => {

--- a/test/cli/statusline-cwd.test.ts
+++ b/test/cli/statusline-cwd.test.ts
@@ -31,6 +31,25 @@ describe("SPEC-0075 R1 cwd matching", () => {
     expect(normalizeCwd("C:\\Repo\\")).toBe("c:/Repo");
     expect(cwdMatches("c:/Repo", "c:/repo/sub")).toBe(false);
   });
+
+  it("resolves dot segments lexically — a traversal never matches the traversed-out project", () => {
+    expect(normalizeCwd("/repo/../other")).toBe("/other");
+    expect(cwdMatches("/repo", "/repo/../other")).toBe(false);
+    expect(cwdMatches("/other", "/repo/../other")).toBe(true);
+    expect(normalizeCwd("/repo/./sub")).toBe("/repo/sub");
+    expect(normalizeCwd("/../..")).toBe("/");
+  });
+
+  it("collapses duplicate interior slashes and keeps a UNC prefix", () => {
+    expect(normalizeCwd("/repo//sub///dir")).toBe("/repo/sub/dir");
+    expect(normalizeCwd(String.raw`\\server\share\repo`)).toBe("//server/share/repo");
+    expect(cwdMatches("//server/share/repo", String.raw`\\server\share\repo\sub`)).toBe(true);
+  });
+
+  it("keeps a relative session cwd from matching an unrelated absolute path", () => {
+    expect(cwdMatches("repo", "/repo/sub")).toBe(false);
+    expect(cwdMatches("../repo", "/repo")).toBe(false);
+  });
 });
 
 describe("SPEC-0075 R1 Claude Code cwd encoding", () => {
@@ -47,5 +66,13 @@ describe("SPEC-0075 R1 Claude Code cwd encoding", () => {
 
   it("computes ancestor lookups before encoding", () => {
     expect(claudeProjectDirectoryNames("/my/repo")).toEqual(["-", "-my", "-my-repo"]);
+  });
+
+  it("keeps both UNC leading slashes in encoded ancestor names", () => {
+    expect(claudeProjectDirectoryNames("//server/share/repo")).toEqual([
+      "--server",
+      "--server-share",
+      "--server-share-repo",
+    ]);
   });
 });

--- a/test/cli/statusline-cwd.test.ts
+++ b/test/cli/statusline-cwd.test.ts
@@ -1,0 +1,51 @@
+// SPEC-0075 R1 — pure cwd attribution rules and Claude Code's lossy project
+// directory encoding. These tests never inspect the developer's real home.
+import { describe, expect, it } from "vitest";
+import {
+  claudeProjectDirectoryNames,
+  cwdMatches,
+  encodeClaudeProjectCwd,
+  normalizeCwd,
+} from "../../src/parse/cwdScope.js";
+
+describe("SPEC-0075 R1 cwd matching", () => {
+  it("matches equal POSIX paths", () => {
+    expect(cwdMatches("/repo", "/repo")).toBe(true);
+  });
+
+  it("matches only whole-segment ancestor prefixes", () => {
+    expect(cwdMatches("/repo", "/repo/sub")).toBe(true);
+    expect(cwdMatches("/repo", "/repo-old")).toBe(false);
+  });
+
+  it("strips trailing separators", () => {
+    expect(cwdMatches("/repo/", "/repo/sub/")).toBe(true);
+  });
+
+  it("matches when the requested cwd is deeper than the session cwd", () => {
+    expect(cwdMatches("/repo", "/repo/sub/dir")).toBe(true);
+  });
+
+  it("normalizes Windows separators and folds only the drive letter", () => {
+    expect(cwdMatches("c:/repo", String.raw`C:\repo\sub`)).toBe(true);
+    expect(normalizeCwd("C:\\Repo\\")).toBe("c:/Repo");
+    expect(cwdMatches("c:/Repo", "c:/repo/sub")).toBe(false);
+  });
+});
+
+describe("SPEC-0075 R1 Claude Code cwd encoding", () => {
+  it("replaces every non-ASCII-alphanumeric character with a dash", () => {
+    expect(encodeClaudeProjectCwd("/my/repo")).toBe("-my-repo");
+    expect(encodeClaudeProjectCwd("/my/.repo_name")).toBe("-my--repo-name");
+  });
+
+  it("matches Claude Code's observed worktree directory name", () => {
+    expect(encodeClaudeProjectCwd("/Users/x/codebase/aireceipts/.claude/worktrees/add_status_line_codex")).toBe(
+      "-Users-x-codebase-aireceipts--claude-worktrees-add-status-line-codex",
+    );
+  });
+
+  it("computes ancestor lookups before encoding", () => {
+    expect(claudeProjectDirectoryNames("/my/repo")).toEqual(["-", "-my", "-my-repo"]);
+  });
+});

--- a/test/cli/statusline.test.ts
+++ b/test/cli/statusline.test.ts
@@ -15,6 +15,7 @@ import {
   loadFromCwd,
   loadFromDisk,
   loadFromStdinPayload,
+  MAX_SCOPED_LOAD_ATTEMPTS,
   readStdin,
   runStatusline,
 } from "../../src/cli/index.js";
@@ -146,6 +147,38 @@ describe("loadFromCwd (SPEC-0075 R1, fixture-injected)", () => {
     expect(code).toBe(0);
     expect(output).toContain("[aireceipts · Codex]");
     expect(output).not.toContain("Claude Code");
+  });
+
+  it("caps full-transcript loads at MAX_SCOPED_LOAD_ATTEMPTS on a collision-heavy candidate list", async () => {
+    const fixture = (await loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl")))!;
+    // 20 colliding CC candidates; the walk must stop at the cap and render the
+    // placeholder — bounded work, never a long stall in a polling status bar.
+    const candidates: SessionSummary[] = Array.from({ length: 20 }, (_, i) => ({
+      ...fixture,
+      id: `collision-${i}`,
+      cwd: "/my/repo",
+    }));
+    let loads = 0;
+    const scopedLoader = (cwd: string) =>
+      loadFromCwd(
+        cwd,
+        async () => candidates,
+        async (summary) => {
+          loads++;
+          return { ...fixture, id: summary.id, cwd: "/my/repo" };
+        },
+      );
+
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
+        cwd: "/my-repo",
+        loadFromCwdFn: scopedLoader,
+      }),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toBe("aireceipts: no sessions detected\n");
+    expect(loads).toBe(MAX_SCOPED_LOAD_ATTEMPTS);
   });
 
   it("rejects a Claude Code encoding collision after full load", async () => {

--- a/test/cli/statusline.test.ts
+++ b/test/cli/statusline.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 import { loadById } from "../../src/index.js";
 import type { Session, SessionSummary } from "../../src/parse/types.js";
 import {
+  loadFromCwd,
   loadFromDisk,
   loadFromStdinPayload,
   readStdin,
@@ -118,7 +119,101 @@ describe("loadFromDisk (R3b, fixture-injected — never touches real ~/.claude/p
   });
 });
 
+describe("loadFromCwd (SPEC-0075 R1, fixture-injected)", () => {
+  it("skips a newer colliding Claude Code candidate and selects the matching Codex session", async () => {
+    const fixture = (await loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl")))!;
+    const claudeElsewhere: Session = { ...fixture, id: "cc-collision", cwd: "/elsewhere", endedAt: 2_000 };
+    const codexHere: Session = { ...fixture, id: "codex-here", source: "codex", cwd: "/repo", endedAt: 1_000 };
+    const candidates: SessionSummary[] = [claudeElsewhere, codexHere];
+    const loaded = new Map<string, Session>([
+      [claudeElsewhere.id, claudeElsewhere],
+      [codexHere.id, codexHere],
+    ]);
+    const scopedLoader = (cwd: string) =>
+      loadFromCwd(
+        cwd,
+        async () => candidates,
+        async (summary) => loaded.get(summary.id) ?? null,
+      );
+
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
+        cwd: "/repo/sub",
+        loadFromCwdFn: scopedLoader,
+      }),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toContain("[aireceipts · Codex]");
+    expect(output).not.toContain("Claude Code");
+  });
+
+  it("rejects a Claude Code encoding collision after full load", async () => {
+    const fixture = (await loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl")))!;
+    const collision: Session = { ...fixture, id: "collision", cwd: "/my/repo" };
+    const scopedLoader = (cwd: string) => loadFromCwd(cwd, async () => [collision], async () => collision);
+
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub("", true), async () => fixture, undefined, undefined, {
+        cwd: "/my-repo",
+        loadFromCwdFn: scopedLoader,
+      }),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toBe("aireceipts: no sessions detected\n");
+  });
+
+  it("returns the neutral placeholder without falling back globally when no scoped session matches", async () => {
+    let globalFallbackCalled = false;
+    const { code, output } = await captureStdout(() =>
+      runStatusline(
+        stdinStub("", true),
+        async () => {
+          globalFallbackCalled = true;
+          return loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl"));
+        },
+        undefined,
+        undefined,
+        { cwd: "/repo", loadFromCwdFn: async () => null },
+      ),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toBe("aireceipts: no sessions detected\n");
+    expect(globalFallbackCalled).toBe(false);
+  });
+});
+
 describe("runStatusline (R3/R4 end-to-end)", () => {
+  it("SPEC-0075 R1: a usable stdin payload wins over --cwd with byte-identical output", async () => {
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    const payload = JSON.stringify({ transcript_path: transcriptPath });
+    const baseline = await captureStdout(() => runStatusline(stdinStub(payload), async () => null));
+    let scopedLoaderCalled = false;
+    const scoped = await captureStdout(() =>
+      runStatusline(stdinStub(payload), async () => null, undefined, undefined, {
+        cwd: "/some/other/project",
+        loadFromCwdFn: async () => {
+          scopedLoaderCalled = true;
+          return null;
+        },
+      }),
+    );
+
+    expect(scoped).toEqual(baseline);
+    expect(scopedLoaderCalled).toBe(false);
+  });
+
+  it("SPEC-0075 R1: an unscoped invocation preserves the existing disk-fallback bytes", async () => {
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    const loadFromDiskFn = async (): Promise<Session | null> => loadById("claude-code", transcriptPath);
+    const baseline = await captureStdout(() => runStatusline(stdinStub("", true), loadFromDiskFn));
+    const explicitDefaults = await captureStdout(() => runStatusline(stdinStub("", true), loadFromDiskFn, undefined, undefined, {}));
+
+    expect(explicitDefaults).toEqual(baseline);
+  });
+
   it("R3a: prefers the stdin payload's session over disk fallback", async () => {
     const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
     const stdin = stdinStub(JSON.stringify({ transcript_path: transcriptPath }));
@@ -218,6 +313,25 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
     expect(err).toContain("unknown statusline segment");
   });
 
+  it("SPEC-0075 R1: a bare or empty --cwd fails fast with stderr only", async () => {
+    const { parseOptions } = await import("../../src/cli/options.js");
+    expect(parseOptions(["statusline", "--cwd"]).cwd).toBe("");
+    expect(parseOptions(["statusline", "--cwd="]).cwd).toBe("");
+    let err = "";
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
+        cwd: "",
+        writeError: (s) => {
+          err += s;
+        },
+      }),
+    );
+
+    expect(code).toBe(1);
+    expect(output).toBe("");
+    expect(err).toBe("--cwd requires a non-empty path\n");
+  });
+
   it("SPEC-0062 R5: telemetry customFormat is false by default and true under --format", async () => {
     const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
     const stdin1 = stdinStub(JSON.stringify({ transcript_path: transcriptPath }));
@@ -274,6 +388,41 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
     const model = await attachSubagentRollup(await buildReceiptModel(session!), session!.filePath);
     const elapsedMs = performance.now() - started;
     expect(model.subagents?.count).toBe(2);
+    expect(elapsedMs).toBeLessThanOrEqual(200);
+  });
+
+  it("SPEC-0075 R8 latency: cwd-scoped discovery + load + render stays within the 200ms budget", async () => {
+    const { copyFile, mkdir, mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { ClaudeCodeAdapter } = await import("../../src/parse/claudeCode.js");
+    const { claudeProjectDirectoryNames, encodeClaudeProjectCwd } = await import("../../src/parse/cwdScope.js");
+    const home = await mkdtemp(path.join(tmpdir(), "aireceipts-cwd-lat-"));
+    const projectsRoot = path.join(home, ".claude", "projects");
+    const sessionCwd = "/home/dev/webapp";
+    const requestedCwd = `${sessionCwd}/src`;
+    const projectDir = path.join(projectsRoot, encodeClaudeProjectCwd(sessionCwd));
+    await mkdir(projectDir, { recursive: true });
+    await copyFile(fixturePath("clean-multi-tool-2-models.jsonl"), path.join(projectDir, "session.jsonl"));
+    const adapter = new ClaudeCodeAdapter({ root: projectsRoot });
+    const scopedLoader = (cwd: string) =>
+      loadFromCwd(
+        cwd,
+        (value) =>
+          adapter.listSessions({ roots: claudeProjectDirectoryNames(value).map((name) => path.join(projectsRoot, name)) }),
+        (summary) => adapter.loadSession(summary.id),
+      );
+
+    const started = performance.now();
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
+        cwd: requestedCwd,
+        loadFromCwdFn: scopedLoader,
+      }),
+    );
+    const elapsedMs = performance.now() - started;
+
+    expect(code).toBe(0);
+    expect(output).toContain("[aireceipts · Claude Code]");
     expect(elapsedMs).toBeLessThanOrEqual(200);
   });
 });


### PR DESCRIPTION
## What

Stage 1 of SPEC-0075 (approved; spec lands via #215): `aireceipts statusline --cwd <path>` selects the newest session **attributed to that path** instead of the globally newest — the agent-agnostic statusline for Codex and opencode (neither exposes a command-backed status hook), and the correctness fix for any terminal surface on a multi-agent machine.

```tmux
set -g status-right '#(aireceipts statusline --cwd "#{pane_current_path}")'
```

## How it stays honest (I2/I3)

- **Scoped discovery:** Claude Code enumerates only the project dirs matching the encoded requested cwd or an encoded ancestor (`[^A-Za-z0-9]` → `-`, verified against real dir names); codex/opencode/gemini filter their lazy summaries' `cwd` field; Cursor is never queried (no cwd data, 0/41 measured).
- **Confirm-on-load:** the CC encoding is lossy (`/my-repo` collides with `/my/repo`), so a CC candidate must re-match the full transcript's own recorded `cwd` after load. Collision/unreadable → next candidate; nothing matches → the neutral placeholder. **Never another project's dollars, never a global fallback in `--cwd` mode.**
- **Traversal-safe matching:** `.`/`..` resolve lexically (`--cwd /repo/../other` can never match `/repo`); UNC prefixes and Windows drive roots are unpoppable boundaries; `/repo` never matches `/repo-old` (whole-segment prefix only).
- **Bounded work:** full-transcript loads cap at 8 candidates — a collision-heavy dir renders the placeholder rather than stalling a polling status bar.
- **Native path untouched (I5):** a usable stdin payload wins over `--cwd`; unscoped invocations are byte-identical (existing assertions unloosened). Docs state Claude Code's native `statusLine` hook remains the recommended, richer surface.

## Review trail

Implemented by Codex from the stage-1 brief; independently reviewed by Fable, then three adversarial Codex review rounds. **Accepted and fixed:** dot-segment traversal, UNC ancestor encoding, unbounded candidate loads, `--cwd` consuming a following flag, e2e encoder circularity, drive-prefix poppable by `..`. **Adjudicated-rejected (with reasons in commits):** lazy-summary filtering for cwd-bearing adapters (exactly what approved R1 specifies), `--format`'s pre-existing value-consumption (out of scope), drive-root/UNC subtree matching (the ancestor rule working as specified).

## Tests

Matcher/encoding unit battery (POSIX, sibling rejection, traversal, UNC, drive-root, Windows fold, observed real dir name), injected-seam behavior tests (scoped pick, collision guard, placeholder-never-global, stdin-wins bytes, unscoped bytes, fail-fast, load cap), 200ms in-process budget variant (R8), built-CLI e2e (scoped pick against the literal encoded dir name, bare `--cwd`, flag-not-consumed).

Full verification block green, unmasked: tsc / eslint / vitest (1,773+) / goldens / determinism ×10 / spec-lint / hygiene — all `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)