### PR TITLE
feat: statusline config, prompt recipes, poll-safe telemetry (stage 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,20 @@ jobs:
 
       - name: built CLI and packed tarball
         run: npx vitest run test/cli-e2e
+
+  windows-statusline:
+    # SPEC-0075 R7 — prove cwd/config path handling and the built CLI on native
+    # Windows without duplicating the full Linux verification matrix.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: statusline Windows paths and built CLI
+        run: npx vitest run test/cli/statusline-cwd.test.ts test/cli/statusline.test.ts test/cli-e2e/built-cli.test.ts

--- a/docs/guide/07-statusline.md
+++ b/docs/guide/07-statusline.md
@@ -35,8 +35,9 @@ If `aireceipts` isn't on your `PATH`, put the absolute path (the output of `whic
 aireceipts`) in the `command` field.
 
 Using tmux too? The [terminal-surfaces recipe](../statusline.md#terminal-surfaces)
-shows how to put the right session in each pane with `statusline --cwd`, while
-keeping Claude Code's richer native stdin hook as the primary setup.
+shows tmux, Starship, raw zsh/bash, OSC terminal-title, and PowerShell patterns
+that pass each pane's cwd to `statusline --cwd`, while keeping Claude Code's
+richer native stdin hook as the primary setup.
 
 ## What the line shows
 

--- a/docs/statusline.md
+++ b/docs/statusline.md
@@ -37,8 +37,17 @@ path (or an ancestor of it) and prints the neutral placeholder when none match.
 It never falls back to another project's newest session, and a session launched
 from your home directory (or above it) only ever matches that exact path — it is
 not treated as an ancestor of everything, so one `~`-launched session can't
-shadow every pane on the machine. Cursor sessions never match in this mode
-because Cursor's session data carries no cwd.
+shadow every pane on the machine. Relative `--cwd` paths resolve against the
+directory where `aireceipts` is invoked; a path beginning with `-` must use the
+`--cwd=<path>` form. Matching intentionally folds only a Windows drive letter's
+case: the rest of every path remains case-sensitive because over-matching on a
+case-sensitive filesystem is the worse failure. Cursor is excluded from scoped
+discovery entirely because its session data carries no cwd.
+
+Path matching is lexical rather than filesystem-canonical. If `$PWD` uses a
+symlinked spelling while a session records the physical path, they do not
+match. tmux's `#{pane_current_path}` is resolved, so the tmux recipe below is
+unaffected.
 
 For tmux, add this to `~/.tmux.conf`:
 
@@ -48,6 +57,157 @@ set -g status-right '#(aireceipts statusline --cwd "#{pane_current_path}")'
 
 tmux refreshes `#(...)` commands on `status-interval`; lower that setting if you
 want a fresher line, keeping in mind that each refresh runs the command again.
+
+<!-- SPEC-0075 R3b -->
+
+tmux is the recommended live terminal surface because it keeps polling while a
+command or agent owns the pane. The prompt and title recipes below refresh only
+**between commands**: while an agent owns the terminal they sit stale, and the
+cached line you see is one prompt behind. Each refresh is a per-prompt
+fire-and-forget process that exits after its atomic cache write — there is no
+resident daemon.
+
+### Starship (zsh/bash)
+
+Starship's default `command_timeout` is 500ms, below Node's roughly one-second
+startup floor. This custom module therefore prints the last cwd-keyed cache and
+starts the next refresh in the background. Add it to `~/.config/starship.toml`:
+
+```toml
+[custom.aireceipts]
+command = '''
+key=$(printf '%s' "$PWD" | shasum | cut -c1-12)
+cache="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/aireceipts-statusline-$key"
+[ -r "$cache" ] && cat "$cache"
+(
+  tmp="${cache}.$$.tmp"
+  if aireceipts statusline --cwd "$PWD" >"$tmp" 2>/dev/null; then
+    mv -f "$tmp" "$cache"
+  else
+    rm -f "$tmp"
+  fi
+) >/dev/null 2>&1 &
+'''
+when = true
+shell = ["sh"]
+format = "$output "
+```
+
+The hash keeps panes in different repositories from reading each other's line;
+the temp-file-plus-`mv` keeps readers from seeing a partial line.
+
+### Raw zsh or bash
+
+Without a prompt engine, use the same cache-first pattern. For zsh, add this to
+`~/.zshrc`:
+
+```zsh
+_aireceipts_precmd() {
+  local key cache
+  key=$(printf '%s' "$PWD" | shasum | cut -c1-12)
+  cache="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/aireceipts-statusline-$key"
+  [[ -r "$cache" ]] && command cat "$cache"
+  (
+    local tmp="${cache}.$$.tmp"
+    if aireceipts statusline --cwd "$PWD" >"$tmp" 2>/dev/null; then
+      mv -f "$tmp" "$cache"
+    else
+      rm -f "$tmp"
+    fi
+  ) >/dev/null 2>&1 &!
+}
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _aireceipts_precmd
+```
+
+For bash, add this to `~/.bashrc`:
+
+```bash
+_aireceipts_prompt_command() {
+  local key cache
+  key=$(printf '%s' "$PWD" | shasum | cut -c1-12)
+  cache="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/aireceipts-statusline-$key"
+  [[ -r "$cache" ]] && command cat "$cache"
+  (
+    local tmp="${cache}.$$.tmp"
+    if aireceipts statusline --cwd "$PWD" >"$tmp" 2>/dev/null; then
+      mv -f "$tmp" "$cache"
+    else
+      rm -f "$tmp"
+    fi
+  ) >/dev/null 2>&1 &
+}
+PROMPT_COMMAND="_aireceipts_prompt_command${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+```
+
+### OSC terminal title
+
+An OSC title is independent of the prompt engine and works in any OSC-capable
+terminal emulator. This zsh `precmd` emits `ESC]0;<line>BEL`, then refreshes the
+cwd-keyed cache for the next prompt:
+
+```zsh
+_aireceipts_title_precmd() {
+  local key cache line
+  key=$(printf '%s' "$PWD" | shasum | cut -c1-12)
+  cache="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/aireceipts-statusline-$key"
+  if [[ -r "$cache" ]]; then
+    IFS= read -r line < "$cache"
+    printf '\033]0;%s\007' "$line"
+  fi
+  (
+    local tmp="${cache}.$$.tmp"
+    if aireceipts statusline --cwd "$PWD" >"$tmp" 2>/dev/null; then
+      mv -f "$tmp" "$cache"
+    else
+      rm -f "$tmp"
+    fi
+  ) >/dev/null 2>&1 &!
+}
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _aireceipts_title_precmd
+```
+
+### Windows PowerShell
+
+Starship and Oh My Posh both work in PowerShell. Put this wrapper **after** the
+prompt engine's initialization line in `$PROFILE`; it preserves that engine's
+prompt, prints the last cwd-keyed line, and starts an atomic refresh job. Completed
+jobs are removed on the next prompt, so the refresh never becomes a daemon.
+
+```powershell
+$global:AireceiptsBasePrompt = (Get-Command prompt).ScriptBlock
+function global:prompt {
+  $cwd = (Get-Location).Path
+  $runtime = if ($env:XDG_RUNTIME_DIR) { $env:XDG_RUNTIME_DIR } elseif ($env:TEMP) { $env:TEMP } else { [IO.Path]::GetTempPath() }
+  $bytes = [Text.Encoding]::UTF8.GetBytes($cwd)
+  $key = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).Substring(0, 12).ToLowerInvariant()
+  $cache = Join-Path $runtime "aireceipts-statusline-$key"
+
+  Get-Job -Name "aireceipts-statusline-*" -State Completed -ErrorAction SilentlyContinue | Remove-Job
+  if (Test-Path -LiteralPath $cache) {
+    $line = Get-Content -LiteralPath $cache -Raw
+    if ($line) { Write-Host -NoNewline "$($line.TrimEnd()) " }
+  }
+
+  Start-Job -Name "aireceipts-statusline-$key" -ArgumentList $cache, $cwd -ScriptBlock {
+    param($cache, $cwd)
+    $tmp = "$cache.$PID.tmp"
+    $line = & aireceipts statusline --cwd $cwd 2>$null
+    if ($LASTEXITCODE -eq 0) {
+      [IO.File]::WriteAllText($tmp, ($line -join [Environment]::NewLine) + [Environment]::NewLine)
+      Move-Item -LiteralPath $tmp -Destination $cache -Force
+    } else {
+      Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
+  } | Out-Null
+
+  & $global:AireceiptsBasePrompt
+}
+```
+
+On Windows, the tmux recipe is WSL-only. Use the PowerShell pattern above for
+native Starship or Oh My Posh sessions.
 
 For Claude Code, its native `statusLine` stdin hook above remains the recommended
 surface. It is faster because the payload points directly at the active
@@ -96,6 +256,22 @@ is omitted, and an unknown name exits 1 with the valid list on stderr):
   }
 }
 ```
+
+For a persistent format shared by every statusline surface, create
+`~/.aireceipts/statusline.json` (under `AIRECEIPTS_HOME` when set):
+
+```json
+{
+  "items": ["brand", "cost", "tokens", "quota5h"]
+}
+```
+
+The array uses the same vocabulary and literal ordering as `--format`, including
+duplicate items. Precedence is explicit `--format`, then `statusline.json`, then
+the default above. A missing file is silent. An unreadable file, bad JSON, wrong
+shape, empty `items`, or unknown item prints one stderr note and safely renders
+the default; a broken dotfile never blanks a polling status bar. Config can only
+select known segments — it cannot inject text, colors, paths, or values.
 
 | Segment | Renders | Source |
 |---|---|---|

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -109,7 +109,14 @@ Every field below is validated against a `.strict()` zod schema before it is que
 | `inputMode` | enum | `stdin_payload` \| `disk_fallback` \| `none` | |
 | `payloadValid` | boolean | | Whether the stdin payload was usable for the integration. |
 | `customFormat` | boolean (optional) | | statusline only (SPEC-0062): an explicit `--format` was passed. The boolean only — never the format string. |
+| `scoped` | boolean (optional) | | statusline only (SPEC-0075 R6): `--cwd` was supplied. The boolean only — never the path. |
+| `configFile` | boolean (optional) | | statusline only (SPEC-0075 R6): a valid `statusline.json` supplied the item order. The boolean only — never the items. |
 | `result` | enum | `success` \| `no_data` \| `invalid_args` \| `declined` \| `external_missing` \| `external_failed` \| `write_failed` \| `internal_error` | |
+
+`statusline --cwd` is a polled surface: it still advances the local run counter
+and records these bounded booleans in-process, but that invocation skips the
+network flush. A 15-second tmux poll therefore does not become a stream of
+network events.
 
 ### `activation_milestone` — once per milestone per local state file
 

--- a/site/docs/07-statusline.html
+++ b/site/docs/07-statusline.html
@@ -357,7 +357,7 @@ footer{
 
 <p>If <code>aireceipts</code> isn't on your <code>PATH</code>, put the absolute path (the output of <code>which aireceipts</code>) in the <code>command</code> field.</p>
 
-<p>Using tmux too? The <a href="statusline.html#terminal-surfaces">terminal-surfaces recipe</a> shows how to put the right session in each pane with <code>statusline --cwd</code>, while keeping Claude Code's richer native stdin hook as the primary setup.</p>
+<p>Using tmux too? The <a href="statusline.html#terminal-surfaces">terminal-surfaces recipe</a> shows tmux, Starship, raw zsh/bash, OSC terminal-title, and PowerShell patterns that pass each pane's cwd to <code>statusline --cwd</code>, while keeping Claude Code's richer native stdin hook as the primary setup.</p>
 
 <h2 id="what-the-line-shows">What the line shows</h2>
 

--- a/site/docs/statusline.html
+++ b/site/docs/statusline.html
@@ -353,13 +353,139 @@ footer{
 
 <h2 id="terminal-surfaces">Terminal surfaces</h2>
 
-<p>Any terminal surface that can run a command and display one line of stdout can show an aireceipts statusline. Pass that surface's pane or prompt working directory to <code>--cwd</code>; aireceipts selects the newest session attributed to that path (or an ancestor of it) and prints the neutral placeholder when none match. It never falls back to another project's newest session, and a session launched from your home directory (or above it) only ever matches that exact path — it is not treated as an ancestor of everything, so one <code>~</code>-launched session can't shadow every pane on the machine. Cursor sessions never match in this mode because Cursor's session data carries no cwd.</p>
+<p>Any terminal surface that can run a command and display one line of stdout can show an aireceipts statusline. Pass that surface's pane or prompt working directory to <code>--cwd</code>; aireceipts selects the newest session attributed to that path (or an ancestor of it) and prints the neutral placeholder when none match. It never falls back to another project's newest session, and a session launched from your home directory (or above it) only ever matches that exact path — it is not treated as an ancestor of everything, so one <code>~</code>-launched session can't shadow every pane on the machine. Relative <code>--cwd</code> paths resolve against the directory where <code>aireceipts</code> is invoked; a path beginning with <code>-</code> must use the <code>--cwd=&lt;path&gt;</code> form. Matching intentionally folds only a Windows drive letter's case: the rest of every path remains case-sensitive because over-matching on a case-sensitive filesystem is the worse failure. Cursor is excluded from scoped discovery entirely because its session data carries no cwd.</p>
+
+<p>Path matching is lexical rather than filesystem-canonical. If <code>$PWD</code> uses a symlinked spelling while a session records the physical path, they do not match. tmux's <code>#{pane_current_path}</code> is resolved, so the tmux recipe below is unaffected.</p>
 
 <p>For tmux, add this to <code>~/.tmux.conf</code>:</p>
 
 <pre class="doc-code"><code class="language-tmux">set -g status-right '#(aireceipts statusline --cwd &quot;#{pane_current_path}&quot;)'</code></pre>
 
 <p>tmux refreshes <code>#(...)</code> commands on <code>status-interval</code>; lower that setting if you want a fresher line, keeping in mind that each refresh runs the command again.</p>
+
+<p>tmux is the recommended live terminal surface because it keeps polling while a command or agent owns the pane. The prompt and title recipes below refresh only <strong>between commands</strong>: while an agent owns the terminal they sit stale, and the cached line you see is one prompt behind. Each refresh is a per-prompt fire-and-forget process that exits after its atomic cache write — there is no resident daemon.</p>
+
+<h3 id="starship-zshbash">Starship (zsh/bash)</h3>
+
+<p>Starship's default <code>command_timeout</code> is 500ms, below Node's roughly one-second startup floor. This custom module therefore prints the last cwd-keyed cache and starts the next refresh in the background. Add it to <code>~/.config/starship.toml</code>:</p>
+
+<pre class="doc-code"><code class="language-toml">[custom.aireceipts]
+command = '''
+key=$(printf '%s' &quot;$PWD&quot; | shasum | cut -c1-12)
+cache=&quot;${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/aireceipts-statusline-$key&quot;
+[ -r &quot;$cache&quot; ] &amp;&amp; cat &quot;$cache&quot;
+(
+  tmp=&quot;${cache}.$$.tmp&quot;
+  if aireceipts statusline --cwd &quot;$PWD&quot; &gt;&quot;$tmp&quot; 2&gt;/dev/null; then
+    mv -f &quot;$tmp&quot; &quot;$cache&quot;
+  else
+    rm -f &quot;$tmp&quot;
+  fi
+) &gt;/dev/null 2&gt;&amp;1 &amp;
+'''
+when = true
+shell = [&quot;sh&quot;]
+format = &quot;$output &quot;</code></pre>
+
+<p>The hash keeps panes in different repositories from reading each other's line; the temp-file-plus-<code>mv</code> keeps readers from seeing a partial line.</p>
+
+<h3 id="raw-zsh-or-bash">Raw zsh or bash</h3>
+
+<p>Without a prompt engine, use the same cache-first pattern. For zsh, add this to <code>~/.zshrc</code>:</p>
+
+<pre class="doc-code"><code class="language-zsh">_aireceipts_precmd() {
+  local key cache
+  key=$(printf '%s' &quot;$PWD&quot; | shasum | cut -c1-12)
+  cache=&quot;${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/aireceipts-statusline-$key&quot;
+  [[ -r &quot;$cache&quot; ]] &amp;&amp; command cat &quot;$cache&quot;
+  (
+    local tmp=&quot;${cache}.$$.tmp&quot;
+    if aireceipts statusline --cwd &quot;$PWD&quot; &gt;&quot;$tmp&quot; 2&gt;/dev/null; then
+      mv -f &quot;$tmp&quot; &quot;$cache&quot;
+    else
+      rm -f &quot;$tmp&quot;
+    fi
+  ) &gt;/dev/null 2&gt;&amp;1 &amp;!
+}
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _aireceipts_precmd</code></pre>
+
+<p>For bash, add this to <code>~/.bashrc</code>:</p>
+
+<pre class="doc-code"><code class="language-bash">_aireceipts_prompt_command() {
+  local key cache
+  key=$(printf '%s' &quot;$PWD&quot; | shasum | cut -c1-12)
+  cache=&quot;${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/aireceipts-statusline-$key&quot;
+  [[ -r &quot;$cache&quot; ]] &amp;&amp; command cat &quot;$cache&quot;
+  (
+    local tmp=&quot;${cache}.$$.tmp&quot;
+    if aireceipts statusline --cwd &quot;$PWD&quot; &gt;&quot;$tmp&quot; 2&gt;/dev/null; then
+      mv -f &quot;$tmp&quot; &quot;$cache&quot;
+    else
+      rm -f &quot;$tmp&quot;
+    fi
+  ) &gt;/dev/null 2&gt;&amp;1 &amp;
+}
+PROMPT_COMMAND=&quot;_aireceipts_prompt_command${PROMPT_COMMAND:+;$PROMPT_COMMAND}&quot;</code></pre>
+
+<h3 id="osc-terminal-title">OSC terminal title</h3>
+
+<p>An OSC title is independent of the prompt engine and works in any OSC-capable terminal emulator. This zsh <code>precmd</code> emits <code>ESC]0;&lt;line&gt;BEL</code>, then refreshes the cwd-keyed cache for the next prompt:</p>
+
+<pre class="doc-code"><code class="language-zsh">_aireceipts_title_precmd() {
+  local key cache line
+  key=$(printf '%s' &quot;$PWD&quot; | shasum | cut -c1-12)
+  cache=&quot;${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/aireceipts-statusline-$key&quot;
+  if [[ -r &quot;$cache&quot; ]]; then
+    IFS= read -r line &lt; &quot;$cache&quot;
+    printf '\033]0;%s\007' &quot;$line&quot;
+  fi
+  (
+    local tmp=&quot;${cache}.$$.tmp&quot;
+    if aireceipts statusline --cwd &quot;$PWD&quot; &gt;&quot;$tmp&quot; 2&gt;/dev/null; then
+      mv -f &quot;$tmp&quot; &quot;$cache&quot;
+    else
+      rm -f &quot;$tmp&quot;
+    fi
+  ) &gt;/dev/null 2&gt;&amp;1 &amp;!
+}
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _aireceipts_title_precmd</code></pre>
+
+<h3 id="windows-powershell">Windows PowerShell</h3>
+
+<p>Starship and Oh My Posh both work in PowerShell. Put this wrapper <strong>after</strong> the prompt engine's initialization line in <code>$PROFILE</code>; it preserves that engine's prompt, prints the last cwd-keyed line, and starts an atomic refresh job. Completed jobs are removed on the next prompt, so the refresh never becomes a daemon.</p>
+
+<pre class="doc-code"><code class="language-powershell">$global:AireceiptsBasePrompt = (Get-Command prompt).ScriptBlock
+function global:prompt {
+  $cwd = (Get-Location).Path
+  $runtime = if ($env:XDG_RUNTIME_DIR) { $env:XDG_RUNTIME_DIR } elseif ($env:TEMP) { $env:TEMP } else { [IO.Path]::GetTempPath() }
+  $bytes = [Text.Encoding]::UTF8.GetBytes($cwd)
+  $key = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).Substring(0, 12).ToLowerInvariant()
+  $cache = Join-Path $runtime &quot;aireceipts-statusline-$key&quot;
+
+  Get-Job -Name &quot;aireceipts-statusline-*&quot; -State Completed -ErrorAction SilentlyContinue | Remove-Job
+  if (Test-Path -LiteralPath $cache) {
+    $line = Get-Content -LiteralPath $cache -Raw
+    if ($line) { Write-Host -NoNewline &quot;$($line.TrimEnd()) &quot; }
+  }
+
+  Start-Job -Name &quot;aireceipts-statusline-$key&quot; -ArgumentList $cache, $cwd -ScriptBlock {
+    param($cache, $cwd)
+    $tmp = &quot;$cache.$PID.tmp&quot;
+    $line = &amp; aireceipts statusline --cwd $cwd 2&gt;$null
+    if ($LASTEXITCODE -eq 0) {
+      [IO.File]::WriteAllText($tmp, ($line -join [Environment]::NewLine) + [Environment]::NewLine)
+      Move-Item -LiteralPath $tmp -Destination $cache -Force
+    } else {
+      Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    }
+  } | Out-Null
+
+  &amp; $global:AireceiptsBasePrompt
+}</code></pre>
+
+<p>On Windows, the tmux recipe is WSL-only. Use the PowerShell pattern above for native Starship or Oh My Posh sessions.</p>
 
 <p>For Claude Code, its native <code>statusLine</code> stdin hook above remains the recommended surface. It is faster because the payload points directly at the active transcript, and it is richer: <code>context</code>, <code>quota5h</code>, <code>quota7d</code>, and <code>quotaEta</code> depend on stdin data. Terminal surfaces are additive when you also want a line in tmux or another shell UI.</p>
 
@@ -389,6 +515,14 @@ footer{
     &quot;command&quot;: &quot;aireceipts statusline --format brand,cost,quota5h,quotaEta&quot;
   }
 }</code></pre>
+
+<p>For a persistent format shared by every statusline surface, create <code>~/.aireceipts/statusline.json</code> (under <code>AIRECEIPTS_HOME</code> when set):</p>
+
+<pre class="doc-code"><code class="language-json">{
+  &quot;items&quot;: [&quot;brand&quot;, &quot;cost&quot;, &quot;tokens&quot;, &quot;quota5h&quot;]
+}</code></pre>
+
+<p>The array uses the same vocabulary and literal ordering as <code>--format</code>, including duplicate items. Precedence is explicit <code>--format</code>, then <code>statusline.json</code>, then the default above. A missing file is silent. An unreadable file, bad JSON, wrong shape, empty <code>items</code>, or unknown item prints one stderr note and safely renders the default; a broken dotfile never blanks a polling status bar. Config can only select known segments — it cannot inject text, colors, paths, or values.</p>
 
 <div class="table-wrap"><table>
   <thead><tr><th>Segment</th><th>Renders</th><th>Source</th></tr></thead>

--- a/site/docs/telemetry.html
+++ b/site/docs/telemetry.html
@@ -467,9 +467,13 @@ footer{
     <tr><td><code>inputMode</code></td><td>enum</td><td><code>stdin_payload</code> | <code>disk_fallback</code> | <code>none</code></td><td></td></tr>
     <tr><td><code>payloadValid</code></td><td>boolean</td><td></td><td>Whether the stdin payload was usable for the integration.</td></tr>
     <tr><td><code>customFormat</code></td><td>boolean (optional)</td><td></td><td>statusline only (SPEC-0062): an explicit <code>--format</code> was passed. The boolean only — never the format string.</td></tr>
+    <tr><td><code>scoped</code></td><td>boolean (optional)</td><td></td><td>statusline only (SPEC-0075 R6): <code>--cwd</code> was supplied. The boolean only — never the path.</td></tr>
+    <tr><td><code>configFile</code></td><td>boolean (optional)</td><td></td><td>statusline only (SPEC-0075 R6): a valid <code>statusline.json</code> supplied the item order. The boolean only — never the items.</td></tr>
     <tr><td><code>result</code></td><td>enum</td><td><code>success</code> | <code>no_data</code> | <code>invalid_args</code> | <code>declined</code> | <code>external_missing</code> | <code>external_failed</code> | <code>write_failed</code> | <code>internal_error</code></td><td></td></tr>
   </tbody>
 </table></div>
+
+<p><code>statusline --cwd</code> is a polled surface: it still advances the local run counter and records these bounded booleans in-process, but that invocation skips the network flush. A 15-second tmux poll therefore does not become a stream of network events.</p>
 
 <h3 id="activationmilestone-once-per-milestone-per-local-state-file"><code>activation_milestone</code> — once per milestone per local state file</h3>
 

--- a/src/cli/commands/statusline.ts
+++ b/src/cli/commands/statusline.ts
@@ -7,6 +7,7 @@
 // `brand,cost,tokens,waste,quota5h`, and `--format` selects any other segment
 // list (unknown names fail fast, exit 1).
 import * as os from "node:os";
+import * as path from "node:path";
 import { listSessions, listSessionsForCwd, loadById, loadSession } from "../../index.js";
 import type { Session, SessionSummary } from "../../parse/types.js";
 import { cwdMatchesForAttribution } from "../../parse/cwdScope.js";
@@ -14,6 +15,7 @@ import { buildReceiptModel } from "../../receipt/model.js";
 import { attachSubagentRollup } from "../../receipt/subagents.js";
 import { buildMiniSummary } from "../../receipt/mini.js";
 import { DEFAULT_FORMAT, parseFormat, renderSegments, SEGMENT_NAMES } from "../statuslineSegments.js";
+import { loadStatuslineFormatConfig } from "../statuslineConfig.js";
 import type { CommandContext, CommandDef } from "../types.js";
 import type { InputModeValue, ResultValue } from "../../telemetry/schemas.js";
 
@@ -23,6 +25,10 @@ export interface StatuslineTelemetryInfo {
   result: ResultValue;
   /** SPEC-0062 R5 — the invocation carried an explicit `--format` (boolean, never the format string). */
   customFormat: boolean;
+  /** SPEC-0075 R6 — boolean only; the raw `--cwd` path must never enter a telemetry payload. */
+  scoped: boolean;
+  /** SPEC-0075 R6 — boolean only; config contents must never enter a telemetry payload. */
+  configFile: boolean;
 }
 
 /**
@@ -94,27 +100,26 @@ export async function loadFromDisk(
 export const MAX_SCOPED_LOAD_ATTEMPTS = 8;
 
 /**
- * SPEC-0075 R1 — load the newest cwd-scoped candidate. Claude Code directory
- * names are lossy, so its candidate must be confirmed against the cwd parsed
- * from the full transcript; a collision or unreadable candidate falls through
- * to the next-most-recent row, and the walk stops at MAX_SCOPED_LOAD_ATTEMPTS.
+ * SPEC-0075 R1 — load the newest cwd-scoped candidate. Claude Code needs
+ * post-load cwd confirmation because its directory names are lossy; every
+ * other adapter gets the same belt-and-suspenders check so an injected
+ * `listSessionsFn` or future lazy/full divergence can never render a mismatched
+ * session. A mismatch or unreadable candidate falls through to the next row,
+ * and the walk stops at MAX_SCOPED_LOAD_ATTEMPTS.
  */
 export async function loadFromCwd(
   requestedCwd: string,
-  listSessionsFn: (cwd: string) => Promise<SessionSummary[]> = listSessionsForCwd,
+  listSessionsFn: (cwd: string, homeDir: string) => Promise<SessionSummary[]> = listSessionsForCwd,
   loadSessionFn: (summary: SessionSummary) => Promise<Session | null> = loadSession,
   homeDir: string = os.homedir(),
 ): Promise<Session | null> {
-  const sessions = await listSessionsFn(requestedCwd);
+  const sessions = await listSessionsFn(requestedCwd, homeDir);
   for (const summary of sessions.slice(0, MAX_SCOPED_LOAD_ATTEMPTS)) {
     const session = await loadSessionFn(summary);
     if (!session) {
       continue;
     }
-    if (
-      summary.source === "claude-code" &&
-      (typeof session.cwd !== "string" || !cwdMatchesForAttribution(session.cwd, requestedCwd, homeDir))
-    ) {
+    if (typeof session.cwd !== "string" || !cwdMatchesForAttribution(session.cwd, requestedCwd, homeDir)) {
       continue;
     }
     return session;
@@ -134,6 +139,8 @@ export interface RunStatuslineOptions {
   /** Clock + state-file seams for the `quotaEta` segment (tests). */
   nowMs?: number;
   quotaStatePath?: string;
+  /** SPEC-0075 R2 — exact config-file path seam for tests. */
+  formatConfigPath?: string;
 }
 
 /**
@@ -153,26 +160,47 @@ export async function runStatusline(
   record?: (info: StatuslineTelemetryInfo) => void | Promise<void>,
   opts: RunStatuslineOptions = {},
 ): Promise<number> {
+  const writeError =
+    opts.writeError ??
+    ((s: string) => {
+      process.stderr.write(s);
+    });
   const customFormat = opts.format !== undefined;
-  const parsed = parseFormat(opts.format ?? DEFAULT_FORMAT);
-  if ("unknown" in parsed) {
-    const writeError =
-      opts.writeError ??
-      ((s: string) => {
-        process.stderr.write(s);
-      });
+  let configFile = false;
+  let parsed = parseFormat(opts.format ?? DEFAULT_FORMAT);
+  if (customFormat && "unknown" in parsed) {
     writeError(`unknown statusline segment "${parsed.unknown}" (valid: ${SEGMENT_NAMES.join(", ")})\n`);
     return 1;
   }
   if (opts.cwd !== undefined && !opts.cwd.trim()) {
-    const writeError =
-      opts.writeError ??
-      ((s: string) => {
-        process.stderr.write(s);
-      });
     writeError("--cwd requires a non-empty path\n");
     return 1;
   }
+  // Resolve only genuinely relative input (`--cwd .`). A path that is already
+  // absolute in EITHER platform's spelling passes through untouched — on
+  // Windows, `path.resolve("/home/x")` would prepend the current drive and a
+  // POSIX-recorded session (or a fixture) would never match again.
+  const requestedCwd =
+    opts.cwd === undefined
+      ? undefined
+      : path.posix.isAbsolute(opts.cwd) || path.win32.isAbsolute(opts.cwd)
+        ? opts.cwd
+        : path.resolve(opts.cwd);
+  if (!customFormat) {
+    const loaded = await loadStatuslineFormatConfig(opts.formatConfigPath);
+    if (loaded.status === "ok") {
+      parsed = { segments: loaded.config.items };
+      configFile = true;
+    } else if (loaded.status === "invalid") {
+      writeError(`statusline.json ignored: ${loaded.reason}\n`);
+    }
+  }
+  // `DEFAULT_FORMAT` is a source-controlled constant; only user input can
+  // produce the unknown branch, which returned above.
+  if ("unknown" in parsed) {
+    return 1;
+  }
+  const scoped = requestedCwd !== undefined;
   const raw = await readStdin(stdin);
   const payload = parsePayload(raw);
   let inputMode: InputModeValue = raw.trim() ? "stdin_payload" : "none";
@@ -181,7 +209,8 @@ export async function runStatusline(
   if (session) {
     payloadValid = true;
   } else {
-    const diskSession = opts.cwd !== undefined ? await (opts.loadFromCwdFn ?? loadFromCwd)(opts.cwd) : await loadFromDiskFn();
+    const diskSession =
+      requestedCwd !== undefined ? await (opts.loadFromCwdFn ?? loadFromCwd)(requestedCwd) : await loadFromDiskFn();
     if (diskSession) {
       inputMode = "disk_fallback";
       session = diskSession;
@@ -189,7 +218,7 @@ export async function runStatusline(
   }
   if (!session) {
     write("aireceipts: no sessions detected\n");
-    await record?.({ inputMode, payloadValid, result: "no_data", customFormat });
+    await record?.({ inputMode, payloadValid, result: "no_data", customFormat, scoped, configFile });
     return 0;
   }
   // SPEC-0061 R3 — the one-liner covers parent + subagents (no children → zero extra transcript reads).
@@ -202,7 +231,7 @@ export async function runStatusline(
     ...(opts.quotaStatePath !== undefined ? { quotaStatePath: opts.quotaStatePath } : {}),
   });
   write(`${line}\n`);
-  await record?.({ inputMode, payloadValid, result: "success", customFormat });
+  await record?.({ inputMode, payloadValid, result: "success", customFormat, scoped, configFile });
   return 0;
 }
 
@@ -220,6 +249,9 @@ export const command: CommandDef = {
   name: "statusline",
   priority: 90,
   matches: (options) => options.positional[0] === "statusline",
+  // SPEC-0075 R6 — `--cwd` is a polling integration: keep local counters and
+  // event recording, but do not turn a 15s prompt/tmux poll into a network send.
+  shouldFlushTelemetry: (options) => options.cwd === undefined,
   run,
   help: {
     order: 180,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,6 +27,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
   const isTelemetryShow = command.name === "telemetry-show";
   const isSilentHook = command.name === "hook-pre-push";
   const skipTelemetry = isTelemetryShow || isSilentHook;
+  const shouldFlushTelemetry = command.shouldFlushTelemetry?.(options) ?? true;
   if (!skipTelemetry) {
     await ensureFirstRunNotice((text) => process.stderr.write(text + "\n"), undefined);
   }
@@ -56,7 +57,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<numb
     }
     return isSilentHook ? 0 : 1;
   } finally {
-    if (!skipTelemetry) {
+    if (!skipTelemetry && shouldFlushTelemetry) {
       await flushTelemetry();
     }
   }

--- a/src/cli/statuslineConfig.ts
+++ b/src/cli/statuslineConfig.ts
@@ -1,0 +1,73 @@
+// SPEC-0075 R2 — persistent statusline item order. This mirrors the existing
+// `~/.aireceipts` config convention: resolve the home at call time, validate a
+// closed shape, and return a typed failure instead of throwing.
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { SEGMENT_NAMES, type SegmentName } from "./statuslineSegments.js";
+
+export interface StatuslineFormatConfig {
+  items: SegmentName[];
+}
+
+export type StatuslineFormatConfigLoadResult =
+  | { status: "absent" }
+  | { status: "invalid"; reason: string }
+  | { status: "ok"; config: StatuslineFormatConfig };
+
+/** Resolution order: explicit home, `AIRECEIPTS_HOME`, then the real home. */
+export function statuslineFormatConfigPath(homeOverride?: string): string {
+  return join(homeOverride ?? process.env.AIRECEIPTS_HOME ?? homedir(), ".aireceipts", "statusline.json");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Only `{ items: SegmentName[] }` is accepted; duplicates and order stay literal. */
+export function validateStatuslineFormatConfig(
+  parsed: unknown,
+): { ok: true; config: StatuslineFormatConfig } | { ok: false; reason: string } {
+  if (!isRecord(parsed)) {
+    return { ok: false, reason: "statusline.json must be a JSON object" };
+  }
+  const keys = Object.keys(parsed);
+  if (keys.length !== 1 || keys[0] !== "items") {
+    return { ok: false, reason: 'statusline.json must contain only an "items" array' };
+  }
+  if (!Array.isArray(parsed.items) || parsed.items.length === 0) {
+    return { ok: false, reason: "items must be a non-empty array" };
+  }
+  const items: SegmentName[] = [];
+  for (const item of parsed.items) {
+    if (typeof item !== "string" || !(SEGMENT_NAMES as readonly string[]).includes(item)) {
+      const shown = typeof item === "string" ? JSON.stringify(item) : JSON.stringify(item) ?? String(item);
+      return { ok: false, reason: `unknown statusline item ${shown} (valid: ${SEGMENT_NAMES.join(", ")})` };
+    }
+    items.push(item as SegmentName);
+  }
+  return { ok: true, config: { items } };
+}
+
+/** Load `statusline.json` from an optional exact path seam. Never throws. */
+export async function loadStatuslineFormatConfig(
+  path: string = statuslineFormatConfigPath(),
+): Promise<StatuslineFormatConfigLoadResult> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { status: "absent" };
+    }
+    return { status: "invalid", reason: "could not read statusline.json" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: "invalid", reason: "statusline.json is not valid JSON" };
+  }
+  const validated = validateStatuslineFormatConfig(parsed);
+  return validated.ok ? { status: "ok", config: validated.config } : { status: "invalid", reason: validated.reason };
+}

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -65,6 +65,8 @@ export interface CommandDef {
   /** Higher `priority` is checked first; the first `matches` hit wins. receipt = 0 (default). */
   readonly priority: number;
   matches(options: CliOptions): boolean;
+  /** SPEC-0075 R6 — invocation-level network flush policy; local recording still runs. */
+  shouldFlushTelemetry?(options: CliOptions): boolean;
   run(ctx: CommandContext): number | Promise<number>;
   readonly help?: HelpEntry;
 }

--- a/src/parse/cwdScope.ts
+++ b/src/parse/cwdScope.ts
@@ -51,17 +51,26 @@ export function normalizeCwd(cwd: string): string {
   return joined === "" ? "" : joined === "//" ? "/" : joined;
 }
 
-/** True when the session cwd is the requested cwd or one of its whole-segment ancestors. */
-export function cwdMatches(sessionCwd: string, requestedCwd: string): boolean {
-  const session = normalizeCwd(sessionCwd);
-  const requested = normalizeCwd(requestedCwd);
+function matchesNormalized(session: string, requested: string): boolean {
+  if (session === "" || requested === "") {
+    return false;
+  }
   if (session === requested) {
     return true;
   }
   if (session === "/") {
     return requested.startsWith("/");
   }
-  return session !== "" && requested.startsWith(`${session}/`);
+  return requested.startsWith(`${session}/`);
+}
+
+/**
+ * RAW whole-segment ancestor rule: a session cwd matches itself and its whole
+ * subtree (including root `/` and its whole subtree). Attribution callers MUST
+ * use `cwdMatchesForAttribution`, which also blocks home-or-above shadowing.
+ */
+export function cwdMatches(sessionCwd: string, requestedCwd: string): boolean {
+  return matchesNormalized(normalizeCwd(sessionCwd), normalizeCwd(requestedCwd));
 }
 
 /**
@@ -77,11 +86,11 @@ export function cwdMatches(sessionCwd: string, requestedCwd: string): boolean {
 export function cwdMatchesForAttribution(sessionCwd: string, requestedCwd: string, homeDir: string): boolean {
   const session = normalizeCwd(sessionCwd);
   const requested = normalizeCwd(requestedCwd);
+  if (!matchesNormalized(session, requested)) {
+    return false;
+  }
   if (session === requested) {
     return true;
-  }
-  if (!cwdMatches(sessionCwd, requestedCwd)) {
-    return false;
   }
   if (session === "/") {
     // A root-recorded session shadows everything regardless of whether the

--- a/src/parse/load.ts
+++ b/src/parse/load.ts
@@ -30,7 +30,7 @@ export async function listSessionsForCwd(requestedCwd: string, homeDir: string =
       try {
         if (adapter.id === "claude-code") {
           const root = adapter.roots()[0];
-          if (!root) {
+          if (!root || !root.trim()) {
             return [];
           }
           const roots = claudeProjectDirectoryNames(requestedCwd).map((name) => path.join(root, name));
@@ -41,6 +41,7 @@ export async function listSessionsForCwd(requestedCwd: string, homeDir: string =
           (session) => typeof session.cwd === "string" && cwdMatchesForAttribution(session.cwd, requestedCwd, homeDir),
         );
       } catch {
+        // Statusline discovery is deliberately fail-safe: one adapter failure contributes no rows.
         return [] as SessionSummary[];
       }
     }),

--- a/src/telemetry/index.test.ts
+++ b/src/telemetry/index.test.ts
@@ -163,7 +163,15 @@ describe("SPEC-0043 recorders", () => {
       result: "success",
     });
     recordHookConfigured({ operation: "install", promptOutcome: "accepted", result: "success" });
-    recordIntegrationSurfaceRendered({ integration: "statusline", inputMode: "stdin_payload", payloadValid: true, result: "success" });
+    recordIntegrationSurfaceRendered({
+      integration: "statusline",
+      inputMode: "stdin_payload",
+      payloadValid: true,
+      result: "success",
+      customFormat: false,
+      scoped: true,
+      configFile: true,
+    });
 
     const names = peekQueuedEvents().map((e) => e.name);
     expect(new Set(names)).toEqual(new Set(EVENT_NAMES));

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -236,6 +236,10 @@ export interface RecordIntegrationSurfaceRenderedInput {
   result: ResultValue;
   /** SPEC-0062 R5 — statusline only: an explicit `--format` was passed (boolean, never the format string). */
   customFormat?: boolean;
+  /** SPEC-0075 R6 — boolean only; the raw `--cwd` path must never enter a telemetry payload. */
+  scoped?: boolean;
+  /** SPEC-0075 R6 — boolean only; config contents must never enter a telemetry payload. */
+  configFile?: boolean;
 }
 
 export function recordIntegrationSurfaceRendered(input: RecordIntegrationSurfaceRenderedInput): void {

--- a/src/telemetry/schemas.test.ts
+++ b/src/telemetry/schemas.test.ts
@@ -77,7 +77,7 @@ describe("SPEC-0043 R9: docs parity", () => {
       "result",
     ],
     hook_configured: ["operation", "promptOutcome", "result"],
-    integration_surface_rendered: ["integration", "inputMode", "payloadValid", "result"],
+    integration_surface_rendered: ["integration", "inputMode", "payloadValid", "customFormat", "scoped", "configFile", "result"],
     activation_milestone: ["milestone", "command", "installAgeBucket"],
   } as const;
 
@@ -206,7 +206,15 @@ describe("SPEC-0043 R1-R5: valid events pass their schema", () => {
     ["hook_configured", { operation: "install", promptOutcome: "accepted", result: "success" }],
     [
       "integration_surface_rendered",
-      { integration: "statusline", inputMode: "stdin_payload", payloadValid: true, result: "success" },
+      {
+        integration: "statusline",
+        inputMode: "stdin_payload",
+        payloadValid: true,
+        customFormat: false,
+        scoped: true,
+        configFile: true,
+        result: "success",
+      },
     ],
     ["activation_milestone", { milestone: "first_receipt", command: "receipt", installAgeBucket: "first_day" }],
   ] as const)("accepts a well-formed %s event", (name, properties) => {
@@ -228,6 +236,21 @@ describe("SPEC-0043 R1-R5: valid events pass their schema", () => {
         runOrdinalBucket: "unavailable",
       }).success,
     ).toBe(true);
+  });
+
+  it("SPEC-0075 R6 strictly accepts boolean-only statusline scope/config markers", () => {
+    const valid = {
+      integration: "statusline",
+      inputMode: "disk_fallback",
+      payloadValid: false,
+      result: "success",
+      customFormat: false,
+      scoped: true,
+      configFile: true,
+    };
+    expect(integrationSurfaceRenderedPropertiesSchema.safeParse(valid).success).toBe(true);
+    expect(integrationSurfaceRenderedPropertiesSchema.safeParse({ ...valid, scoped: "/private/repo" }).success).toBe(false);
+    expect(integrationSurfaceRenderedPropertiesSchema.safeParse({ ...valid, configFile: "brand,cost" }).success).toBe(false);
   });
 });
 

--- a/src/telemetry/schemas.ts
+++ b/src/telemetry/schemas.ts
@@ -254,6 +254,10 @@ export const integrationSurfaceRenderedPropertiesSchema = z
     result: z.enum(RESULT_VALUES),
     /** SPEC-0062 R5 — statusline only: the invocation carried an explicit `--format` (boolean, never the format string). */
     customFormat: z.boolean().optional(),
+    /** SPEC-0075 R6 — boolean only; the raw `--cwd` path must never enter a telemetry payload. */
+    scoped: z.boolean().optional(),
+    /** SPEC-0075 R6 — boolean only; config contents must never enter a telemetry payload. */
+    configFile: z.boolean().optional(),
   })
   .strict();
 export type IntegrationSurfaceRenderedProperties = z.infer<typeof integrationSurfaceRenderedPropertiesSchema>;

--- a/test/cli-e2e/built-cli.test.ts
+++ b/test/cli-e2e/built-cli.test.ts
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { copyFile, mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readdir, readFile, realpath, rm, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -683,21 +683,53 @@ describe("built CLI e2e", () => {
     expect(result.stdout.endsWith("\n")).toBe(true);
   });
 
-  it("scopes statusline disk discovery to --cwd", async () => {
+  it("SPEC-0075 R2: sandbox-home statusline config changes the built CLI line", async () => {
+    const home = await makeHome();
+    await writeFile(path.join(home, ".aireceipts", "statusline.json"), JSON.stringify({ items: ["tokens"] }), "utf8");
+    const transcriptPath = path.join(fixturesDir, "claude-code", "clean-multi-tool-2-models.jsonl");
+
+    const result = await runCli(["statusline"], home, JSON.stringify({ transcript_path: transcriptPath }));
+
+    expect(result.code, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("147k\n");
+  });
+
+  it("SPEC-0075 R2: corrupt sandbox-home config falls back with one stderr note", async () => {
+    const home = await makeHome();
+    await writeFile(path.join(home, ".aireceipts", "statusline.json"), "{bad json", "utf8");
+    const transcriptPath = path.join(fixturesDir, "claude-code", "clean-multi-tool-2-models.jsonl");
+
+    const result = await runCli(["statusline"], home, JSON.stringify({ transcript_path: transcriptPath }));
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("[aireceipts] $0.18");
+    expect(result.stderr).toBe("statusline.json ignored: statusline.json is not valid JSON\n");
+  });
+
+  it("scopes statusline disk discovery to --cwd instead of a newer foreign session", async () => {
     const home = await makeHome();
     const sessionCwd = "/home/dev/webapp";
+    const projectsRoot = path.join(home, ".claude", "projects");
     // The literal encoded name, NOT encodeClaudeProjectCwd(sessionCwd): the
     // fixture layout must pin Claude Code's real on-disk convention, so an
     // encoder regression cannot silently reshape the fixture to keep matching.
-    const projectDir = path.join(home, ".claude", "projects", "-home-dev-webapp");
-    await mkdir(projectDir, { recursive: true });
-    await copyFile(path.join(fixturesDir, "claude-code", "clean-multi-tool-2-models.jsonl"), path.join(projectDir, "session.jsonl"));
+    const projectDir = path.join(projectsRoot, "-home-dev-webapp");
+    const foreignProjectDir = path.join(projectsRoot, "-home-dev-app5");
+    await Promise.all([mkdir(projectDir, { recursive: true }), mkdir(foreignProjectDir, { recursive: true })]);
+    const matchingPath = path.join(projectDir, "session.jsonl");
+    const foreignPath = path.join(foreignProjectDir, "newer-foreign.jsonl");
+    await copyFile(path.join(fixturesDir, "claude-code", "clean-multi-tool-2-models.jsonl"), matchingPath);
+    await copyFile(path.join(fixturesDir, "claude-code", "trivial-spans-quick-qa.jsonl"), foreignPath);
+    await utimes(matchingPath, 1_700_000_000, 1_700_000_000);
+    await utimes(foreignPath, 1_700_000_100, 1_700_000_100);
 
     const result = await runCli(["statusline", "--cwd", `${sessionCwd}/src`], home);
 
     expect(result.code, result.stderr).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("[aireceipts · Claude Code]");
+    expect(result.stdout).toContain("147k");
   });
 
   it("fails fast when statusline --cwd has no value", async () => {

--- a/test/cli/command-path-telemetry.test.ts
+++ b/test/cli/command-path-telemetry.test.ts
@@ -12,6 +12,7 @@
 import { copyFileSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { Readable } from "node:stream";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const savedEnv = vi.hoisted(() => {
@@ -43,6 +44,25 @@ function opencodeRoot(home: string): string {
   return process.platform === "win32" ? join(home, "AppData", "Local", "opencode") : join(home, ".local", "share", "opencode");
 }
 
+async function withStdinPayload<T>(payload: string, fn: () => Promise<T>): Promise<T> {
+  const stream = process.stdin;
+  const ttyDescriptor = Object.getOwnPropertyDescriptor(stream, "isTTY");
+  const iteratorDescriptor = Object.getOwnPropertyDescriptor(stream, Symbol.asyncIterator);
+  Object.defineProperty(stream, "isTTY", { configurable: true, value: false });
+  Object.defineProperty(stream, Symbol.asyncIterator, {
+    configurable: true,
+    value: () => Readable.from([Buffer.from(payload, "utf8")])[Symbol.asyncIterator](),
+  });
+  try {
+    return await fn();
+  } finally {
+    if (ttyDescriptor) Object.defineProperty(stream, "isTTY", ttyDescriptor);
+    else delete (stream as { isTTY?: boolean }).isTTY;
+    if (iteratorDescriptor) Object.defineProperty(stream, Symbol.asyncIterator, iteratorDescriptor);
+    else delete (stream as unknown as Record<symbol, unknown>)[Symbol.asyncIterator];
+  }
+}
+
 describe("SPEC-0043 command-path telemetry", () => {
   const home = homedir(); // the mocked, factory-created temp home
   // Captured ONCE at module scope: a beforeEach save would capture the previous
@@ -51,6 +71,7 @@ describe("SPEC-0043 command-path telemetry", () => {
   const origErr = process.stderr.write.bind(process.stderr);
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     mkdirSync(join(home, ".aireceipts"), { recursive: true });
     writeFileSync(join(home, ".aireceipts", "telemetry.json"), JSON.stringify({ shown: true }));
     mkdirSync(opencodeRoot(home), { recursive: true });
@@ -105,6 +126,32 @@ describe("SPEC-0043 command-path telemetry", () => {
     const runs = events.filter((e) => e.name === "cli_run");
     expect(runs).toHaveLength(1);
     expect((runs[0].properties as Record<string, unknown>).commandClass).toBe("receipt");
+  });
+
+  it("SPEC-0075 R6: scoped statusline advances the local counter but skips the network flush", async () => {
+    const transcriptPath = join(fixturesDir, "claude-code", "clean-multi-tool-2-models.jsonl");
+    const before = await telemetry.readState(home);
+
+    const code = await withStdinPayload(JSON.stringify({ transcript_path: transcriptPath }), () =>
+      main(["statusline", "--cwd", home]),
+    );
+
+    expect(code).toBe(0);
+    expect((await telemetry.readState(home)).runCount).toBe(before.runCount + 1);
+    expect(telemetry.flushTelemetry).not.toHaveBeenCalled();
+    const integration = peekQueuedEvents().find((event) => event.name === "integration_surface_rendered");
+    expect(integration?.properties).toEqual(
+      expect.objectContaining({ customFormat: false, scoped: true, configFile: false }),
+    );
+  });
+
+  it("SPEC-0075 R6: unscoped statusline keeps the existing network flush", async () => {
+    const transcriptPath = join(fixturesDir, "claude-code", "clean-multi-tool-2-models.jsonl");
+
+    const code = await withStdinPayload(JSON.stringify({ transcript_path: transcriptPath }), () => main(["statusline"]));
+
+    expect(code).toBe(0);
+    expect(telemetry.flushTelemetry).toHaveBeenCalledTimes(1);
   });
 
   // SPEC-0054 R8 — detailsView is true only for renders that carry the DETAILS

--- a/test/cli/statusline-cwd.test.ts
+++ b/test/cli/statusline-cwd.test.ts
@@ -1,6 +1,17 @@
 // SPEC-0075 R1 — pure cwd attribution rules and Claude Code's lossy project
 // directory encoding. These tests never inspect the developer's real home.
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSource, SessionAdapter, SessionSummary } from "../../src/parse/types.js";
+
+const { adaptersMock } = vi.hoisted(() => ({ adaptersMock: vi.fn() }));
+
+vi.mock("../../src/parse/registry.js", () => ({
+  adapterFor: vi.fn(),
+  adapters: adaptersMock,
+  detectedAdapters: vi.fn(),
+}));
+
+import { listSessionsForCwd } from "../../src/parse/load.js";
 import {
   claudeProjectDirectoryNames,
   cwdMatches,
@@ -8,6 +19,10 @@ import {
   encodeClaudeProjectCwd,
   normalizeCwd,
 } from "../../src/parse/cwdScope.js";
+
+beforeEach(() => {
+  adaptersMock.mockReset();
+});
 
 describe("SPEC-0075 R1 cwd matching", () => {
   it("matches equal POSIX paths", () => {
@@ -57,6 +72,16 @@ describe("SPEC-0075 R1 cwd matching", () => {
     expect(normalizeCwd("C:/..")).toBe("c:");
     expect(cwdMatches("Other", "C:/../Other")).toBe(false);
     expect(cwdMatches("c:/Other", "C:/../Other")).toBe(true);
+  });
+
+  it("never matches an empty normalized path", () => {
+    expect(cwdMatches("", "/x")).toBe(false);
+    expect(cwdMatches("/x", "")).toBe(false);
+  });
+
+  it("preserves host-only UNC paths", () => {
+    expect(normalizeCwd("//server")).toBe("//server");
+    expect(normalizeCwd(String.raw`\\server`)).toBe("//server");
   });
 });
 
@@ -108,11 +133,60 @@ describe("SPEC-0075 R1 Claude Code cwd encoding", () => {
     expect(claudeProjectDirectoryNames("/my/repo")).toEqual(["-", "-my", "-my-repo"]);
   });
 
+  it("handles empty, root, and Windows-drive inputs", () => {
+    expect(claudeProjectDirectoryNames("")).toEqual([]);
+    expect(claudeProjectDirectoryNames("/")).toEqual(["-"]);
+    expect(claudeProjectDirectoryNames("c:/repo/sub")).toEqual(["c-", "c--repo", "c--repo-sub"]);
+  });
+
   it("keeps both UNC leading slashes in encoded ancestor names", () => {
     expect(claudeProjectDirectoryNames("//server/share/repo")).toEqual([
       "--server",
       "--server-share",
       "--server-share-repo",
     ]);
+  });
+});
+
+describe("SPEC-0075 R1 scoped adapter discovery", () => {
+  const totals = {
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheCreation: 0, total: 0 },
+    turnCount: 0,
+    toolCallCount: 0,
+  };
+
+  function summary(id: string, source: AgentSource, cwd: string, endedAt: number): SessionSummary {
+    return { id, source, cwd, endedAt, totals, filePath: `/${id}.jsonl` };
+  }
+
+  function adapter(id: AgentSource, listSessions: SessionAdapter["listSessions"]): SessionAdapter {
+    return {
+      id,
+      label: id,
+      roots: () => [],
+      detect: async () => true,
+      listSessions,
+      loadSession: async () => null,
+    };
+  }
+
+  it("isolates an adapter exception without dropping another adapter's matches", async () => {
+    const kept = summary("kept", "gemini", "/repo", 1_000);
+    adaptersMock.mockReturnValue([
+      adapter("codex", async () => {
+        throw new Error("broken adapter");
+      }),
+      adapter("gemini", async () => [kept]),
+    ]);
+
+    await expect(listSessionsForCwd("/repo/sub", "/home/dev")).resolves.toEqual([kept]);
+  });
+
+  it("keeps only cwd-matching rows from a codex-like adapter", async () => {
+    const kept = summary("kept", "codex", "/repo", 1_000);
+    const dropped = summary("dropped", "codex", "/elsewhere", 2_000);
+    adaptersMock.mockReturnValue([adapter("codex", async () => [dropped, kept])]);
+
+    await expect(listSessionsForCwd("/repo/sub", "/home/dev")).resolves.toEqual([kept]);
   });
 });

--- a/test/cli/statusline.test.ts
+++ b/test/cli/statusline.test.ts
@@ -6,9 +6,11 @@
 // `~/.claude/projects` directory (context-safety rule: never scan real
 // transcripts).
 import { fileURLToPath } from "node:url";
+import { mkdir, mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { loadById } from "../../src/index.js";
 import type { Session, SessionSummary } from "../../src/parse/types.js";
 import {
@@ -21,6 +23,21 @@ import {
 } from "../../src/cli/index.js";
 
 const fixturesDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../fixtures/claude-code");
+let isolatedHome: string;
+let savedAireceiptsHome: string | undefined;
+
+beforeAll(async () => {
+  savedAireceiptsHome = process.env.AIRECEIPTS_HOME;
+  isolatedHome = await mkdtemp(path.join(tmpdir(), "aireceipts-statusline-test-"));
+  process.env.AIRECEIPTS_HOME = isolatedHome;
+  await mkdir(path.join(isolatedHome, ".aireceipts"), { recursive: true });
+});
+
+afterAll(async () => {
+  if (savedAireceiptsHome === undefined) delete process.env.AIRECEIPTS_HOME;
+  else process.env.AIRECEIPTS_HOME = savedAireceiptsHome;
+  await rm(isolatedHome, { recursive: true, force: true });
+});
 
 function fixturePath(name: string): string {
   return path.join(fixturesDir, name);
@@ -149,15 +166,85 @@ describe("loadFromCwd (SPEC-0075 R1, fixture-injected)", () => {
     expect(output).not.toContain("Claude Code");
   });
 
-  it("caps full-transcript loads at MAX_SCOPED_LOAD_ATTEMPTS on a collision-heavy candidate list", async () => {
+  it("rejects a non-Claude candidate when its fully loaded cwd no longer matches", async () => {
     const fixture = (await loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl")))!;
-    // 20 colliding CC candidates; the walk must stop at the cap and render the
-    // placeholder — bounded work, never a long stall in a polling status bar.
-    const candidates: SessionSummary[] = Array.from({ length: 20 }, (_, i) => ({
+    const candidate: Session = { ...fixture, id: "codex-lazy-match", source: "codex", cwd: "/repo" };
+    const loaded: Session = { ...candidate, cwd: "/elsewhere" };
+    let listArgs: [string, string] | undefined;
+
+    const session = await loadFromCwd(
+      "/repo/sub",
+      async (cwd, homeDir) => {
+        listArgs = [cwd, homeDir];
+        return [candidate];
+      },
+      async () => loaded,
+      "/Users/test",
+    );
+
+    expect(session).toBeNull();
+    expect(listArgs).toEqual(["/repo/sub", "/Users/test"]);
+  });
+
+  it("accepts a non-Claude candidate only after its fully loaded cwd is confirmed", async () => {
+    const fixture = (await loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl")))!;
+    const candidate: Session = { ...fixture, id: "codex-confirmed", source: "codex", cwd: "/repo" };
+    let loads = 0;
+
+    const session = await loadFromCwd(
+      "/repo/sub",
+      async () => [candidate],
+      async () => {
+        loads++;
+        return candidate;
+      },
+      "/Users/test",
+    );
+
+    expect(session).toBe(candidate);
+    expect(loads).toBe(1);
+  });
+
+  it("renders a genuine match at the final allowed load index", async () => {
+    const fixture = (await loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl")))!;
+    const collisions: Session[] = Array.from({ length: MAX_SCOPED_LOAD_ATTEMPTS - 1 }, (_, i) => ({
       ...fixture,
       id: `collision-${i}`,
       cwd: "/my/repo",
     }));
+    const match: Session = { ...fixture, id: "match-at-cap-minus-one", cwd: "/my-repo" };
+    let loads = 0;
+    const scopedLoader = (cwd: string) =>
+      loadFromCwd(
+        cwd,
+        async () => [...collisions, match],
+        async (summary) => {
+          loads++;
+          return [...collisions, match].find((session) => session.id === summary.id) ?? null;
+        },
+      );
+
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
+        cwd: "/my-repo",
+        loadFromCwdFn: scopedLoader,
+      }),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toContain("[aireceipts · Claude Code]");
+    expect(loads).toBe(MAX_SCOPED_LOAD_ATTEMPTS);
+  });
+
+  it("renders the placeholder when the first genuine match is beyond the load cap", async () => {
+    const fixture = (await loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl")))!;
+    const collisions: Session[] = Array.from({ length: MAX_SCOPED_LOAD_ATTEMPTS }, (_, i) => ({
+      ...fixture,
+      id: `collision-${i}`,
+      cwd: "/my/repo",
+    }));
+    const match: Session = { ...fixture, id: "match-at-cap", cwd: "/my-repo" };
+    const candidates = [...collisions, match];
     let loads = 0;
     const scopedLoader = (cwd: string) =>
       loadFromCwd(
@@ -165,7 +252,7 @@ describe("loadFromCwd (SPEC-0075 R1, fixture-injected)", () => {
         async () => candidates,
         async (summary) => {
           loads++;
-          return { ...fixture, id: summary.id, cwd: "/my/repo" };
+          return candidates.find((session) => session.id === summary.id) ?? null;
         },
       );
 
@@ -184,7 +271,8 @@ describe("loadFromCwd (SPEC-0075 R1, fixture-injected)", () => {
   it("rejects a Claude Code encoding collision after full load", async () => {
     const fixture = (await loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl")))!;
     const collision: Session = { ...fixture, id: "collision", cwd: "/my/repo" };
-    const scopedLoader = (cwd: string) => loadFromCwd(cwd, async () => [collision], async () => collision);
+    const scopedLoader = (cwd: string) =>
+      loadFromCwd(cwd, async () => [collision], async () => collision);
 
     const { code, output } = await captureStdout(() =>
       runStatusline(stdinStub("", true), async () => fixture, undefined, undefined, {
@@ -245,6 +333,176 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
     const explicitDefaults = await captureStdout(() => runStatusline(stdinStub("", true), loadFromDiskFn, undefined, undefined, {}));
 
     expect(explicitDefaults).toEqual(baseline);
+  });
+
+  it("SPEC-0075 R1: resolves --cwd . against the invocation directory before scoped loading", async () => {
+    const fixture = (await loadById("claude-code", fixturePath("clean-multi-tool-2-models.jsonl")))!;
+    let loadedCwd: string | undefined;
+
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
+        cwd: ".",
+        loadFromCwdFn: async (cwd) => {
+          loadedCwd = cwd;
+          return cwd === process.cwd() ? fixture : null;
+        },
+      }),
+    );
+
+    expect(code).toBe(0);
+    expect(loadedCwd).toBe(process.cwd());
+    expect(output).toContain("[aireceipts · Claude Code]");
+  });
+
+  it("SPEC-0075 R1: an already-absolute --cwd passes through unresolved (never drive-mangled on Windows)", async () => {
+    // On win32, path.resolve("/home/x") prepends the current drive — a
+    // POSIX-recorded session would then never match. Absolute input in either
+    // platform's spelling must reach the scoped loader byte-identical.
+    for (const absolute of ["/home/dev/webapp", "C:\\repo\\sub"]) {
+      let loadedCwd: string | undefined;
+      await captureStdout(() =>
+        runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
+          cwd: absolute,
+          loadFromCwdFn: async (cwd) => {
+            loadedCwd = cwd;
+            return null;
+          },
+        }),
+      );
+      expect(loadedCwd).toBe(absolute);
+    }
+  });
+
+  it("SPEC-0075 R2: stdin/native mode renders configured items in literal order, including duplicates", async () => {
+    const configPath = path.join(isolatedHome, "ordered-statusline.json");
+    await writeFile(configPath, JSON.stringify({ items: ["tokens", "brand", "cost", "brand"] }), "utf8");
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub(JSON.stringify({ transcript_path: transcriptPath })), async () => null, undefined, undefined, {
+        formatConfigPath: configPath,
+      }),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toBe("147k · [aireceipts] · $0.18 · [aireceipts]\n");
+  });
+
+  it("SPEC-0075 R2: explicit --format beats a valid config file", async () => {
+    const configPath = path.join(isolatedHome, "overridden-statusline.json");
+    await writeFile(configPath, JSON.stringify({ items: ["tokens"] }), "utf8");
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub(JSON.stringify({ transcript_path: transcriptPath })), async () => null, undefined, undefined, {
+        format: "cost,brand",
+        formatConfigPath: configPath,
+      }),
+    );
+
+    expect(code).toBe(0);
+    expect(output).toBe("$0.18 · [aireceipts]\n");
+  });
+
+  it.each([
+    ["bad JSON", "{bad json"],
+    ["unknown item", JSON.stringify({ items: ["brand", "bogus"] })],
+    ["wrong shape", JSON.stringify({ items: "brand" })],
+    ["empty items", JSON.stringify({ items: [] })],
+  ])("SPEC-0075 R2: %s falls back to the default with one stderr note", async (_case, rawConfig) => {
+    const configPath = path.join(isolatedHome, `invalid-${_case.replace(/\s/g, "-")}.json`);
+    const absentPath = path.join(isolatedHome, "absent-default.json");
+    await writeFile(configPath, rawConfig, "utf8");
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    const payload = JSON.stringify({ transcript_path: transcriptPath });
+    const baseline = await captureStdout(() =>
+      runStatusline(stdinStub(payload), async () => null, undefined, undefined, { formatConfigPath: absentPath }),
+    );
+    let err = "";
+    const actual = await captureStdout(() =>
+      runStatusline(stdinStub(payload), async () => null, undefined, undefined, {
+        formatConfigPath: configPath,
+        writeError: (s) => {
+          err += s;
+        },
+      }),
+    );
+
+    expect(actual.code).toBe(0);
+    expect(actual.output).toBe(baseline.output);
+    expect(err).toContain("statusline.json ignored:");
+    expect(err.trimEnd().split("\n")).toHaveLength(1);
+  });
+
+  it("SPEC-0075 R2: an unreadable config falls back to the default with one stderr note", async () => {
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    const payload = JSON.stringify({ transcript_path: transcriptPath });
+    const absentPath = path.join(isolatedHome, "absent-unreadable-default.json");
+    const baseline = await captureStdout(() =>
+      runStatusline(stdinStub(payload), async () => null, undefined, undefined, { formatConfigPath: absentPath }),
+    );
+    let err = "";
+    const actual = await captureStdout(() =>
+      runStatusline(stdinStub(payload), async () => null, undefined, undefined, {
+        formatConfigPath: isolatedHome,
+        writeError: (s) => {
+          err += s;
+        },
+      }),
+    );
+
+    expect(actual).toEqual({ code: 0, output: baseline.output });
+    expect(err).toBe("statusline.json ignored: could not read statusline.json\n");
+  });
+
+  it("SPEC-0075 R2: an absent config silently preserves the default", async () => {
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    let err = "";
+    const baseline = await captureStdout(() =>
+      runStatusline(stdinStub(JSON.stringify({ transcript_path: transcriptPath })), async () => null, undefined, undefined, {
+        formatConfigPath: path.join(isolatedHome, "definitely-absent.json"),
+        writeError: (s) => {
+          err += s;
+        },
+      }),
+    );
+
+    expect(baseline.code).toBe(0);
+    expect(baseline.output).toContain("[aireceipts] $0.18");
+    expect(err).toBe("");
+  });
+
+  it("SPEC-0075 R2: AIRECEIPTS_HOME is resolved at call time", async () => {
+    const configPath = path.join(isolatedHome, ".aireceipts", "statusline.json");
+    await writeFile(configPath, JSON.stringify({ items: ["tokens"] }), "utf8");
+    const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
+    try {
+      const { code, output } = await captureStdout(() =>
+        runStatusline(stdinStub(JSON.stringify({ transcript_path: transcriptPath })), async () => null),
+      );
+      expect(code).toBe(0);
+      expect(output).toBe("147k\n");
+    } finally {
+      await unlink(configPath);
+    }
+  });
+
+  it("SPEC-0075 R2: invalid explicit --format still fails fast when config is valid", async () => {
+    const configPath = path.join(isolatedHome, "valid-but-unused.json");
+    await writeFile(configPath, JSON.stringify({ items: ["tokens"] }), "utf8");
+    let err = "";
+    const { code, output } = await captureStdout(() =>
+      runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
+        format: "bogus",
+        formatConfigPath: configPath,
+        writeError: (s) => {
+          err += s;
+        },
+      }),
+    );
+
+    expect(code).toBe(1);
+    expect(output).toBe("");
+    expect(err).toContain('unknown statusline segment "bogus"');
+    expect(err).not.toContain("statusline.json ignored");
   });
 
   it("R3a: prefers the stdin payload's session over disk fallback", async () => {
@@ -346,33 +604,55 @@ describe("runStatusline (R3/R4 end-to-end)", () => {
     expect(err).toContain("unknown statusline segment");
   });
 
-  it("SPEC-0075 R1: a bare or empty --cwd fails fast with stderr only", async () => {
+  it("SPEC-0075 R1: parses relative, absolute, and leading-dash --cwd values", async () => {
+    const { parseOptions } = await import("../../src/cli/options.js");
+    expect(parseOptions(["statusline", "--cwd", "."]).cwd).toBe(".");
+    expect(parseOptions(["statusline", "--cwd=/repo"]).cwd).toBe("/repo");
+    expect(parseOptions(["statusline", "--cwd=-negative-path"]).cwd).toBe("-negative-path");
+  });
+
+  it("SPEC-0075 R1: a bare, empty, or whitespace-only --cwd fails fast with stderr only", async () => {
     const { parseOptions } = await import("../../src/cli/options.js");
     expect(parseOptions(["statusline", "--cwd"]).cwd).toBe("");
     expect(parseOptions(["statusline", "--cwd="]).cwd).toBe("");
-    let err = "";
-    const { code, output } = await captureStdout(() =>
-      runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
-        cwd: "",
-        writeError: (s) => {
-          err += s;
-        },
-      }),
-    );
+    for (const cwd of ["", "  "]) {
+      let err = "";
+      const { code, output } = await captureStdout(() =>
+        runStatusline(stdinStub("", true), async () => null, undefined, undefined, {
+          cwd,
+          writeError: (s) => {
+            err += s;
+          },
+        }),
+      );
 
-    expect(code).toBe(1);
-    expect(output).toBe("");
-    expect(err).toBe("--cwd requires a non-empty path\n");
+      expect(code).toBe(1);
+      expect(output).toBe("");
+      expect(err).toBe("--cwd requires a non-empty path\n");
+    }
   });
 
-  it("SPEC-0062 R5: telemetry customFormat is false by default and true under --format", async () => {
+  it("SPEC-0062 R5 / SPEC-0075 R6: telemetry records format, scope, and config booleans only", async () => {
     const transcriptPath = fixturePath("clean-multi-tool-2-models.jsonl");
     const stdin1 = stdinStub(JSON.stringify({ transcript_path: transcriptPath }));
-    const infos: { customFormat: boolean }[] = [];
+    const infos: Array<{ customFormat: boolean; scoped: boolean; configFile: boolean }> = [];
     await captureStdout(() => runStatusline(stdin1, async () => null, undefined, (i) => void infos.push(i)));
     const stdin2 = stdinStub(JSON.stringify({ transcript_path: transcriptPath }));
-    await captureStdout(() => runStatusline(stdin2, async () => null, undefined, (i) => void infos.push(i), { format: "brand,cost" }));
-    expect(infos.map((i) => i.customFormat)).toEqual([false, true]);
+    await captureStdout(() =>
+      runStatusline(stdin2, async () => null, undefined, (i) => void infos.push(i), {
+        format: "brand,cost",
+        cwd: "/repo",
+      }),
+    );
+    const configPath = path.join(isolatedHome, "telemetry-config.json");
+    await writeFile(configPath, JSON.stringify({ items: ["brand", "tokens"] }), "utf8");
+    const stdin3 = stdinStub(JSON.stringify({ transcript_path: transcriptPath }));
+    await captureStdout(() =>
+      runStatusline(stdin3, async () => null, undefined, (i) => void infos.push(i), { formatConfigPath: configPath }),
+    );
+    expect(infos.map((i) => i.customFormat)).toEqual([false, true, false]);
+    expect(infos.map((i) => i.scoped)).toEqual([false, true, false]);
+    expect(infos.map((i) => i.configFile)).toEqual([false, false, true]);
   });
 
   it("SPEC-0062 R3 mixed mode: dead transcript_path falls back to disk for the session, but payload quota still renders", async () => {


### PR DESCRIPTION
## What

**Stacked on #217** (base = `feat/0075-statusline-cwd`; merge #217 first, then retarget/merge this). SPEC-0075 stage 2 plus every accepted finding from the 9-model consensus review of stage 1.

### Stage 2 (R2 / R3b / R6 / R7)

- **`~/.aireceipts/statusline.json`** — `{"items":[...]}` ordered segment list, Codex `[tui].status_line` parity. Precedence: `--format` > config file > default. The flag stays fail-fast; an invalid *file* degrades to the default with one stderr note and exit 0 — a broken dotfile never blanks a polling status bar.
- **Prompt-engine + title recipes** — starship, raw zsh/bash, pwsh (Windows), OSC title; async-cached pattern (atomic, cwd-keyed cache), with the one-prompt staleness and between-commands visibility stated plainly. tmux remains the recommended live surface.
- **Poll-safe telemetry** — `--cwd` invocations keep local counters but skip the network flush (a 15s tmux poll never becomes ~5,760 events/day). Schema gains `scoped`/`configFile` booleans (strict zod + fixtures + docs/telemetry.md; never the path or format string).
- **`windows-latest` CI job** — cwd matcher battery + statusline suites + built-CLI e2e.

### Consensus-review fixes (9-model panel; 4 explicit convergence APPROVEs, 0 valid objections)

- Post-load cwd re-validation on **every** adapter (consensus MAJOR — GLM-5/Qwen/MiMo/Kimi).
- Relative `--cwd` resolves against the invocation dir — `--cwd .` works (MiMo, re-designed); already-absolute input passes through untouched (Codex push-gate caught the win32 drive-mangling `path.resolve` would cause — pinned by test).
- `homeDir` threaded through the injectable seam (Gemini/MiMo); empty-path guard + raw-ancestor JSDoc on `cwdMatches` (Kimi/MiniMax); single normalization pass (Kimi/MiniMax); `roots()` trim + deliberate-catch comment (DeepSeek/Qwen); privacy note on telemetry booleans (DeepSeek); docs for case-folding, symlinks, Cursor exclusion, dash-prefixed paths.
- Regression pins for panel claims **refuted with executed ground truth**: host-only UNC normalization, `--cwd=` parse forms, `claudeProjectDirectoryNames("/")`, cap boundary, adapter-throw isolation, two-project e2e.

Full verification block green, unmasked: tsc / eslint / vitest (**1,805**) / goldens / determinism ×10 / spec-lint / hygiene — all `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)