### PR TITLE
chore: release v0.8.1 — gpt-5.6 price rows + README restructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.8.0):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.8.1):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.8.1 — 2026-07-10
+
+Patch: **OpenAI `gpt-5.6` family price rows** — `gpt-5.6-sol` ($5.00 in / $0.50 cached /
+$30.00 out per 1M), `gpt-5.6-terra` ($2.50 / $0.25 / $15.00), `gpt-5.6-luna` ($1.00 /
+$0.10 / $6.00); Standard short-context tier, effective 2026-07-09, every row cited to
+the official OpenAI pricing page (PR #223). Codex CLI sessions on these models — which
+rendered tokens-only under I2's no-fabricated-dollars rule — now price in receipts and
+the statusline. Additive data change only; no code touched.
+
+Also: the README was restructured around a features-first flow with an agent-assisted
+install section ("point your agent at this README and it installs + wires the
+statusline"), contributed in PR #213. Docs-only; ships as the npm package README.
+
 ## v0.8.0 — 2026-07-10
 
 Minor: **the statusline now works at the terminal level — tmux, starship, zsh/bash,

--- a/docs/releases/0.8.1-verdict.md
+++ b/docs/releases/0.8.1-verdict.md
@@ -1,0 +1,49 @@
+# Release verdict — v0.8.1
+
+- **Candidate version:** 0.8.1 (patch)
+- **Content SHA:** `2e5c84a` (HEAD of `main` after #223)
+- **Changelog range:** `v0.8.0..2e5c84a` — two commits (#213 docs, #223 prices).
+- **Bump rationale:** PATCH — additive price-table data (three new cited OpenAI rows)
+  plus a docs-only README restructure. No product code touched in the range
+  (`git diff v0.8.0..2e5c84a --stat`: `data/prices/openai.json` +54, `README.md`).
+  Rendered output for previously-priced sessions is byte-identical (goldens unchanged);
+  the only behavior change is that `gpt-5.6-*` sessions now price instead of rendering
+  tokens-only — which is the price table doing its job, not a code path change.
+- **Date:** 2026-07-10 (UTC)
+
+## Right-sizing (why not the full 4-persona panel)
+
+v0.7.2 precedent: a self-contained data/docs range with no code change. The v0.8.0
+board ran in full <24h ago on the same code; this range adds cited data on top.
+Verdict scoped to the mechanical gates + citation integrity + the live pricing proof —
+the lenses with signal. Documented right-sizing, not a skipped gate.
+
+## Scope & correctness
+
+- **#223 — `gpt-5.6-sol` / `-terra` / `-luna` rows.** Every row cites the official
+  OpenAI pricing page (fetched and read; third-party aggregators from research were
+  NOT used as sources). Standard short-context tier, matching the table's `gpt-5.5`
+  convention; long-context rates quoted in each row's `excerpt` so the tier choice is
+  auditable. `from_date` 2026-07-09 (public availability). Additive-only 54-line diff —
+  no historical row edited (I3). `cite-check`: cited URL live, every row cited.
+  **Live proof:** a real local Codex session on `gpt-5.6-sol` renders
+  `[aireceipts · Codex] $0.10 · $30/hr · 65k` with the row (was `65k` tokens-only).
+- **#213 — README features-first restructure** (community contribution, repaired to
+  pass the SPEC-0029/0053 readme-guard: 11/11 pins green, 248 lines ≤ 260 cap). Ships
+  as the npm package README; no code claims added beyond what v0.8.0 verified.
+
+## Mechanical checks (lead-run, unmasked, on the release tree)
+
+- `tsc` 0 · `eslint` 0 · `vitest` 0 (**1,841 tests**) · goldens 0 · determinism ×10 0 ·
+  spec-lint 0 · hygiene 0 · `cite-check` 0 (run on the exact changed file).
+- `preflight-release.mjs` full mode: run fresh for this verdict (result recorded in the
+  release PR); `release-publish.yml` re-runs it on the merged SHA before `npm publish`.
+
+## Open risks
+
+1. `gpt-5.6-sol-pro` / "Sol Ultra" appear on third-party pages without an official
+   published price — deliberately NOT added (rule zero: never infer). If Codex sessions
+   appear on those ids they render tokens-only until OpenAI publishes a rate.
+2. Same carry-overs as the v0.8.0 verdict (blank-line cosmetic edge, young Windows job).
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",

--- a/site/docs/CHANGELOG.html
+++ b/site/docs/CHANGELOG.html
@@ -336,6 +336,12 @@ footer{
 
 <p>All notable changes to <code>aireceipts-cli</code>. Factual, grouped by conventional-commit type (I6: a log, not marketing). Dates are UTC.</p>
 
+<h2 id="v081-2026-07-10">v0.8.1 — 2026-07-10</h2>
+
+<p>Patch: <strong>OpenAI <code>gpt-5.6</code> family price rows</strong> — <code>gpt-5.6-sol</code> ($5.00 in / $0.50 cached / $30.00 out per 1M), <code>gpt-5.6-terra</code> ($2.50 / $0.25 / $15.00), <code>gpt-5.6-luna</code> ($1.00 / $0.10 / $6.00); Standard short-context tier, effective 2026-07-09, every row cited to the official OpenAI pricing page (PR #223). Codex CLI sessions on these models — which rendered tokens-only under I2's no-fabricated-dollars rule — now price in receipts and the statusline. Additive data change only; no code touched.</p>
+
+<p>Also: the README was restructured around a features-first flow with an agent-assisted install section (&quot;point your agent at this README and it installs + wires the statusline&quot;), contributed in PR #213. Docs-only; ships as the npm package README.</p>
+
 <h2 id="v080-2026-07-10">v0.8.0 — 2026-07-10</h2>
 
 <p>Minor: <strong>the statusline now works at the terminal level — tmux, starship, zsh/bash, PowerShell, terminal titles — so Codex and opencode sessions get a live cost line too, not just Claude Code.</strong> Neither Codex nor opencode exposes a command-backed status hook (openai/codex#17827 and sst/opencode#8619 are open), so the surface moved to the terminal itself (SPEC-0075, PRs #217/#221).</p>


### PR DESCRIPTION
## Release v0.8.1 (patch)

Content SHA under release: `2e5c84a` — two commits since v0.8.0, **no product code**: #223 (cited `gpt-5.6-sol`/`-terra`/`-luna` price rows) and #213 (features-first README with agent-assisted install).

**Verdict: GO** — [docs/releases/0.8.1-verdict.md](docs/releases/0.8.1-verdict.md), right-sized per the v0.7.2 precedent (data/docs-only range; the full 4-persona board ran on this same code <24h ago for v0.8.0). Mechanicals all `0` on the release tree: tsc / eslint / vitest (1,841) / goldens / determinism ×10 / spec-lint / hygiene / cite-check / **full preflight**. Live proof: a real `gpt-5.6-sol` Codex session now renders `$0.10 · $30/hr · 65k` (was tokens-only).

## After merging — maintainer publish (button 4)

```
gh workflow run release-publish.yml --ref main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)