### PR TITLE
docs: shell-wrapper recipe — statusline appears whenever the agent launches

### DIFF
--- a/docs/guide/07-statusline.md
+++ b/docs/guide/07-statusline.md
@@ -44,9 +44,12 @@ line. With `aireceipts` installed globally, add to `~/.tmux.conf`:
 set -g status-right '#(aireceipts statusline --cwd "#{pane_current_path}")'
 ```
 
-Each pane shows its own session's cost. Starship, raw zsh/bash, PowerShell, and
-OSC terminal-title recipes — plus the path-matching rules — are in the
-[terminal-surfaces reference](../statusline.md#terminal-surfaces). For Claude
+Each pane shows its own session's cost. To get the bar automatically every
+time you launch the agent — without living in tmux full-time — see the
+[shell-wrapper recipe](../statusline.md#make-the-bar-appear-whenever-you-launch-your-agent)
+(a `codex()` function that starts tmux on demand). Starship, raw zsh/bash,
+PowerShell, and OSC terminal-title recipes — plus the path-matching rules —
+are in the [terminal-surfaces reference](../statusline.md#terminal-surfaces). For Claude
 Code itself, the native stdin hook above stays the richer, recommended setup.
 
 ## What the line shows

--- a/docs/statusline.md
+++ b/docs/statusline.md
@@ -46,6 +46,37 @@ set -g status-right '#(aireceipts statusline --cwd "#{pane_current_path}")'
 tmux refreshes `#(...)` commands on `status-interval`; lower that setting if you
 want a fresher line, keeping in mind that each refresh runs the command again.
 
+### Make the bar appear whenever you launch your agent
+
+The tmux bar only exists inside tmux — a plain terminal tab has no status bar
+to draw on. To get the bar automatically every time you run Codex or opencode
+(without changing how the rest of your terminal behaves), wrap the command in
+a shell function that starts tmux on demand. In `~/.zshrc` (or `~/.bashrc`):
+
+```sh
+_aireceipts_tmux_wrap() {
+  local bin="$1"; shift
+  if [ -n "$TMUX" ] || ! command -v tmux >/dev/null; then
+    command "$bin" "$@"
+  else
+    tmux new-session -- "$bin" "$@"
+  fi
+}
+codex()    { _aireceipts_tmux_wrap codex "$@"; }
+opencode() { _aireceipts_tmux_wrap opencode "$@"; }
+```
+
+Running `codex` in any new tab now opens it inside a fresh tmux session with
+the status bar live; when the agent exits, the session ends (tmux's default —
+one window, `remain-on-exit` off) and you are back in your plain shell. Inside
+an existing tmux session the wrapper steps aside and runs the command
+directly. tmux auto-names each session, so concurrent launches never collide
+or mirror each other. Multiple arguments are passed through to the program
+verbatim (no shell re-parsing). If a TUI's colors or keys look
+wrong inside the wrapper, set `set -g default-terminal "tmux-256color"` in
+`~/.tmux.conf`. Claude Code needs no wrapper — its native `statusLine` hook
+above renders inside the app itself.
+
 ### Matching rules
 
 `--cwd` selects the newest session attributed to that path (or an ancestor of

--- a/site/docs/07-statusline.html
+++ b/site/docs/07-statusline.html
@@ -363,7 +363,7 @@ footer{
 
 <pre class="doc-code"><code class="language-tmux">set -g status-right '#(aireceipts statusline --cwd &quot;#{pane_current_path}&quot;)'</code></pre>
 
-<p>Each pane shows its own session's cost. Starship, raw zsh/bash, PowerShell, and OSC terminal-title recipes — plus the path-matching rules — are in the <a href="statusline.html#terminal-surfaces">terminal-surfaces reference</a>. For Claude Code itself, the native stdin hook above stays the richer, recommended setup.</p>
+<p>Each pane shows its own session's cost. To get the bar automatically every time you launch the agent — without living in tmux full-time — see the <a href="statusline.html#make-the-bar-appear-whenever-you-launch-your-agent">shell-wrapper recipe</a> (a <code>codex()</code> function that starts tmux on demand). Starship, raw zsh/bash, PowerShell, and OSC terminal-title recipes — plus the path-matching rules — are in the <a href="statusline.html#terminal-surfaces">terminal-surfaces reference</a>. For Claude Code itself, the native stdin hook above stays the richer, recommended setup.</p>
 
 <h2 id="what-the-line-shows">What the line shows</h2>
 

--- a/site/docs/statusline.html
+++ b/site/docs/statusline.html
@@ -361,6 +361,23 @@ footer{
 
 <p>tmux refreshes <code>#(...)</code> commands on <code>status-interval</code>; lower that setting if you want a fresher line, keeping in mind that each refresh runs the command again.</p>
 
+<h3 id="make-the-bar-appear-whenever-you-launch-your-agent">Make the bar appear whenever you launch your agent</h3>
+
+<p>The tmux bar only exists inside tmux — a plain terminal tab has no status bar to draw on. To get the bar automatically every time you run Codex or opencode (without changing how the rest of your terminal behaves), wrap the command in a shell function that starts tmux on demand. In <code>~/.zshrc</code> (or <code>~/.bashrc</code>):</p>
+
+<pre class="doc-code"><code class="language-sh">_aireceipts_tmux_wrap() {
+  local bin=&quot;$1&quot;; shift
+  if [ -n &quot;$TMUX&quot; ] || ! command -v tmux &gt;/dev/null; then
+    command &quot;$bin&quot; &quot;$@&quot;
+  else
+    tmux new-session -- &quot;$bin&quot; &quot;$@&quot;
+  fi
+}
+codex()    { _aireceipts_tmux_wrap codex &quot;$@&quot;; }
+opencode() { _aireceipts_tmux_wrap opencode &quot;$@&quot;; }</code></pre>
+
+<p>Running <code>codex</code> in any new tab now opens it inside a fresh tmux session with the status bar live; when the agent exits, the session ends (tmux's default — one window, <code>remain-on-exit</code> off) and you are back in your plain shell. Inside an existing tmux session the wrapper steps aside and runs the command directly. tmux auto-names each session, so concurrent launches never collide or mirror each other. Multiple arguments are passed through to the program verbatim (no shell re-parsing). If a TUI's colors or keys look wrong inside the wrapper, set <code>set -g default-terminal &quot;tmux-256color&quot;</code> in <code>~/.tmux.conf</code>. Claude Code needs no wrapper — its native <code>statusLine</code> hook above renders inside the app itself.</p>
+
 <h3 id="matching-rules">Matching rules</h3>
 
 <p><code>--cwd</code> selects the newest session attributed to that path (or an ancestor of it) and prints the neutral placeholder when none match — it never falls back to another project's newest session. A session launched from your home directory (or above it) only ever matches that exact path, so one <code>~</code>-launched session can't shadow every pane on the machine. Relative <code>--cwd</code> paths resolve against the directory where <code>aireceipts</code> is invoked; a path beginning with <code>-</code> must use the <code>--cwd=&lt;path&gt;</code> form. Matching intentionally folds only a Windows drive letter's case — the rest of every path remains case-sensitive, because over-matching on a case-sensitive filesystem is the worse failure. Cursor is excluded from scoped discovery entirely because its session data carries no cwd.</p>


### PR DESCRIPTION
## What

Closes a discoverability gap found in live use: the tmux recipe assumes you're already inside tmux, but a user opening Codex in a plain terminal tab sees no bar — and the docs never said how to close that gap.

New subsection under **Terminal surfaces** in `docs/statusline.md`: a `codex()`/`opencode()` shell function that starts tmux on demand — own auto-named session per launch (no collisions/mirroring), steps aside inside existing tmux, drops back to the plain shell on exit (qualified with tmux's defaults), arguments passed through verbatim, TERM troubleshooting note. Claude Code explicitly excluded (native `statusLine` renders in-app). Guide 07 cross-links it.

Snippet behavior verified live on tmux 3.6a (spaced-args pass-through, auto-name collision test). Two Codex review rounds: direct-argv instead of `%q`-through-sh, `$$` collision fixed via auto-naming, over-claims qualified, and a wrong `tmux ≥ 3.4` version claim removed entirely rather than corrected (behavior is old enough not to need a qualifier).

Docs-only; hygiene + readme-guard green; site mirror regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)