### PR TITLE
feat: SPEC-0079 amendments — single Sponsor row, README samosa section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
-# The samosa story page (custom) + the Ko-fi tip jar it points at (SPEC-0079).
-ko_fi: anandgupta42
+# The samosa story page is the single Sponsor-block entry (SPEC-0079 amendment:
+# the page mediates the tip jar everywhere — no direct Ko-fi row).
 custom: ["https://anandgupta42.github.io/receipts/samosa.html"]

--- a/README.md
+++ b/README.md
@@ -240,4 +240,7 @@ welcome and run the same gates: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Apache-2.0.
 
-Support the project: [buy me a samosa](https://anandgupta42.github.io/receipts/samosa.html).
+## Buy me a samosa
+
+Every open-source project asks you to buy the maintainer a coffee. Not this one —
+[buy me a samosa](https://anandgupta42.github.io/receipts/samosa.html), and I'll explain.

--- a/specs/SPEC-0079-samosa-comeback.md
+++ b/specs/SPEC-0079-samosa-comeback.md
@@ -63,9 +63,12 @@ the artifact golden must pass untouched.
   tests) stays green and gains one assertion: README contains
   `[buy me a samosa](<SAMOSA_URL>)`. The link adds zero emoji; the intentional-emoji set
   stays exact `[]`.
-- **R3 — FUNDING.yml gains the native Ko-fi row.** `ko_fi: anandgupta42` is added alongside
-  the existing `custom:` samosa-page entry (`.github/FUNDING.yml`), so the repo Sponsor
-  button offers both the story page and the tip jar.
+- **R3 (amended 2026-07-10, post-merge) — the Sponsor block offers only the story page.**
+  `.github/FUNDING.yml` carries exactly one entry: the `custom:` samosa-page URL. The
+  originally-shipped `ko_fi:` row was removed at the maintainer's directive after seeing
+  the rendered sidebar ("don't want two links — just the main samosa page link"): the page
+  mediates the tip jar on every surface, which is the kill criterion's own logic extended
+  to the Sponsor block. No direct payment-platform row (`ko_fi`/`github`/etc.) may return.
 - **R4 — the existing own-surface links are pinned, not trusted.** The landing page
   (`site/index.html:484`), the viewer chrome (`site/view.html:62`), and the docs-site
   footer template (`scripts/build-docs-site.mjs:820`) already link `samosa.html`; a small
@@ -94,8 +97,8 @@ the artifact golden must pass untouched.
   unchanged by this spec — no samosa link appears (SPEC-0070's tests and the artifact
   golden pass untouched); with opt-in `--samosa`, the artifact footer carries the same
   single link with the R5 glyph paths.
-- **Given** the repo's GitHub page, **then** the Sponsor button offers the Ko-fi row and
-  the samosa-page custom row.
+- **Given** the repo's GitHub page, **then** the Sponsor button offers exactly one row —
+  the samosa-page link (the page carries the Ko-fi ask).
 
 ## Non-goals
 
@@ -149,7 +152,7 @@ Card structure (existing aesthetic — monospace, paper card, drawn glyph on top
 | R5 propagation | site html + docs template/output | drift guard green; no old paths anywhere (repo grep) |
 | R5 zero churn | `verify-goldens` | passes with no golden regenerated |
 | R2 README | README bytes | `[buy me a samosa](SAMOSA_URL)` present; guard suite green; emoji set exact `[]` |
-| R3 funding | `.github/FUNDING.yml` | `ko_fi: anandgupta42` + the existing `custom:` entry |
+| R3 funding | `.github/FUNDING.yml` | the `custom:` samosa-page entry only; no payment-platform rows |
 | R4 surface pins | index.html, view.html, build-docs-site.mjs | each carries a `samosa.html` href |
 | PR surfaces untouched | SPEC-0070 suite + `verify-goldens` | default comment/artifact link-free; `pr-artifact.html` golden byte-identical |
 
@@ -256,3 +259,19 @@ prove completeness or the absence of the retired face marks; it now pins the ful
 path **sequence** and asserts the two legacy path prefixes are absent from every inlined
 copy. Codex otherwise verified: zero golden churn (102 artifacts), all 25 regenerated docs
 pages carry the four new paths, no old glyph or sponsors URL remains shipped.
+
+**2026-07-10 · button-1 amendment 4 (post-merge, the Sponsor block):** after enabling the
+Sponsorships toggle and seeing the sidebar render two rows, the maintainer directed:
+*"don't want two links — just the main samosa page link."* The `ko_fi:` row is removed from
+FUNDING.yml (follow-up PR); the R3 test now asserts the custom entry is the only row and
+no payment-platform key can silently return. Consistent with the kill criterion: the story
+page is the only door to the tip jar, now including the Sponsor block.
+
+**2026-07-10 · button-1 amendment 5 (post-merge, README placement):** the maintainer's
+rationale, recorded verbatim in intent: the README samosa link is the viral bet — "it has
+a chance of going viral because not many people ask for it." The License-area afterthought
+("Support the project: …") is replaced by a dedicated closing `## Buy me a samosa` section
+carrying the quotable subversion line ("Every open-source project asks you to buy the
+maintainer a coffee. Not this one — buy me a samosa, and I'll explain."). R2's guard
+assertion (lowercase `[buy me a samosa](SAMOSA_URL)`) still pins the link; line count 246
+of the guard's 260 cap; badge row untouched.

--- a/specs/SPEC-0079-samosa-comeback.md
+++ b/specs/SPEC-0079-samosa-comeback.md
@@ -28,7 +28,7 @@ buy me one?" — pointing at the maintainer's now-live Ko-fi jar
 (`https://ko-fi.com/anandgupta42`, created and supplied in-session 2026-07-10; Ko-fi
 bot-blocks automated fetches, so the URL is maintainer-attested — the page's current
 `github.com/sponsors` href is dead: GraphQL `hasSponsorsListing: false`). The README gets
-its `buy me a samosa` link back, and FUNDING.yml gains the native Ko-fi row.
+its `buy me a samosa` link back; FUNDING.yml's single row is the story page (R3, amended).
 
 **Kill criterion:** the story page keeps exactly **two** external hrefs — the Wikipedia
 samosa article and the Ko-fi jar — and zero `<script>` tags; the photo is embedded in the
@@ -107,8 +107,9 @@ the artifact golden must pass untouched.
 - **A `--no-samosa` flag, payload changes, golden churn, or new telemetry** — all were in
   the pre-correction draft and died with the reversal; no CLI or product-path surface
   changes, so SPEC-0043's telemetry-with-every-feature rule has nothing to attach to.
-- **A direct Ko-fi link anywhere but the story page and FUNDING.yml** — README, landing,
-  viewer, and docs link the story page; the page mediates the payment link.
+- **A direct Ko-fi link anywhere but the story page** — README, landing, viewer, docs,
+  and (post-amendment) the Sponsor block all link the story page; the page mediates the
+  payment link.
 - **The terminal receipt card** — plain install footer, unchanged (SPEC-0055).
 
 ## Design — the story page copy (lead-authored; implementer executes, never invents)
@@ -273,5 +274,5 @@ a chance of going viral because not many people ask for it." The License-area af
 ("Support the project: …") is replaced by a dedicated closing `## Buy me a samosa` section
 carrying the quotable subversion line ("Every open-source project asks you to buy the
 maintainer a coffee. Not this one — buy me a samosa, and I'll explain."). R2's guard
-assertion (lowercase `[buy me a samosa](SAMOSA_URL)`) still pins the link; line count 246
-of the guard's 260 cap; badge row untouched.
+assertion (lowercase `[buy me a samosa](SAMOSA_URL)`) still pins the link; line count 247
+of the guard's 260 cap (trailing newline counts); badge row untouched.

--- a/test/samosa-page.test.ts
+++ b/test/samosa-page.test.ts
@@ -62,11 +62,13 @@ describe("SPEC-0079 R1 · the story page contract", () => {
   });
 });
 
-describe("SPEC-0079 R3 · FUNDING.yml offers the tip jar", () => {
-  it("carries the ko_fi row alongside the samosa-page custom entry", () => {
+describe("SPEC-0079 R3 (amended) · the Sponsor block offers only the story page", () => {
+  it("carries the samosa-page custom entry and no direct payment row", () => {
     const funding = readFileSync(".github/FUNDING.yml", "utf8");
-    expect(funding).toContain("ko_fi: anandgupta42");
     expect(funding).toContain('custom: ["https://anandgupta42.github.io/receipts/samosa.html"]');
+    // Maintainer directive (2026-07-10): one Sponsor-block entry — the page
+    // mediates the tip jar; no ko_fi/github/etc. platform rows.
+    expect(funding).not.toMatch(/^\s*(ko_fi|github|patreon|open_collective|tidelift|liberapay|buy_me_a_coffee):/m);
   });
 });
 

--- a/test/samosa-page.test.ts
+++ b/test/samosa-page.test.ts
@@ -1,7 +1,7 @@
 // SPEC-0079 — the samosa story page contract and the own-surface link pins.
 // R1: the page is self-contained (zero scripts, embedded photo, exactly two
 // external hrefs — Wikipedia and the Ko-fi jar, ask-last) and carries the
-// Design-section copy verbatim. R3: FUNDING.yml offers the Ko-fi row. R4: the
+// Design-section copy verbatim. R3 (amended): FUNDING.yml's only active row is the story page. R4: the
 // landing/viewer/docs surfaces keep their samosa.html links — a README rework
 // once silently dropped the link, so these are pinned, not trusted.
 import { readFileSync } from "node:fs";
@@ -63,12 +63,13 @@ describe("SPEC-0079 R1 · the story page contract", () => {
 });
 
 describe("SPEC-0079 R3 (amended) · the Sponsor block offers only the story page", () => {
-  it("carries the samosa-page custom entry and no direct payment row", () => {
+  it("the custom samosa-page entry is the ONLY active line", () => {
     const funding = readFileSync(".github/FUNDING.yml", "utf8");
-    expect(funding).toContain('custom: ["https://anandgupta42.github.io/receipts/samosa.html"]');
-    // Maintainer directive (2026-07-10): one Sponsor-block entry — the page
-    // mediates the tip jar; no ko_fi/github/etc. platform rows.
-    expect(funding).not.toMatch(/^\s*(ko_fi|github|patreon|open_collective|tidelift|liberapay|buy_me_a_coffee):/m);
+    // Allowlist, not denylist (Codex review): any platform key GitHub adds
+    // later must fail this too. Maintainer directive (2026-07-10): one
+    // Sponsor-block entry — the page mediates the tip jar.
+    const active = funding.split("\n").filter((l) => l.trim() !== "" && !l.trim().startsWith("#"));
+    expect(active).toEqual(['custom: ["https://anandgupta42.github.io/receipts/samosa.html"]']);
   });
 });
 


### PR DESCRIPTION
## SPEC-0079 amendments 4–5 — one Sponsor row, a README section worth quoting

Two post-merge maintainer directives on the samosa surfaces:

- **Sponsor block → one link.** The `ko_fi:` row leaves FUNDING.yml; the sidebar now offers only the samosa story page, which carries the Ko-fi ask itself. This extends the spec's own kill-criterion logic — the story page is the only door to the tip jar — to the Sponsor block. The R3 test switched from denylist to **allowlist** (Codex review): the custom entry must be the *only* active line, so any platform key GitHub adds later fails it too.
- **README: the viral bet gets its own section.** The License-area afterthought ("Support the project: …") becomes a closing `## Buy me a samosa` section: *"Every open-source project asks you to buy the maintainer a coffee. Not this one — buy me a samosa, and I'll explain."* Rationale recorded in the spec: the samosa ask is the shareable line precisely because nobody asks for one. Guard intact: 247/260 lines, 3/3 badges, 0 emoji, lowercase link assertion unchanged.

SPEC-0079 validation carries amendments 4–5 + the S-review record. Note: the second commit's message duplicates the first (a push-gate retry reused the message file; not amended deliberately — see #239 for why amends are currently harmful to receipts).

### Gates (unmasked)
`tsc` 0 · `eslint` 0 · `vitest` 0 · `verify-goldens` 0 · `determinism ×10` 0 · `spec-lint` 0 · `hygiene` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
