### PR TITLE
chore: release v0.8.0 — terminal statusline + node:sqlite fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.7.2):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.8.0):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,
@@ -101,6 +101,11 @@ after each release — don't hand-edit it elsewhere.*
   npm-native `pr-check`** an adopter runs in its own workflow with no reusable-workflow `uses:`
   and no org Actions-policy gate (SPEC-0064, shipped v0.5.0, #176); a **richer default
   statusline** — burn rate, context %, `M`/`B` tokens, inline 5h reset countdown (SPEC-0071);
+  a **terminal-surface statusline** — `statusline --cwd` scoped per-pane session selection with
+  attribution guards (confirm-on-load, home-shadow, bounded loads), `statusline.json` item
+  config, tmux/starship/pwsh/OSC recipes, poll-safe telemetry, and a `windows-latest` CI job
+  (SPEC-0075, v0.8.0), plus the `node:sqlite` bundle fix making sqlite-backed reads ~3.5×
+  faster in the published CLI (#214);
   the **samosa tip link off by default** on PR-posted surfaces, behind `--samosa` (SPEC-0070);
   and a faster parse/preflight path — in-process sqlite, goldens compile cache, parallel
   preflight (SPEC-0063) — plus **incremental mutation testing** on the money paths (SPEC-0069);
@@ -111,7 +116,7 @@ after each release — don't hand-edit it elsewhere.*
   was orphaned by `--amend`/rebase, with an authorship guard so a cherry-pick can't steal credit
   from a session that already directly claimed the commit (a narrower residual — a cherry-pick
   onto a branch SHA the true author never claims — is documented in the spec's Non-goals)
-  (SPEC-0072, v0.6.0). 42 specs at `status: shipped`.
+  (SPEC-0072, v0.6.0). 43 specs at `status: shipped`.
 - **In progress (`building`):** SPEC-0044 cost-attribution confidence — its
   implemented slices ship in v0.2.0 (ConfidenceEvent contract + no-silent-drop,
   cost matrix, rows-sum-to-total, cache-write caveat, parse-skip/load-failure

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ Tool by tool, locally, including where tokens went to waste. No install, no acco
 
 </div>
 
-**Live cost in your status bar** — `npx aireceipts-cli statusline`
-Claude Code's status line shows running cost as you work, not just a total at the end.
+**Live cost in your status bar** — wire in `aireceipts statusline` ([setup](docs/statusline.md))
+One settings line puts running cost in Claude Code's status bar — and with
+`--cwd`, any terminal surface (tmux, starship, PowerShell) shows each pane its
+own session's cost, covering Codex and opencode too.
 
 <div align="center">
 
@@ -116,7 +118,7 @@ Full walkthrough: [getting started](docs/guide/01-getting-started.md) · a real 
 | `aireceipts integrations [target]` | Exact local snippets for Claude Code, Codex, opencode, Cursor, and GitHub — [guide](docs/guide/15-integrations.md) |
 | `aireceipts --handoff` | Paste-ready block that tells your *agent* what to do cheaper next time — [guide](docs/guide/09-handoff.md) |
 | `aireceipts install-hook` | Consent-gated Claude Code hook: every session ends with a mini-receipt — [guide](docs/guide/03-install-hook.md) |
-| `aireceipts statusline` | Live cost line in Claude Code's status bar — [setup](docs/statusline.md) |
+| `aireceipts statusline` | Live cost line in Claude Code's status bar, or any terminal via `--cwd` (tmux/starship/pwsh) — [setup](docs/statusline.md) |
 | `aireceipts --quota` / `--check-budget` | Claude Code rate-limit window, read from the statusline stdin payload (silent otherwise); `--check-budget` exits 1 when your local budget cap is exceeded |
 | `aireceipts --json` / `--csv` / `--svg` / `--png` | Versioned schema, RFC 4180 rows, shareable SVG/PNG image — [schema](docs/json-schema.md) |
 | `aireceipts stats` | Local usage counters — receipts generated on this machine |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,64 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.8.0 — 2026-07-10
+
+Minor: **the statusline now works at the terminal level — tmux, starship, zsh/bash,
+PowerShell, terminal titles — so Codex and opencode sessions get a live cost line too,
+not just Claude Code.** Neither Codex nor opencode exposes a command-backed status hook
+(openai/codex#17827 and sst/opencode#8619 are open), so the surface moved to the
+terminal itself (SPEC-0075, PRs #217/#221).
+
+### feat
+
+- `aireceipts statusline --cwd <path>` selects the newest session **attributed to that
+  path** instead of the machine's globally newest one, so a tmux `status-right` line
+  (`--cwd "#{pane_current_path}"`) shows each pane its own session. Attribution is
+  guarded: Claude Code's lossy project-directory encoding is confirmed against the
+  transcript's own recorded `cwd` after load, sessions launched from the home directory
+  (or `/`) never ancestor-match everything, dot-segments resolve lexically, full-parse
+  work is capped, and no match renders the neutral placeholder — never another
+  project's line. Cursor sessions carry no cwd and are excluded. Relative paths resolve
+  against the invocation directory; a usable Claude Code stdin payload still wins.
+  Recipes for tmux, starship, plain zsh/bash, PowerShell, and OSC terminal titles are
+  in `docs/statusline.md` — the Claude Code native `statusLine` hook remains the
+  recommended (richer, faster) surface where it exists (PRs #217, #221).
+- `~/.aireceipts/statusline.json` (`{"items": ["brand", "cost", …]}`) sets a persistent
+  default segment list for the statusline. Precedence: explicit `--format` > config
+  file > built-in default. An invalid file degrades to the default line with one stderr
+  note (exit 0); the `--format` flag keeps its fail-fast contract (PR #221).
+- Telemetry: `--cwd` invocations are polling surfaces, so they count locally but never
+  network-flush (a 15-second tmux poll adds zero events). The
+  `integration_surface_rendered` event gains `scoped` and `configFile` booleans — never
+  the path or the format string (`docs/telemetry.md`, PR #221).
+
+### fix
+
+- **The published CLI is ~3.5× faster wherever sqlite-backed sessions (opencode,
+  Cursor) are read** (PR #214). tsup's `removeNodeProtocol` default rewrote
+  `import("node:sqlite")` to `import("sqlite")` in `dist/`, which fails at runtime, so
+  every published build silently fell back to spawning the `sqlite3` CLI per query —
+  measured 4.0s → 1.15s for one statusline render on a sqlite-heavy machine. On
+  Node ≥ 22.13 the `sqlite3` binary is no longer needed at all; older runtimes keep the
+  fallback. Built-artifact regression tests now pin the import specifier and the
+  in-process read path.
+
+### chore
+
+- CI gains a `windows-latest` job (cwd matching, statusline suites, built-CLI e2e). Its
+  first runs surfaced and fixed three real Windows issues: `.cmd` spawns need a shell
+  under Node's CVE-2024-27980 hardening, goldens/fixtures gained `-text` line-ending
+  exemptions, and absolute POSIX paths are never drive-prefixed by `path.resolve`
+  (PR #221).
+- OpenSSF Scorecard hardening: esbuild override for the open advisory, absolute
+  `SECURITY.md` link (PR #212); adopter `pr-check` workflow hardened with
+  `continue-on-error` + concurrency groups (PR #207).
+
+Rendered receipt output is byte-identical (receipt goldens unchanged; the help golden
+gains the `--cwd` line); the default statusline
+line renders through the exact same code path as 0.7.2 when neither `--cwd` nor a
+config file is present.
+
 ## v0.7.2 — 2026-07-09
 
 Patch: **PR-receipt refs are now written under `refs/aireceipts/*` instead of the generic

--- a/docs/guide/07-statusline.md
+++ b/docs/guide/07-statusline.md
@@ -34,10 +34,20 @@ no daemon, one disk read per invocation.
 If `aireceipts` isn't on your `PATH`, put the absolute path (the output of `which
 aireceipts`) in the `command` field.
 
-Using tmux too? The [terminal-surfaces recipe](../statusline.md#terminal-surfaces)
-shows tmux, Starship, raw zsh/bash, OSC terminal-title, and PowerShell patterns
-that pass each pane's cwd to `statusline --cwd`, while keeping Claude Code's
-richer native stdin hook as the primary setup.
+## In tmux or another shell (Codex, opencode)
+
+The statusline is not Claude-Code-only. Any terminal surface that can run a
+command shows it — which is how Codex and opencode sessions get a live cost
+line. With `aireceipts` installed globally, add to `~/.tmux.conf`:
+
+```tmux
+set -g status-right '#(aireceipts statusline --cwd "#{pane_current_path}")'
+```
+
+Each pane shows its own session's cost. Starship, raw zsh/bash, PowerShell, and
+OSC terminal-title recipes — plus the path-matching rules — are in the
+[terminal-surfaces reference](../statusline.md#terminal-surfaces). For Claude
+Code itself, the native stdin hook above stays the richer, recommended setup.
 
 ## What the line shows
 

--- a/docs/releases/0.8.0-verdict.md
+++ b/docs/releases/0.8.0-verdict.md
@@ -1,0 +1,89 @@
+# Release verdict — v0.8.0
+
+- **Candidate version:** 0.8.0 (minor)
+- **Content SHA:** `9da2973` (HEAD of `main` after #221)
+- **Changelog range:** `v0.7.2..9da2973` — six commits (#207, #212, #214, #215, #217, #221).
+- **Bump rationale:** MINOR — new additive capability (SPEC-0075 terminal statusline:
+  `--cwd`, `statusline.json`, terminal recipes, poll-safe telemetry, Windows CI) plus a
+  published-artifact perf fix (#214). `--json` shape unchanged; rendered receipt output
+  byte-identical (receipt goldens unchanged; the help golden gains the `--cwd` line); the
+  default statusline line renders through the exact 0.7.2 code path absent `--cwd`/config.
+- **Date:** 2026-07-10 (UTC)
+
+## Panel (full four-persona board, separate agent contexts)
+
+- **Product Manager — GO.** Coherent two-pillar release (terminal statusline + 3.5×
+  sqlite-read perf fix); every documented surface verified against `src/` (flags, config
+  file, default format constant); docs over-disclose limits rather than over-claim.
+  Findings folded into the release commit: README now names the agent-agnostic terminal
+  surface at top level (was Claude-Code-only framing); SPEC-0075 success boxes ticked.
+- **Engineering Manager — GO.** Strictly additive minor (new flag + read-only user config
+  + optional interface method); default render path byte-identical BY CONSTRUCTION
+  (`statuslineSegments.ts` untouched in the range); dependency delta is the dev-only
+  esbuild security override, `npm audit --omit=dev` = 0 vulns; rollback to 0.7.2 clean
+  (only new state artifact is user-authored `statusline.json`, which 0.7.2 ignores; no
+  writers in our code); CI 16/16 green on the exact SHA incl. the new native-Windows job;
+  no open P0/blocking issue or unmerged 0.8.0 PR. windows-statusline flake risk judged
+  acceptable: deterministic fixture specs, no network/timing; its 3 fix iterations were
+  real platform bugs, not flake-chasing.
+- **Designer — GO.** All surfaces rendered fresh and eyeballed: priced + tokens-only
+  terminal receipts (aligned, dollar-free where unpriced), SVG+PNG light/dark (byte-equal
+  to the goldens the README embeds), statusline in default/`--format`/config modes with
+  graceful invalid-config fallback, README hero/badges/proof image with all 32 local
+  links live. Artifacts under the session scratchpad `design/` dir.
+- **QA / adversarial — GO.** ~20 min of hostile input: **0 crashes**; `--cwd` abuse
+  (spaces, unicode, traversal, file-not-dir, unreadable dir, 1000-char, newline) all
+  degrade exit 0; full malformed-config matrix → default line + one stderr note; 50
+  concurrent polls left `quota-window.json` valid; 40MB session parsed in 0.29s.
+  **I2 PASS including a direct cost-injection attack**: a stdin payload carrying
+  `total_cost_usd: 999.99` on an unpriced session rendered tokens-only — injected cost
+  fields ignored on every surface. One LOW cosmetic finding (a hand-authored brand-less
+  format of all-nullable segments can render a blank line in a no-data state —
+  unreachable via the default install; follow-up, not a blocker).
+
+## Docs panel (/review-docs, two lenses)
+
+- **Cold reader — 4 findings, ALL FIXED in the release commit:** README quickstart line
+  reframed as a setup step; `docs/statusline.md` terminal-surfaces section now leads with
+  the action + a global-install note, caveats demoted to a "Matching rules" subsection;
+  guide 07 gains an inline tmux subsection (the release's headline was invisible there);
+  the neutral placeholder line is now shown in the Output block.
+- **Correctness auditor — 1 finding (0 blocking), FIXED:** the changelog's "(goldens
+  unchanged)" tightened to "receipt goldens unchanged; the help golden gains the `--cwd`
+  line". Everything else verified by running the CLI: default format constant, config
+  precedence and degrade semantics, scoped discovery on a real Codex fixture, home/root
+  shadow guards, stdin-wins, telemetry rows exactly matching `schemas.ts`, `node:sqlite`
+  specifier intact in `dist/`, poll-flush suppression.
+
+## Mechanical checks (lead-run, unmasked, on `9da2973`)
+
+- `tsc` 0 · `eslint` 0 · `vitest` 0 (**1,805 tests**) · goldens 0 · determinism ×10 0 ·
+  spec-lint 0 · hygiene 0.
+- `preflight-release.mjs` **0** (full mode — tarball builds, installs into a clean
+  project, runs a fixture, prints a priced receipt).
+- `npm publish --dry-run` **0** — 72 files, 127.4 kB packed / 493.0 kB unpacked:
+  `dist/` + cited `data/prices` + README/LICENSE/NOTICE only; zero fixtures, tests,
+  transcripts, `.env`, or internal docs.
+- gitleaks full-history **0** (clean).
+
+## Prior review depth on the range
+
+Stage 1 (#217) additionally passed a 9-model consensus code review (Claude + GPT 5.4,
+Gemini 3.1 Pro, Kimi K2.5, MiniMax M2.7, GLM-5, Qwen 3.6 Plus, DeepSeek V3.2,
+MiMo-V2-Pro): 5 convergence APPROVEs, 0 valid objections; every accepted finding shipped
+in #221 with refuted claims pinned as regression tests. The `node:sqlite` fix (#214) and
+both feature PRs each carried adversarial Codex reviews with negative-control-verified
+regression tests.
+
+## Open risks (accepted, tracked)
+
+1. QA's blank-line cosmetic edge (brand-less custom format, no-data state) — follow-up.
+2. windows-statusline is young (first release with it); failures so far were
+   deterministic platform bugs, now fixed and pinned. Infra flakes retryable.
+3. Pre-existing open issues (#218/#219 hook items, #170 CSV formula-injection, #161
+   subagent undercount) predate this range and are not regressed by it.
+4. The release commit itself (version bump, changelog, docs fixes, this verdict, spec
+   flip, AGENTS.md) lands after the content SHA; it contains no product code — the
+   publish workflow re-runs preflight on the final SHA before `npm publish`.
+
+VERDICT: GO

--- a/docs/statusline.md
+++ b/docs/statusline.md
@@ -30,24 +30,12 @@ instead of `aireceipts` in the `command` field (for example, the output of
 
 ## Terminal surfaces
 
-Any terminal surface that can run a command and display one line of stdout can
-show an aireceipts statusline. Pass that surface's pane or prompt working
-directory to `--cwd`; aireceipts selects the newest session attributed to that
-path (or an ancestor of it) and prints the neutral placeholder when none match.
-It never falls back to another project's newest session, and a session launched
-from your home directory (or above it) only ever matches that exact path — it is
-not treated as an ancestor of everything, so one `~`-launched session can't
-shadow every pane on the machine. Relative `--cwd` paths resolve against the
-directory where `aireceipts` is invoked; a path beginning with `-` must use the
-`--cwd=<path>` form. Matching intentionally folds only a Windows drive letter's
-case: the rest of every path remains case-sensitive because over-matching on a
-case-sensitive filesystem is the worse failure. Cursor is excluded from scoped
-discovery entirely because its session data carries no cwd.
-
-Path matching is lexical rather than filesystem-canonical. If `$PWD` uses a
-symlinked spelling while a session records the physical path, they do not
-match. tmux's `#{pane_current_path}` is resolved, so the tmux recipe below is
-unaffected.
+Pass a pane's working directory to `--cwd` and aireceipts shows that pane its
+own session — any terminal surface that can run a command and display one line
+of stdout works, which is how Codex and opencode sessions get a statusline.
+These recipes call `aireceipts` directly: install it first
+(`npm i -g aireceipts-cli`) — paying `npx` startup on every refresh is too slow
+for a polled bar.
 
 For tmux, add this to `~/.tmux.conf`:
 
@@ -57,6 +45,25 @@ set -g status-right '#(aireceipts statusline --cwd "#{pane_current_path}")'
 
 tmux refreshes `#(...)` commands on `status-interval`; lower that setting if you
 want a fresher line, keeping in mind that each refresh runs the command again.
+
+### Matching rules
+
+`--cwd` selects the newest session attributed to that path (or an ancestor of
+it) and prints the neutral placeholder when none match — it never falls back to
+another project's newest session. A session launched from your home directory
+(or above it) only ever matches that exact path, so one `~`-launched session
+can't shadow every pane on the machine. Relative `--cwd` paths resolve against
+the directory where `aireceipts` is invoked; a path beginning with `-` must use
+the `--cwd=<path>` form. Matching intentionally folds only a Windows drive
+letter's case — the rest of every path remains case-sensitive, because
+over-matching on a case-sensitive filesystem is the worse failure. Cursor is
+excluded from scoped discovery entirely because its session data carries no
+cwd.
+
+Path matching is lexical rather than filesystem-canonical. If `$PWD` uses a
+symlinked spelling while a session records the physical path, they do not
+match. tmux's `#{pane_current_path}` is resolved, so the tmux recipe above is
+unaffected.
 
 <!-- SPEC-0075 R3b -->
 
@@ -221,6 +228,7 @@ in tmux or another shell UI.
 [aireceipts] $4.20 · $9/hr · 128k · ctx 42% · 5h 24% ↺2h13m
 [aireceipts] $2.50 · $6/hr · 20k · ⚠ Bash loop ×5 · 5h 41% ↺58m
 [aireceipts · Cursor] 8k
+aireceipts: no sessions detected
 ```
 
 - `$X.XX` is the session's priced cost (aireceipts' own cited-price figure, incl.
@@ -239,8 +247,8 @@ in tmux or another shell UI.
 - Outside a piped invocation (or when stdin carries no usable payload),
   `aireceipts statusline` falls back to the most-recently-ended session found
   on disk — the prefix then names whose session it is (`[aireceipts · Codex]`).
-  If no sessions are detected at all, it prints a neutral placeholder line
-  rather than an error, so the statusline layout never breaks.
+  If no sessions are detected at all, it prints the neutral placeholder line
+  shown above rather than an error, so the statusline layout never breaks.
 
 ## Custom formats (`--format`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",

--- a/site/docs/07-statusline.html
+++ b/site/docs/07-statusline.html
@@ -357,7 +357,13 @@ footer{
 
 <p>If <code>aireceipts</code> isn't on your <code>PATH</code>, put the absolute path (the output of <code>which aireceipts</code>) in the <code>command</code> field.</p>
 
-<p>Using tmux too? The <a href="statusline.html#terminal-surfaces">terminal-surfaces recipe</a> shows tmux, Starship, raw zsh/bash, OSC terminal-title, and PowerShell patterns that pass each pane's cwd to <code>statusline --cwd</code>, while keeping Claude Code's richer native stdin hook as the primary setup.</p>
+<h2 id="in-tmux-or-another-shell-codex-opencode">In tmux or another shell (Codex, opencode)</h2>
+
+<p>The statusline is not Claude-Code-only. Any terminal surface that can run a command shows it — which is how Codex and opencode sessions get a live cost line. With <code>aireceipts</code> installed globally, add to <code>~/.tmux.conf</code>:</p>
+
+<pre class="doc-code"><code class="language-tmux">set -g status-right '#(aireceipts statusline --cwd &quot;#{pane_current_path}&quot;)'</code></pre>
+
+<p>Each pane shows its own session's cost. Starship, raw zsh/bash, PowerShell, and OSC terminal-title recipes — plus the path-matching rules — are in the <a href="statusline.html#terminal-surfaces">terminal-surfaces reference</a>. For Claude Code itself, the native stdin hook above stays the richer, recommended setup.</p>
 
 <h2 id="what-the-line-shows">What the line shows</h2>
 

--- a/site/docs/CHANGELOG.html
+++ b/site/docs/CHANGELOG.html
@@ -336,6 +336,33 @@ footer{
 
 <p>All notable changes to <code>aireceipts-cli</code>. Factual, grouped by conventional-commit type (I6: a log, not marketing). Dates are UTC.</p>
 
+<h2 id="v080-2026-07-10">v0.8.0 — 2026-07-10</h2>
+
+<p>Minor: <strong>the statusline now works at the terminal level — tmux, starship, zsh/bash, PowerShell, terminal titles — so Codex and opencode sessions get a live cost line too, not just Claude Code.</strong> Neither Codex nor opencode exposes a command-backed status hook (openai/codex#17827 and sst/opencode#8619 are open), so the surface moved to the terminal itself (SPEC-0075, PRs #217/#221).</p>
+
+<h3 id="feat">feat</h3>
+
+<ul>
+  <li><code>aireceipts statusline --cwd &lt;path&gt;</code> selects the newest session <strong>attributed to that path</strong> instead of the machine's globally newest one, so a tmux <code>status-right</code> line (<code>--cwd &quot;#{pane_current_path}&quot;</code>) shows each pane its own session. Attribution is guarded: Claude Code's lossy project-directory encoding is confirmed against the transcript's own recorded <code>cwd</code> after load, sessions launched from the home directory (or <code>/</code>) never ancestor-match everything, dot-segments resolve lexically, full-parse work is capped, and no match renders the neutral placeholder — never another project's line. Cursor sessions carry no cwd and are excluded. Relative paths resolve against the invocation directory; a usable Claude Code stdin payload still wins. Recipes for tmux, starship, plain zsh/bash, PowerShell, and OSC terminal titles are in <code>docs/statusline.md</code> — the Claude Code native <code>statusLine</code> hook remains the recommended (richer, faster) surface where it exists (PRs #217, #221).</li>
+  <li><code>~/.aireceipts/statusline.json</code> (<code>{&quot;items&quot;: [&quot;brand&quot;, &quot;cost&quot;, …]}</code>) sets a persistent default segment list for the statusline. Precedence: explicit <code>--format</code> &gt; config file &gt; built-in default. An invalid file degrades to the default line with one stderr note (exit 0); the <code>--format</code> flag keeps its fail-fast contract (PR #221).</li>
+  <li>Telemetry: <code>--cwd</code> invocations are polling surfaces, so they count locally but never network-flush (a 15-second tmux poll adds zero events). The <code>integration_surface_rendered</code> event gains <code>scoped</code> and <code>configFile</code> booleans — never the path or the format string (<code>docs/telemetry.md</code>, PR #221).</li>
+</ul>
+
+<h3 id="fix">fix</h3>
+
+<ul>
+  <li><strong>The published CLI is ~3.5× faster wherever sqlite-backed sessions (opencode, Cursor) are read</strong> (PR #214). tsup's <code>removeNodeProtocol</code> default rewrote <code>import(&quot;node:sqlite&quot;)</code> to <code>import(&quot;sqlite&quot;)</code> in <code>dist/</code>, which fails at runtime, so every published build silently fell back to spawning the <code>sqlite3</code> CLI per query — measured 4.0s → 1.15s for one statusline render on a sqlite-heavy machine. On Node ≥ 22.13 the <code>sqlite3</code> binary is no longer needed at all; older runtimes keep the fallback. Built-artifact regression tests now pin the import specifier and the in-process read path.</li>
+</ul>
+
+<h3 id="chore">chore</h3>
+
+<ul>
+  <li>CI gains a <code>windows-latest</code> job (cwd matching, statusline suites, built-CLI e2e). Its first runs surfaced and fixed three real Windows issues: <code>.cmd</code> spawns need a shell under Node's CVE-2024-27980 hardening, goldens/fixtures gained <code>-text</code> line-ending exemptions, and absolute POSIX paths are never drive-prefixed by <code>path.resolve</code> (PR #221).</li>
+  <li>OpenSSF Scorecard hardening: esbuild override for the open advisory, absolute <code>SECURITY.md</code> link (PR #212); adopter <code>pr-check</code> workflow hardened with <code>continue-on-error</code> + concurrency groups (PR #207).</li>
+</ul>
+
+<p>Rendered receipt output is byte-identical (receipt goldens unchanged; the help golden gains the <code>--cwd</code> line); the default statusline line renders through the exact same code path as 0.7.2 when neither <code>--cwd</code> nor a config file is present.</p>
+
 <h2 id="v072-2026-07-09">v0.7.2 — 2026-07-09</h2>
 
 <p>Patch: <strong>PR-receipt refs are now written under <code>refs/aireceipts/*</code> instead of the generic <code>refs/receipts/*</code>.</strong> The old namespace collided with other tools that also publish to <code>refs/receipts/&lt;slug&gt;</code> (e.g. an attestation producer storing an in-toto <code>receipt.json</code> at the same path). In a repo running both, the namespace was occupied by the other tool's payloads, so CI <code>pr-check</code> fetched a foreign ref, failed its <code>schemaVersion</code> check, and silently posted nothing — the auto-attach hook fired and pushed refs, yet no receipt ever appeared. aireceipts now owns <code>refs/aireceipts/*</code> and never reads or writes <code>refs/receipts/*</code>, so the two coexist; the push classifier still recognizes both namespaces so a foreign receipt-ref push is never mis-counted as a branch commit (PR #204). No migration: aireceipts had never written a <code>refs/receipts/*</code> ref. Hooks and CI on <code>@latest</code> adopt the new namespace together on this release. Rendered receipt output is byte-identical (goldens unchanged); the only user-visible surface change is the ref name in <code>pr --help</code>.</p>
@@ -494,7 +521,7 @@ footer{
   <li>Correct README/getting-started privacy and coverage claims (transcripts/code never uploaded; diagnostics are opt-out; supported-agent list is finite); sync <code>docs/telemetry.md</code> agent-type enums and kill-switch examples; correct the <code>week --json</code> and <code>source</code> entries in <code>docs/json-schema.md</code>; drop a stale pre-release note. (#115)</li>
 </ul>
 
-<h3 id="chore">Chore</h3>
+<h3 id="chore-2">Chore</h3>
 
 <ul>
   <li>Restructure the opencode combinatorial unit test: validate all summaries from one <code>listSessions()</code> and deep round-trip only a structural-coverage sample, instead of reopening the SQLite DB per session (6m40s → ~20s, coverage retained). Local <code>preflight-release.mjs</code> sets <code>AIRECEIPTS_SKIP_STRESS=1</code> so the spawn-heavy 100-session e2e stress case doesn't wedge on throttled dev macOS; CI runs the full suite (env unset), so coverage is unchanged.</li>
@@ -513,7 +540,7 @@ footer{
   <li><code>--handoff</code> resume packet: a deterministic state header, a <code>covers:</code> line, and a versioned <code>--handoff --json</code> surface. (SPEC-0042)</li>
 </ul>
 
-<h3 id="chore-2">Chore</h3>
+<h3 id="chore-3">Chore</h3>
 
 <ul>
   <li>Size two long-running SQLite test timeouts for macOS background-QoS throttling of vitest-spawned children; CI unaffected. (#111)</li>

--- a/site/docs/statusline.html
+++ b/site/docs/statusline.html
@@ -353,15 +353,19 @@ footer{
 
 <h2 id="terminal-surfaces">Terminal surfaces</h2>
 
-<p>Any terminal surface that can run a command and display one line of stdout can show an aireceipts statusline. Pass that surface's pane or prompt working directory to <code>--cwd</code>; aireceipts selects the newest session attributed to that path (or an ancestor of it) and prints the neutral placeholder when none match. It never falls back to another project's newest session, and a session launched from your home directory (or above it) only ever matches that exact path — it is not treated as an ancestor of everything, so one <code>~</code>-launched session can't shadow every pane on the machine. Relative <code>--cwd</code> paths resolve against the directory where <code>aireceipts</code> is invoked; a path beginning with <code>-</code> must use the <code>--cwd=&lt;path&gt;</code> form. Matching intentionally folds only a Windows drive letter's case: the rest of every path remains case-sensitive because over-matching on a case-sensitive filesystem is the worse failure. Cursor is excluded from scoped discovery entirely because its session data carries no cwd.</p>
-
-<p>Path matching is lexical rather than filesystem-canonical. If <code>$PWD</code> uses a symlinked spelling while a session records the physical path, they do not match. tmux's <code>#{pane_current_path}</code> is resolved, so the tmux recipe below is unaffected.</p>
+<p>Pass a pane's working directory to <code>--cwd</code> and aireceipts shows that pane its own session — any terminal surface that can run a command and display one line of stdout works, which is how Codex and opencode sessions get a statusline. These recipes call <code>aireceipts</code> directly: install it first (<code>npm i -g aireceipts-cli</code>) — paying <code>npx</code> startup on every refresh is too slow for a polled bar.</p>
 
 <p>For tmux, add this to <code>~/.tmux.conf</code>:</p>
 
 <pre class="doc-code"><code class="language-tmux">set -g status-right '#(aireceipts statusline --cwd &quot;#{pane_current_path}&quot;)'</code></pre>
 
 <p>tmux refreshes <code>#(...)</code> commands on <code>status-interval</code>; lower that setting if you want a fresher line, keeping in mind that each refresh runs the command again.</p>
+
+<h3 id="matching-rules">Matching rules</h3>
+
+<p><code>--cwd</code> selects the newest session attributed to that path (or an ancestor of it) and prints the neutral placeholder when none match — it never falls back to another project's newest session. A session launched from your home directory (or above it) only ever matches that exact path, so one <code>~</code>-launched session can't shadow every pane on the machine. Relative <code>--cwd</code> paths resolve against the directory where <code>aireceipts</code> is invoked; a path beginning with <code>-</code> must use the <code>--cwd=&lt;path&gt;</code> form. Matching intentionally folds only a Windows drive letter's case — the rest of every path remains case-sensitive, because over-matching on a case-sensitive filesystem is the worse failure. Cursor is excluded from scoped discovery entirely because its session data carries no cwd.</p>
+
+<p>Path matching is lexical rather than filesystem-canonical. If <code>$PWD</code> uses a symlinked spelling while a session records the physical path, they do not match. tmux's <code>#{pane_current_path}</code> is resolved, so the tmux recipe above is unaffected.</p>
 
 <p>tmux is the recommended live terminal surface because it keeps polling while a command or agent owns the pane. The prompt and title recipes below refresh only <strong>between commands</strong>: while an agent owns the terminal they sit stale, and the cached line you see is one prompt behind. Each refresh is a per-prompt fire-and-forget process that exits after its atomic cache write — there is no resident daemon.</p>
 
@@ -493,7 +497,8 @@ function global:prompt {
 
 <pre class="doc-code"><code>[aireceipts] $4.20 · $9/hr · 128k · ctx 42% · 5h 24% ↺2h13m
 [aireceipts] $2.50 · $6/hr · 20k · ⚠ Bash loop ×5 · 5h 41% ↺58m
-[aireceipts · Cursor] 8k</code></pre>
+[aireceipts · Cursor] 8k
+aireceipts: no sessions detected</code></pre>
 
 <ul>
   <li><code>$X.XX</code> is the session's priced cost (aireceipts' own cited-price figure, incl. subagents); omitted when it can't be priced — never a fabricated <code>$</code> amount.</li>
@@ -502,7 +507,7 @@ function global:prompt {
   <li><code>ctx N%</code> is how full the current context window is — Claude Code's own pre-calculated <code>context_window.used_percentage</code>, omitted when the payload lacks it.</li>
   <li><code>5h N% ↺Xh Ym</code> is your official 5-hour rate-limit usage (Claude Code's own <code>rate_limits.five_hour.used_percentage</code>, subscribers only) plus the time until the window resets, derived from the real <code>resets_at</code> — the countdown is dropped (leaving <code>5h N%</code>) when <code>resets_at</code> is absent or already past, never a guessed time.</li>
   <li>The waste flag (<code>⚠ ...</code>) appears only when a waste detector actually fired on the session — its absence is not itself a claim that nothing was found.</li>
-  <li>Outside a piped invocation (or when stdin carries no usable payload), <code>aireceipts statusline</code> falls back to the most-recently-ended session found on disk — the prefix then names whose session it is (<code>[aireceipts · Codex]</code>). If no sessions are detected at all, it prints a neutral placeholder line rather than an error, so the statusline layout never breaks.</li>
+  <li>Outside a piped invocation (or when stdin carries no usable payload), <code>aireceipts statusline</code> falls back to the most-recently-ended session found on disk — the prefix then names whose session it is (<code>[aireceipts · Codex]</code>). If no sessions are detected at all, it prints the neutral placeholder line shown above rather than an error, so the statusline layout never breaks.</li>
 </ul>
 
 <h2 id="custom-formats-format">Custom formats (<code>--format</code>)</h2>

--- a/specs/SPEC-0075-terminal-statusline.md
+++ b/specs/SPEC-0075-terminal-statusline.md
@@ -1,7 +1,7 @@
 ---
 id: SPEC-0075
 title: "Terminal-surface statusline — cwd-scoped, configurable, agent-agnostic (tmux first)"
-status: approved
+status: shipped
 milestone: M5
 depends: [SPEC-0007, SPEC-0062, SPEC-0071]
 ---
@@ -207,13 +207,13 @@ tmux-only (timer surfaces tolerate latency; wrong data is never tolerated).
 
 ## Success criteria
 
-- [ ] Stage 1 (R1, R3a, R5, R8) shipped after the `fix:` PR; stage 2 (R2, R3b, R6,
+- [x] Stage 1 (R1, R3a, R5, R8) shipped after the `fix:` PR; stage 2 (R2, R3b, R6,
       R7) on the same spec.
-- [ ] tmux recipe verified live on macOS/Linux showing the scoped line; wall-clock
+- [x] tmux recipe verified live on macOS/Linux showing the scoped line; wall-clock
       ≤ 1.5s recorded in Validation on the reference corpus.
-- [ ] `docs/statusline.md`, the guide page, `docs/telemetry.md`, and the
+- [x] `docs/statusline.md`, the guide page, `docs/telemetry.md`, and the
       `integrations` recipe updated in the same PR as the code they describe.
-- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+- [x] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
       `node scripts/verify-goldens.mjs`,
       `node scripts/determinism-check.mjs --runs=10 -- node scripts/verify-goldens.mjs`,
       `node scripts/spec-lint.mjs`, `node scripts/hygiene.mjs` all pass unmasked


### PR DESCRIPTION
## Release v0.8.0

Content SHA under release: `9da2973` (this PR adds only release metadata + panel-driven doc fixes — no product code).

**Verdict: GO** — full board in [docs/releases/0.8.0-verdict.md](docs/releases/0.8.0-verdict.md): PM / EM / Designer / QA all GO (QA: 0 crashes, I2 held under direct cost-injection), 2-lens docs panel findings all fixed, mechanical checks all `0` on the content SHA (preflight full-mode, publish dry-run 72-file/127 kB tarball audited, gitleaks clean, 1,805 tests ×2 trees).

- `package.json` 0.7.2 → **0.8.0** (+ lockfile)
- `docs/CHANGELOG.md` v0.8.0 section (the Release job requires it)
- SPEC-0075 → `shipped`, boxes ticked; AGENTS.md inventory updated
- Panel doc fixes: README surfaces the terminal-statusline capability; statusline.md leads with the recipe; guide 07 inline tmux subsection

## After merging — maintainer publish (button 4)

```
gh workflow run release-publish.yml --ref main
```

The workflow re-runs preflight on the merged SHA, publishes `aireceipts-cli@0.8.0` with OIDC provenance, then tags `v0.8.0` and creates the GitHub Release from the changelog section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)