### PR TITLE
chore: release v0.8.2 — auto-attach fires on bare-HEAD publishes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.8.1):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.8.2):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.8.2 — 2026-07-10
+
+Patch: **the auto-attach hook now fires on bare-`HEAD` branch publishes** —
+`git push -u origin HEAD` (and `--force-with-lease` / `HEAD:refs/heads/<x>` forms), the
+dominant idiom for coding agents, previously classified as not-a-branch-publish and the
+SPEC-0073 hook silently wrote no receipt ref. Root-caused from the org dogfood pilots
+producing zero receipts (issue #228, PR #230): the sibling hook on the same event fired
+while ours declined classification. The receipt ref slug always derives from the
+resolved checked-out branch; detached `HEAD` still attaches nothing (fail-safe), and
+tag/sha/receipt-ref/delete publishes stay excluded.
+
+Also: docs — terminal-statusline pages now say what happens without tmux (silent
+fallback + alternatives, #226) and add a shell-wrapper recipe so the statusline appears
+whenever the agent launches (#225).
+
 ## v0.8.1 — 2026-07-10
 
 Patch: **OpenAI `gpt-5.6` family price rows** — `gpt-5.6-sol` ($5.00 in / $0.50 cached /

--- a/docs/releases/0.8.2-verdict.md
+++ b/docs/releases/0.8.2-verdict.md
@@ -1,0 +1,60 @@
+# Release verdict — v0.8.2
+
+- **Candidate version:** 0.8.2 (patch)
+- **Content SHA:** `11419bb` (HEAD of `main` after #230)
+- **Changelog range:** `v0.8.1..11419bb` — three commits (#230 fix, #225/#226 docs).
+- **Bump rationale:** PATCH — one bug fix on the SPEC-0073 auto-attach hook's push
+  classifier (bare-`HEAD` refspecs now attach; 6 lines + branch-resolution extraction)
+  plus two docs commits. Rendered receipt output is untouched (goldens byte-identical);
+  the behavior delta is strictly "receipt refs now get written where they silently
+  weren't."
+- **Date:** 2026-07-10 (UTC)
+
+## Right-sizing (why not the full 4-persona panel)
+
+v0.8.1/v0.7.2 precedent, adapted for a range that DOES touch product code: the lenses
+with signal ran live; the ones without were consciously skipped.
+
+- **PM lens (skipped):** single-fix patch; the story is one sentence and the changelog
+  entry is it. No new user-visible surface.
+- **Designer lens (skipped):** goldens byte-identical; no rendered artifact changed.
+- **QA lens (RAN, split across two harnesses):**
+  - *Negative battery* (10 adversarial hook payloads against a scratch repo + file
+    origin, empty sandbox HOME): bare-`HEAD` w/ `-u`, `--force-with-lease`,
+    `HEAD:refs/heads/x`, tag push, receipt-ref push (must never attach), non-push
+    command, array-form command, 50 KB junk payload, non-git cwd, detached HEAD.
+    Result: **every case rc=0, stdout empty (PreToolUse-safe), stderr empty, zero
+    refs written wrongly.**
+  - *Positive path* (end-to-end reproduction, run twice — pre-fix red, post-fix
+    green): sandboxed clone + attributable Claude Code transcript + published-CLI
+    chain; the previously-failing `-u origin HEAD` payload now lands
+    `refs/aireceipts/<branch>` on the origin with the expected `receipt.json`.
+    Cold start 1.78 s (60 s hook budget).
+- **EM lens (mechanical, RAN):** no dependency delta; rollback = pin `0.8.1`;
+  CI green on the content SHA (#230's full run); the known open findings (#229
+  anchor-miscount — pre-existing, #218 consent ordering, #219 kit pre-filter) are
+  tracked issues, none regressed by this range, none launch-blocking for a patch
+  whose sole effect is un-breaking ref production.
+
+## Mechanical checks (all on this candidate)
+
+- `node scripts/preflight-release.mjs` → **RELEASE-READY, 11 checks** (incl. packed
+  tarball installed into a clean project, binary runs a fixture and prints a priced
+  receipt).
+- Verification block on the release branch: tsc 0 · eslint 0 · vitest 0 · goldens 0 ·
+  spec-lint 0 · hygiene 0 (incl. docs-site freshness gate).
+- `npm publish --dry-run`: 72 files, 128.5 kB tarball; file list inspected — no
+  fixtures, transcripts, internal docs, or env files.
+- Docs panel, scoped: the only doc content changing is the changelog entry; its claims
+  were verified against #230/#228/#225/#226 directly and re-checked by the release-PR
+  Codex gate. Full two-lens panel ran 2026-07-08 for the launch docs; nothing in this
+  range touches those surfaces.
+
+## Open risks (tracked, not blocking)
+
+- #229 — anchor path can count a receipt-ref publish as an attribution write
+  (pre-existing; surfaced by this release's gate review).
+- #218 — hook uploads the ref before a denied push (SPEC-0073 amendment pending).
+- #219 — kit-level npx pre-filter adoption.
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Your AI coding agent just billed you. Here's the receipt.",
   "keywords": [
     "ai",

--- a/site/docs/CHANGELOG.html
+++ b/site/docs/CHANGELOG.html
@@ -336,6 +336,12 @@ footer{
 
 <p>All notable changes to <code>aireceipts-cli</code>. Factual, grouped by conventional-commit type (I6: a log, not marketing). Dates are UTC.</p>
 
+<h2 id="v082-2026-07-10">v0.8.2 — 2026-07-10</h2>
+
+<p>Patch: <strong>the auto-attach hook now fires on bare-<code>HEAD</code> branch publishes</strong> — <code>git push -u origin HEAD</code> (and <code>--force-with-lease</code> / <code>HEAD:refs/heads/&lt;x&gt;</code> forms), the dominant idiom for coding agents, previously classified as not-a-branch-publish and the SPEC-0073 hook silently wrote no receipt ref. Root-caused from the org dogfood pilots producing zero receipts (issue #228, PR #230): the sibling hook on the same event fired while ours declined classification. The receipt ref slug always derives from the resolved checked-out branch; detached <code>HEAD</code> still attaches nothing (fail-safe), and tag/sha/receipt-ref/delete publishes stay excluded.</p>
+
+<p>Also: docs — terminal-statusline pages now say what happens without tmux (silent fallback + alternatives, #226) and add a shell-wrapper recipe so the statusline appears whenever the agent launches (#225).</p>
+
 <h2 id="v081-2026-07-10">v0.8.1 — 2026-07-10</h2>
 
 <p>Patch: <strong>OpenAI <code>gpt-5.6</code> family price rows</strong> — <code>gpt-5.6-sol</code> ($5.00 in / $0.50 cached / $30.00 out per 1M), <code>gpt-5.6-terra</code> ($2.50 / $0.25 / $15.00), <code>gpt-5.6-luna</code> ($1.00 / $0.10 / $6.00); Standard short-context tier, effective 2026-07-09, every row cited to the official OpenAI pricing page (PR #223). Codex CLI sessions on these models — which rendered tokens-only under I2's no-fabricated-dollars rule — now price in receipts and the statusline. Additive data change only; no code touched.</p>


### PR DESCRIPTION
Release prep for **v0.8.2** — ships the #230 fix (auto-attach hook fires on bare-`HEAD` branch publishes, the dogfood-blocking bug) plus docs #225/#226.

- version bump + lockfile
- changelog entry (factual, I6 voice — Codex-verified against the merged PRs)
- `docs/releases/0.8.2-verdict.md` — **VERDICT: GO** at content SHA `11419bb`; right-sized board per v0.8.1 precedent: QA lens ran live (10-case adversarial hook battery: all rc=0, stdout clean, zero wrong refs; plus the end-to-end positive repro that red/greened the fix), preflight **RELEASE-READY (11 checks)**, dry-run tarball inspected (72 files, 128.5 kB, nothing sensitive)
- AGENTS.md inventory version line (release-skill-owned)
- site/docs regenerated (freshness gate green)

After merge: dispatch `release-publish.yml` on main — it re-runs preflight, publishes with OIDC provenance, then tags `v0.8.2` and creates the GitHub Release. Maintainer instructed "merge and release" (button 4 exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
