### PR TITLE
fix: attach receipt refs on bare-HEAD branch publishes

### DIFF
--- a/src/pr/git.ts
+++ b/src/pr/git.ts
@@ -68,6 +68,13 @@ export function currentWorktreeRoot(run: CommandRunner, cwd?: string): string | 
   return path.resolve(res.stdout.trim());
 }
 
+/** The checked-out branch name, or null when HEAD is detached/unresolvable. */
+export function currentBranchName(run: CommandRunner, cwd?: string): string | null {
+  const res = run("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd });
+  const branch = res.code === 0 ? res.stdout.trim() : "";
+  return branch && branch !== "HEAD" ? branch : null;
+}
+
 /** The repo's default branch ref for merge-base (origin/HEAD's target, else `main`). */
 export function defaultBranchRef(run: CommandRunner, cwd?: string): string {
   const res = run("git", ["rev-parse", "--abbrev-ref", "origin/HEAD"], { cwd });

--- a/src/pr/gitWrite.ts
+++ b/src/pr/gitWrite.ts
@@ -407,6 +407,12 @@ function isBranchPushRefspec(refspec: string): boolean {
   if (normalized.startsWith(":")) {
     return false;
   }
+  // Bare HEAD means "publish the checked-out branch". The attach/store path
+  // resolves that branch with `rev-parse --abbrev-ref HEAD`; it never slugs
+  // this token directly and rejects a detached HEAD fail-safe.
+  if (normalized === "HEAD") {
+    return true;
+  }
   const colon = normalized.indexOf(":");
   if (colon >= 0) {
     const src = normalized.slice(0, colon);

--- a/src/pr/index.ts
+++ b/src/pr/index.ts
@@ -15,7 +15,7 @@ import { renderReceipt } from "../receipt/render.js";
 import { cacheServedPct, compactDuration } from "../receipt/present.js";
 import { formatDuration, formatShortTokens } from "../receipt/format.js";
 import { HELPER_FULL_LABEL } from "./body.js";
-import { branchCommits, currentWorktreeRoot, defaultRunner, worktreeRoots, type CommandRunner } from "./git.js";
+import { branchCommits, currentBranchName, currentWorktreeRoot, defaultRunner, worktreeRoots, type CommandRunner } from "./git.js";
 import { isBranchCandidate, overlapsBranchWindow, selectExplicitSession } from "./select.js";
 import { computeSlice } from "./slice.js";
 import { anchorEvents } from "./slice.js";
@@ -609,9 +609,8 @@ export async function runPrDetailed(opts: PrOptions, deps: PrDeps = defaultPrDep
   // default `"comment"`; R3's committed-settings layer is out of scope here.
   const store = opts.store ?? (process.env.AIRECEIPTS_STORE === "ref" ? "ref" : undefined) ?? "comment";
   if (store === "ref") {
-    const branchResult = deps.runGit("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: deps.cwd });
-    const branch = branchResult.code === 0 ? branchResult.stdout.trim() : "";
-    if (!branch || branch === "HEAD") {
+    const branch = currentBranchName(deps.runGit, deps.cwd);
+    if (!branch) {
       deps.err("store=ref skipped: could not resolve current branch");
     } else {
       const payload = buildPrReceiptPayload(bodyInput, extras);

--- a/test/cli/hook-pre-push.test.ts
+++ b/test/cli/hook-pre-push.test.ts
@@ -66,6 +66,8 @@ describe("SPEC-0073 hook pre-push command", () => {
   it.each([
     claudePayload("git push"),
     claudePayload("git push origin feat"),
+    claudePayload("git push -u origin HEAD"),
+    claudePayload("git push --force-with-lease origin HEAD"),
     claudePayload("git push origin HEAD:refs/heads/main"),
     { tool_name: "exec_command", tool_input: { cmd: "git push origin feat" } },
     { name: "functions.exec_command", arguments: JSON.stringify({ command: ["git", "push", "origin", "feat"] }) },

--- a/test/pr/gitWrite.test.ts
+++ b/test/pr/gitWrite.test.ts
@@ -60,12 +60,22 @@ describe("SPEC-0073 classifyPush", () => {
     [["git", "push"]],
     [["git", "push", "origin"]],
     [["git", "push", "origin", "feat"]],
-    [["git", "push", "origin", "HEAD:refs/heads/main"]],
+    [["git", "push", "origin", "HEAD"]],
     [["GIT_SSH_COMMAND=ssh -i key", "git", "push", "origin", "feat"]],
     [["git", "push", "--force-with-lease"]],
     [["git", "push", "-u", "origin", "feat"]],
+    [["git", "push", "-u", "origin", "HEAD"]],
+    [["git", "push", "--set-upstream", "origin", "HEAD"]],
+    [["git", "push", "--force-with-lease", "origin", "HEAD"]],
   ])("attaches on branch push argv %j", (argv) => {
     expect(classifyPush(argv).attach).toBe(true);
+  });
+
+  it("classifies HEAD:refs/heads/x by its branch target (target-name slug propagation is a tested non-goal)", () => {
+    // The classifier validates the explicit remote branch target, but returns no
+    // branch metadata. The attach path therefore keeps slugging the resolved
+    // local current branch; propagating a divergent target name is out of scope.
+    expect(classifyPush(["git", "push", "origin", "HEAD:refs/heads/review"]).attach).toBe(true);
   });
 
   it.each([
@@ -83,8 +93,11 @@ describe("SPEC-0073 classifyPush", () => {
     [["git", "push", "origin", "+refs/aireceipts/x:refs/aireceipts/x"]],
     [["git", "push", "origin", "refs/receipts/x"]],
     [["git", "push", "origin", "+refs/receipts/x:refs/receipts/x"]],
-    [["git", "push", "origin", "HEAD"]],
+    [["git", "push", "origin", "refs/tags/v1"]],
+    [["git", "push", "origin", "HEAD:refs/tags/v1"]],
+    [["git", "push", "origin", "deadbeef"]],
     [["git", "push", "origin", "abc1234:refs/heads/tmp"]],
+    [["git", "push", "origin", ":refs/heads/review"]],
     [["git", "-C", "sub", "push", "origin", "feat"]],
     [["git", "--git-dir=/other/.git", "--work-tree=/other", "push", "origin", "feat"]],
     [["git", "--namespace=ns", "push", "origin", "feat"]],

--- a/test/pr/run.test.ts
+++ b/test/pr/run.test.ts
@@ -1,13 +1,18 @@
 // SPEC-0019 R3 — render-first, fail-visible. The full body is ALWAYS written to
 // stdout before any gh call; a failed/absent gh only adds a stderr diagnostic and
 // exits 1. Also covers auto-select success and the zero/many selection outcomes.
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { loadById } from "../../src/parse/load.js";
 import type { CommandResult, CommandRunner } from "../../src/pr/git.js";
 import { DOGFOOD_MARKER } from "../../src/pr/body.js";
+import { classifyPush } from "../../src/pr/gitWrite.js";
 import { runPr, runPrDetailed, type PrDeps } from "../../src/pr/index.js";
+import { listReceiptRefs } from "../../src/pr/store.js";
 import type { SessionSummary } from "../../src/parse/types.js";
 
 const FIX = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "pr");
@@ -66,6 +71,58 @@ async function makeDeps(over: Partial<PrDeps> = {}): Promise<{ deps: PrDeps; eve
   };
   return { deps, events, out, err };
 }
+
+describe("SPEC-0073 HEAD publish attach/store integration", () => {
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function tempRepo(): Promise<string> {
+    const cwd = await mkdtemp(path.join(tmpdir(), "aireceipts-head-push-"));
+    dirs.push(cwd);
+    const init = spawnSync("git", ["init", "--quiet"], { cwd, encoding: "utf8" });
+    if (init.status !== 0) {
+      throw new Error(`git init failed: ${init.stderr}`);
+    }
+    return cwd;
+  }
+
+  async function attachForPush(argv: string[], resolvedBranch: string) {
+    expect(classifyPush(argv).attach).toBe(true);
+    const cwd = await tempRepo();
+    const runGit: CommandRunner = (cmd, args) => {
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "HEAD") {
+        return ok(`${resolvedBranch}\n`);
+      }
+      return gitOk(cmd, args);
+    };
+    const { deps, err } = await makeDeps({ cwd, runGit });
+    const result = await runPrDetailed({ post: false, store: "ref" }, deps);
+    return { err, refs: listReceiptRefs(cwd), result };
+  }
+
+  it("writes the resolved current-branch slug identically for named and bare-HEAD publishes", async () => {
+    const named = await attachForPush(["git", "push", "origin", "fix/hook-push-head"], "fix/hook-push-head");
+    const head = await attachForPush(["git", "push", "-u", "origin", "HEAD"], "fix/hook-push-head");
+    const expected = [{ ref: "refs/aireceipts/fix-hook-push-head", slug: "fix-hook-push-head" }];
+
+    expect(named.result.code).toBe(0);
+    expect(head.result.code).toBe(0);
+    expect(named.refs).toEqual(expected);
+    expect(head.refs).toEqual(expected);
+  });
+
+  it("writes no receipt ref when bare HEAD resolves to a detached HEAD", async () => {
+    const detached = await attachForPush(["git", "push", "origin", "HEAD"], "HEAD");
+
+    expect(detached.result.code).toBe(0);
+    expect(detached.refs).toEqual([]);
+    expect(detached.err).toContain("store=ref skipped: could not resolve current branch");
+    expect(detached.err.some((line) => line.startsWith("wrote receipt ref "))).toBe(false);
+  });
+});
 
 describe("R3 render-first ordering", () => {
   it("auto-selects, slices, and dry-runs the body to stdout (no gh, exit 0)", async () => {

--- a/test/pr/store.test.ts
+++ b/test/pr/store.test.ts
@@ -6,6 +6,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { currentBranchName, type CommandRunner } from "../../src/pr/git.js";
 import { listReceiptRefs, readReceiptRef, RECEIPT_REF_PREFIX, receiptRef, writeReceiptRef } from "../../src/pr/store.js";
 import { receiptRefSlug } from "../../src/pr/payloadTypes.js";
 
@@ -32,6 +33,32 @@ describe("receipt-ref namespace", () => {
     // posting nothing. aireceipts must own its own namespace.
     expect(RECEIPT_REF_PREFIX).toBe("refs/aireceipts/");
     expect(receiptRef("feat-x")).toBe("refs/aireceipts/feat-x");
+  });
+});
+
+describe("SPEC-0073 HEAD publish branch resolution", () => {
+  it("slugs the resolved current branch identically to an explicit branch publish", () => {
+    const calls: Array<{ cmd: string; args: string[]; cwd?: string }> = [];
+    const run: CommandRunner = (cmd, args, opts) => {
+      calls.push({ cmd, args, cwd: opts?.cwd });
+      return { stdout: "fix/hook-push-head\n", stderr: "", code: 0, missing: false };
+    };
+
+    const branch = currentBranchName(run, "/repo");
+    expect(branch).toBe("fix/hook-push-head");
+    expect(branch).not.toBe("HEAD");
+    expect(receiptRef(receiptRefSlug(branch!))).toBe(receiptRef(receiptRefSlug("fix/hook-push-head")));
+    expect(receiptRef(receiptRefSlug(branch!))).toBe("refs/aireceipts/fix-hook-push-head");
+    expect(calls).toEqual([{ cmd: "git", args: ["rev-parse", "--abbrev-ref", "HEAD"], cwd: "/repo" }]);
+  });
+
+  it.each([
+    { stdout: "HEAD\n", code: 0 },
+    { stdout: "\n", code: 0 },
+    { stdout: "fix/hook-push-head\n", code: 1 },
+  ])("returns no store target for a detached or unresolvable HEAD (%j)", ({ stdout, code }) => {
+    const run: CommandRunner = () => ({ stdout, stderr: "", code, missing: false });
+    expect(currentBranchName(run, "/repo")).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes #228 — the root cause of the dogfood pilots producing zero receipts.

## The bug

`classifyPush` rejected bare `HEAD` as a refspec, so the SPEC-0073 auto-attach hook silently no-opped on `git push -u origin HEAD` — the dominant publish idiom for coding agents. Verified end-to-end: in the pilot repo, a Claude Code-built branch's publish fired the sibling hook in the same settings file while ours declined classification; a local reproduction of the exact deployed command isolated the layer (`{attach:false, reason:"not-branch-refspec"}`), with cold start at 1.78s ruling out the 60s timeout.

## The fix (6 lines in the classifier + branch-resolution extraction)

| Publish form | Attaches | Ref |
|---|---|---|
| `origin <branch>` | yes (unchanged) | `refs/aireceipts/<branch-slug>` |
| `origin HEAD`, `-u origin HEAD`, `--force-with-lease origin HEAD` | **yes (new)** | same resolved-branch ref |
| `HEAD:refs/heads/x` | yes, by target | resolved-branch slug |
| detached HEAD | no (fail-safe) | none |
| tags / shas / receipt-refs / deletes | no (unchanged) | none |

Slug always derives from the resolved checked-out branch (`currentBranchName`, extracted from the store path) — the literal `HEAD` token is never slugged.

## Proof

Red-then-green (red run captured); 1,856 tests green; full verification block all 0. Codex gate re-ran the end-to-end reproduction with the local build: the previously-failing `-u origin HEAD` payload now lands `refs/aireceipts/feat-repro-hook` on the origin with the expected `receipt.json`. Gate verdict: ACCEPT — its one finding (anchor path counting a receipt-ref publish as an attribution write) is pre-existing on main and filed as #229.

## After merge

Needs a release to reach the dogfood repos (they run `@latest`); the next bare-HEAD publish from a Claude Code session in a pilot repo should then mint the first real receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
