### PR TITLE
chore(prices): update openai rates — add gpt-5.6 family

### DIFF
--- a/data/prices/openai.json
+++ b/data/prices/openai.json
@@ -54,6 +54,60 @@
           ]
         }
       ]
+    },
+    "gpt-5.6-sol": {
+      "price_history": [
+        {
+          "input": 5.0,
+          "output": 30.0,
+          "input_cached": 0.5,
+          "from_date": "2026-07-09",
+          "to_date": null,
+          "sources": [
+            {
+              "url": "https://developers.openai.com/api/docs/pricing",
+              "observed_at": "2026-07-10",
+              "excerpt": "gpt-5.6-sol \u2014 Standard (short context): Input $5.00, Cached input $0.50, Output $30.00 per 1M tokens; Standard (long context): Input $10.00, Cached input $1.00, Output $45.00"
+            }
+          ]
+        }
+      ]
+    },
+    "gpt-5.6-terra": {
+      "price_history": [
+        {
+          "input": 2.5,
+          "output": 15.0,
+          "input_cached": 0.25,
+          "from_date": "2026-07-09",
+          "to_date": null,
+          "sources": [
+            {
+              "url": "https://developers.openai.com/api/docs/pricing",
+              "observed_at": "2026-07-10",
+              "excerpt": "gpt-5.6-terra \u2014 Standard (short context): Input $2.50, Cached input $0.25, Output $15.00 per 1M tokens; Standard (long context): Input $5.00, Cached input $0.50, Output $22.50"
+            }
+          ]
+        }
+      ]
+    },
+    "gpt-5.6-luna": {
+      "price_history": [
+        {
+          "input": 1.0,
+          "output": 6.0,
+          "input_cached": 0.1,
+          "from_date": "2026-07-09",
+          "to_date": null,
+          "sources": [
+            {
+              "url": "https://developers.openai.com/api/docs/pricing",
+              "observed_at": "2026-07-10",
+              "excerpt": "gpt-5.6-luna \u2014 Standard (short context): Input $1.00, Cached input $0.10, Output $6.00 per 1M tokens; Standard (long context): Input $2.00, Cached input $0.20, Output $9.00"
+            }
+          ]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## What changed

Three new cited price rows in `data/prices/openai.json` (additive-only diff — no existing row touched):

| Model | Input /1M | Cached /1M | Output /1M |
|---|---|---|---|
| `gpt-5.6-sol` | $5.00 | $0.50 | $30.00 |
| `gpt-5.6-terra` | $2.50 | $0.25 | $15.00 |
| `gpt-5.6-luna` | $1.00 | $0.10 | $6.00 |

Standard tier, **short context** — the table's existing convention (matches the `gpt-5.5` row). Effective `from_date` 2026-07-09 (public availability).

## Citation

Every row cites the official page, fetched and read: **https://developers.openai.com/api/docs/pricing** (observed 2026-07-10). Interpretation note for the reviewer: the page lists both short-context ($5.00/$0.50/$30.00 for sol) and long-context ($10.00/$1.00/$45.00) rates plus cache-write ($6.25) — the row records the short-context standard rates per the table's convention; long-context is quoted in each row's `excerpt` so the choice is auditable. `cite-check`: 1 file OK, cited URL live.

## Why

Real local Codex CLI sessions now run `gpt-5.6-sol` and were rendering tokens-only (`[aireceipts · Codex] 65k`). With this row they price — verified live: `[aireceipts · Codex] $0.10 · $30/hr · 65k`.

Full verification block green, unmasked (tsc / eslint / vitest 1,841 / goldens / determinism ×10 / spec-lint / hygiene — all `0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)