### PR TITLE
fix: attach receipts for chained and redirected agent pushes

### DIFF
--- a/docs/adopt/claude-settings.json
+++ b/docs/adopt/claude-settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y aireceipts-cli@latest hook pre-push",
+            "command": "npx -y aireceipts-cli@latest hook pre-push || true",
             "timeout": 60
           }
         ]

--- a/docs/adopt/codex-hooks.json
+++ b/docs/adopt/codex-hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y aireceipts-cli@latest hook pre-push",
+            "command": "npx -y aireceipts-cli@latest hook pre-push || true",
             "timeout": 60
           }
         ]

--- a/docs/pr-receipts.md
+++ b/docs/pr-receipts.md
@@ -194,6 +194,9 @@ Add the hook for each coding agent the repo uses.
 #### Claude Code
 
 Commit `.claude/settings.json` ([template](https://github.com/anandgupta42/receipts/blob/main/docs/adopt/claude-settings.json)):
+The `|| true` matters: the CLI itself exits 0 on every path, but if `npx` cannot even
+fetch or start it (registry outage, cold cache timeout), the hook must still succeed —
+a receipt is never worth blocking a push.
 
 ```json
 {
@@ -204,7 +207,7 @@ Commit `.claude/settings.json` ([template](https://github.com/anandgupta42/recei
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y aireceipts-cli@latest hook pre-push",
+            "command": "npx -y aireceipts-cli@latest hook pre-push || true",
             "timeout": 60
           }
         ]
@@ -227,7 +230,7 @@ Commit `.codex/hooks.json` ([template](https://github.com/anandgupta42/receipts/
         "hooks": [
           {
             "type": "command",
-            "command": "npx -y aireceipts-cli@latest hook pre-push",
+            "command": "npx -y aireceipts-cli@latest hook pre-push || true",
             "timeout": 60
           }
         ]
@@ -240,6 +243,9 @@ Commit `.codex/hooks.json` ([template](https://github.com/anandgupta42/receipts/
 [Codex loads project hooks](https://learn.chatgpt.com/docs/hooks) only for trusted
 projects. Review and trust the exact hook definition once through `/hooks`; changed
 definitions require review again.
+
+Chained agent commands still auto-attach when they contain an unambiguous branch push
+and keep the same working directory; output redirections are ignored and the hook attaches once.
 
 ### Step 3 — Keep the Codex finalizer instruction
 

--- a/site/docs/pr-receipts.html
+++ b/site/docs/pr-receipts.html
@@ -444,7 +444,7 @@ jobs:
 
 <h4 id="claude-code">Claude Code</h4>
 
-<p>Commit <code>.claude/settings.json</code> (<a href="https://github.com/anandgupta42/receipts/blob/main/docs/adopt/claude-settings.json">template</a>):</p>
+<p>Commit <code>.claude/settings.json</code> (<a href="https://github.com/anandgupta42/receipts/blob/main/docs/adopt/claude-settings.json">template</a>): The <code>|| true</code> matters: the CLI itself exits 0 on every path, but if <code>npx</code> cannot even fetch or start it (registry outage, cold cache timeout), the hook must still succeed — a receipt is never worth blocking a push.</p>
 
 <pre class="doc-code"><code class="language-json">{
   &quot;hooks&quot;: {
@@ -454,7 +454,7 @@ jobs:
         &quot;hooks&quot;: [
           {
             &quot;type&quot;: &quot;command&quot;,
-            &quot;command&quot;: &quot;npx -y aireceipts-cli@latest hook pre-push&quot;,
+            &quot;command&quot;: &quot;npx -y aireceipts-cli@latest hook pre-push || true&quot;,
             &quot;timeout&quot;: 60
           }
         ]
@@ -475,7 +475,7 @@ jobs:
         &quot;hooks&quot;: [
           {
             &quot;type&quot;: &quot;command&quot;,
-            &quot;command&quot;: &quot;npx -y aireceipts-cli@latest hook pre-push&quot;,
+            &quot;command&quot;: &quot;npx -y aireceipts-cli@latest hook pre-push || true&quot;,
             &quot;timeout&quot;: 60
           }
         ]
@@ -485,6 +485,8 @@ jobs:
 }</code></pre>
 
 <p><a href="https://learn.chatgpt.com/docs/hooks">Codex loads project hooks</a> only for trusted projects. Review and trust the exact hook definition once through <code>/hooks</code>; changed definitions require review again.</p>
+
+<p>Chained agent commands still auto-attach when they contain an unambiguous branch push and keep the same working directory; output redirections are ignored and the hook attaches once.</p>
 
 <h3 id="step-3-keep-the-codex-finalizer-instruction">Step 3 — Keep the Codex finalizer instruction</h3>
 

--- a/specs/SPEC-0073-agent-prepush-hook.md
+++ b/specs/SPEC-0073-agent-prepush-hook.md
@@ -33,7 +33,8 @@ ref (SPEC-0065). It **never blocks the push from succeeding** and never fabricat
 ## Requirements
 
 - **R1 — `aireceipts hook pre-push` (hidden) reads a PreToolUse payload and attaches on branch
-  push only, using the tokenized command parser (no substring matching).** It reads a JSON object
+  push only, using the tokenized command parser (no substring matching).** *(Amended 2026-07-13,
+  #241.)* It reads a JSON object
   on stdin (the Claude Code hook payload: `{ tool_name, tool_input: { command } }`, and the
   equivalent Codex shape where present). It acts **only** when `tool_name` is a shell tool
   (`Bash`) **and** `tool_input.command`, parsed with the repo's existing tokenized git-command
@@ -46,9 +47,15 @@ ref (SPEC-0065). It **never blocks the push from succeeding** and never fabricat
   only refspec is `refs/aireceipts/*` (recursion guard); a push to a non-`origin` remote; a
   **repo-retargeting push** (`git -C <dir> push`, `--git-dir`/`--work-tree`/`--namespace`/
   `--exec-path`) whose target repo/worktree differs from the hook's cwd — the attach only runs
-  against the hook's cwd, so attaching would write the ref to the wrong repo; or any command the
-  parser cannot unambiguously resolve to the above (heredocs, aliases, `&&`-chains whose push
-  target is unclear → **no action**, under-attach). When it acts, it runs the existing
+  against the hook's cwd, so attaching would write the ref to the wrong repo; or any push
+  invocation the parser cannot unambiguously resolve to the above (heredocs and aliases remain
+  **no action**, under-attach). The parser tokenizes the whole shell command, strips shell
+  redirections from each invocation before push classification, and acts exactly once when **at
+  least one** invocation is an attachable branch push — including in `&&`/`;`/pipe chains — as
+  long as **no** `cd`, `pushd`, or `popd` invocation appears anywhere in the command. A cwd change
+  before or after the push is conservatively refused because invocation ordering across shell
+  operators cannot safely retarget the attach, which must run against the hook's cwd. When it
+  acts, it runs the existing
   `pr --store ref --push-ref` path (SPEC-0065) — which writes the deterministic ref and pushes it
   to `origin`. A spurious attach is harmless by construction (the ref is deterministic and the
   session is real — it only writes a correct ref slightly early), but ambiguity still resolves to
@@ -130,12 +137,14 @@ ref (SPEC-0065). It **never blocks the push from succeeding** and never fabricat
 | R1 | branch push (bare) | `{tool_name:"Bash",tool_input:{command:"git push"}}` | runs attach (`pr --store ref --push-ref`) |
 | R1 | branch push origin | `git push origin feat` | runs attach |
 | R1 | explicit refspec | `git push origin HEAD:refs/heads/main` | runs attach |
+| R1 | chained or redirected branch push | `npm test && git push`, `git push 2>&1 \| tail -3` | runs one attach |
 | R1 | non-git command | `npm test` | no action, exit 0 |
 | R1 | git non-push | `git status` | no action |
 | R1 | delete/tag-only/dry-run | `git push --delete`, `git push --tags`, `git push --dry-run` | no action |
 | R1 | non-origin remote | `git push upstream feat` | no action (only origin) |
 | R1 | nested receipts push (recursion) | `git push origin refs/aireceipts/x` | no action |
-| R1 | echoed / heredoc / alias | `echo "git push"`, push inside a heredoc, ambiguous `&&`-chain | no action (tokenized parser, under-attach) |
+| R1 | echoed / heredoc / alias | `echo "git push"`, push inside a heredoc, alias | no action (tokenized parser, under-attach) |
+| R1 | cwd-changing chain | `cd /elsewhere && git push`, `pushd /elsewhere && git push && popd` | no action (attach must target the hook's cwd) |
 | R1 | repo-retargeting push | `git -C sub push …`, `git --git-dir=… push …`, `--work-tree`/`--namespace`/`--exec-path` | **no action** — the attach only runs against the hook's cwd, so a push aimed at another repo/worktree must not attach (would write the ref to the wrong repo) |
 | R2 | never blocks | attach throws / no git / empty stdin / bad JSON / no session | exit 0, empty stdout, empty stderr, no decision object |
 | R2 | zero stdout on success | valid branch push, attach succeeds | ref written; hook stdout is empty (runPrDetailed given no-op writers) |

--- a/src/cli/commands/hook-pre-push.ts
+++ b/src/cli/commands/hook-pre-push.ts
@@ -3,7 +3,7 @@
 // best-effort attaches `refs/aireceipts/<slug>` without ever writing a hook
 // decision object or blocking the developer's push.
 import { runPrDetailed, defaultPrDeps } from "../../pr/index.js";
-import { classifyPush, toolCallInvocations } from "../../pr/gitWrite.js";
+import { classifyPush, stripShellRedirections, toolCallInvocations } from "../../pr/gitWrite.js";
 import type { ToolCall } from "../../parse/types.js";
 import { readStdin } from "./statusline.js";
 import type { CommandContext, CommandDef } from "../types.js";
@@ -83,6 +83,36 @@ function commandSource(payload: Record<string, unknown>, input: Record<string, u
   return input.command ?? input.cmd ?? payload.command ?? payload.cmd;
 }
 
+const CWD_CHANGING_COMMANDS = new Set(["cd", "pushd", "popd"]);
+
+function containsHeredoc(source: string | string[]): boolean {
+  const parts = typeof source === "string" ? [source] : source;
+  return parts.some((part) => {
+    let quote: "'" | '"' | undefined;
+    for (let i = 0; i < part.length - 1; i++) {
+      const char = part[i];
+      if (quote) {
+        if (char === quote) quote = undefined;
+        else if (quote === '"' && char === "\\") i++;
+        continue;
+      }
+      if (char === "\\") {
+        i++;
+      } else if (char === "'" || char === '"') {
+        quote = char;
+      } else if (char === "<" && part[i + 1] === "<") {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+function changesWorkingDirectory(argv: string[]): boolean {
+  const command = argv.find((token) => !/^[A-Za-z_][A-Za-z0-9_]*=.*/.test(token));
+  return command !== undefined && CWD_CHANGING_COMMANDS.has(command);
+}
+
 function shouldAttach(payload: unknown): boolean {
   if (!isObject(payload) || !isShellTool(payloadToolName(payload))) {
     return false;
@@ -92,12 +122,15 @@ function shouldAttach(payload: unknown): boolean {
   if (typeof source !== "string" && (!Array.isArray(source) || !source.every((v) => typeof v === "string"))) {
     return false;
   }
-  const call: ToolCall = { name: String(payloadToolName(payload)), shell: true, input: { command: source } };
-  const invocations = toolCallInvocations(call);
-  if (invocations.length !== 1) {
+  if (containsHeredoc(source)) {
     return false;
   }
-  return classifyPush(invocations[0]).attach;
+  const call: ToolCall = { name: String(payloadToolName(payload)), shell: true, input: { command: source } };
+  const invocations = toolCallInvocations(call).map(stripShellRedirections);
+  if (invocations.some(changesWorkingDirectory)) {
+    return false;
+  }
+  return invocations.some((argv) => classifyPush(argv).attach);
 }
 
 export async function runHookPrePush(ctx: CommandContext, deps: HookPrePushDeps = defaultHookPrePushDeps): Promise<number> {

--- a/src/pr/gitWrite.ts
+++ b/src/pr/gitWrite.ts
@@ -530,6 +530,34 @@ export function toolCallInvocations(call: ToolCall): string[][] {
   return resolveInvocations(rawInvocations(call.input));
 }
 
+const SHELL_FD_DUPLICATION_RE = /^(?:\d*)>&\d+$/;
+const SHELL_REDIRECTION_OPERATOR_RE = /^(?:\d*(?:>>?|<)|&>>?)$/;
+const SHELL_ATTACHED_REDIRECTION_RE = /^(?:\d*(?:>>?|<)|&>>?).+$/;
+
+/**
+ * Remove shell redirections from one tokenized argv before classifying the
+ * command itself. A standalone operator consumes its following filename;
+ * attached filenames and fd duplications occupy only their own token.
+ */
+export function stripShellRedirections(argv: string[]): string[] {
+  const stripped: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (SHELL_FD_DUPLICATION_RE.test(token)) {
+      continue;
+    }
+    if (SHELL_REDIRECTION_OPERATOR_RE.test(token)) {
+      i++;
+      continue;
+    }
+    if (SHELL_ATTACHED_REDIRECTION_RE.test(token)) {
+      continue;
+    }
+    stripped.push(token);
+  }
+  return stripped;
+}
+
 /** True if `argv` is a real `codex exec …` invocation (argv[0] is `codex`, first non-option token is `exec`). */
 export function isCodexExec(argv: string[]): boolean {
   if (argv.length === 0 || path.basename(argv[0]) !== "codex") {

--- a/src/setup/integrations.ts
+++ b/src/setup/integrations.ts
@@ -30,7 +30,7 @@ const AGENT_PRE_PUSH_HOOK_JSON = [
   '        "hooks": [',
   "          {",
   '            "type": "command",',
-  '            "command": "npx -y aireceipts-cli@latest hook pre-push",',
+  '            "command": "npx -y aireceipts-cli@latest hook pre-push || true",',
   '            "timeout": 60',
   "          }",
   "        ]",

--- a/test/cli/hook-pre-push.test.ts
+++ b/test/cli/hook-pre-push.test.ts
@@ -72,6 +72,13 @@ describe("SPEC-0073 hook pre-push command", () => {
     { tool_name: "exec_command", tool_input: { cmd: "git push origin feat" } },
     { name: "functions.exec_command", arguments: JSON.stringify({ command: ["git", "push", "origin", "feat"] }) },
     { tool_name: "Bash", command: "git push origin feat" },
+    claudePayload("git add -A && git commit -m msg && git push -u origin feat/x"),
+    claudePayload("git push origin feat/x && gh pr create --fill"),
+    claudePayload("git push -u origin feat/x 2>&1"),
+    claudePayload("git commit -m x; git push 2>&1 | tail -3"),
+    claudePayload("npm test && git push"),
+    claudePayload("git push -u origin HEAD 2>&1 | tee /tmp/push.log"),
+    claudePayload("git push && git push origin feat/x"),
   ])("attaches silently for branch push payload %#", async (payload) => {
     const result = await runPayload(payload);
     expect(result).toEqual({ code: 0, out: "", err: "", attaches: ["/repo"] });
@@ -104,8 +111,13 @@ describe("SPEC-0073 hook pre-push command", () => {
     claudePayload("git -C sub push origin feat"),
     claudePayload("git --git-dir=/other/.git --work-tree=/other push origin feat"),
     claudePayload('echo "git push"'),
+    claudePayload('echo "git push origin main && more"'),
     claudePayload("cat <<'EOF'\ngit push\nEOF"),
-    claudePayload("npm test && git push"),
+    claudePayload("cd /elsewhere && git push"),
+    claudePayload("MODE=quiet cd /elsewhere && git push"),
+    claudePayload("git push; cd /elsewhere"),
+    claudePayload("pushd /elsewhere && git push && popd"),
+    claudePayload("git push --dry-run 2>&1"),
     { tool_name: "Read", tool_input: { command: "git push" } },
     {},
     "",

--- a/test/pr/gitWrite.test.ts
+++ b/test/pr/gitWrite.test.ts
@@ -2,7 +2,15 @@
 // authorship. The load-bearing case: an orchestrator running
 // `codex exec "…git push…"` must NEVER be read as a real push.
 import { describe, expect, it } from "vitest";
-import { classifyPush, gitWriteVerb, hexRuns, matchesBranchSha, toolCallGitVerb, toolCallInvocations } from "../../src/pr/gitWrite.js";
+import {
+  classifyPush,
+  gitWriteVerb,
+  hexRuns,
+  matchesBranchSha,
+  stripShellRedirections,
+  toolCallGitVerb,
+  toolCallInvocations,
+} from "../../src/pr/gitWrite.js";
 import type { ToolCall } from "../../src/parse/types.js";
 
 describe("gitWriteVerb (tokenized argv)", () => {
@@ -105,7 +113,7 @@ describe("SPEC-0073 classifyPush", () => {
     expect(classifyPush(argv).attach).toBe(false);
   });
 
-  it("uses the tokenized invocation view so quoted, heredoc, and compound pushes do not attach", () => {
+  it("uses the tokenized invocation view so quoted and heredoc pushes do not attach", () => {
     const attaches = (command: string) => {
       const call: ToolCall = { name: "Bash", shell: true, input: { command } };
       const invocations = toolCallInvocations(call);
@@ -114,7 +122,39 @@ describe("SPEC-0073 classifyPush", () => {
 
     expect(attaches('echo "git push"')).toBe(false);
     expect(attaches("cat <<'EOF'\ngit push\nEOF")).toBe(false);
-    expect(attaches("npm test && git push")).toBe(false);
+  });
+});
+
+describe("stripShellRedirections", () => {
+  it.each([
+    [["git", "push", ">", "/tmp/out"], ["git", "push"]],
+    [["git", "push", ">>", "/tmp/out"], ["git", "push"]],
+    [["git", "push", "<", "/tmp/in"], ["git", "push"]],
+    [["git", "push", "&>", "/tmp/all"], ["git", "push"]],
+    [["git", "push", "&>>", "/tmp/all"], ["git", "push"]],
+    [["git", "push", "2>", "/tmp/err"], ["git", "push"]],
+    [["git", "push", "3>>", "/tmp/trace"], ["git", "push"]],
+  ])("strips a standalone operator and its filename from argv %j", (argv, expected) => {
+    expect(stripShellRedirections(argv)).toEqual(expected);
+  });
+
+  it("strips attached redirections without consuming the following argv", () => {
+    expect(stripShellRedirections(["git", "push", ">/tmp/out", "2>err.log", "3>>trace.log", "<input", "&>all.log", "&>>append.log", "origin", "feat"])).toEqual([
+      "git",
+      "push",
+      "origin",
+      "feat",
+    ]);
+  });
+
+  it("distinguishes descriptor duplication from file redirection", () => {
+    expect(stripShellRedirections(["git", "push", "2>&1", "origin", "feat"])).toEqual(["git", "push", "origin", "feat"]);
+    expect(stripShellRedirections(["git", "push", ">&2", "origin", "feat"])).toEqual(["git", "push", "origin", "feat"]);
+    expect(stripShellRedirections(["git", "push", "2>file", "origin", "feat"])).toEqual(["git", "push", "origin", "feat"]);
+  });
+
+  it("strips a standalone operator plus a quoted filename token", () => {
+    expect(stripShellRedirections(["git", "push", ">", "a b.txt", "origin", "feat"])).toEqual(["git", "push", "origin", "feat"]);
   });
 });
 


### PR DESCRIPTION
## What this adds

Fixes #241: SPEC-0073 auto-attach now fires for the commands coding agents actually run — chained (`git add && git commit && git push`) and redirected (`git push 2>&1 | tail`) pushes — plus a hardened adopter kit whose hook can never block a push.

## Why it matters to users

- Agent-built PRs finally get their receipt refs automatically; until now the hook effectively never fired from agent sessions (the org dogfood produced **zero** refs across 21 instrumented repos).
- A registry outage or npx failure in the hook can no longer block `git push` (kit templates now `|| true`).

## See it

Pre-fix, the exact payload from a real agent push was refused; post-fix it attaches:

```
"git push -u origin release/v0.9.0 2>&1 | tail -2" → invocations: 2 → REFUSED   (before)
"git add -A && git commit -m msg && git push -u origin feat/x" → attaches once  (after)
"cd /elsewhere && git push" → still refused (cwd veto)
"git push --dry-run 2>&1" → still refused (redirect cannot make a non-attach attachable)
```

(Full battery in `test/cli/hook-pre-push.test.ts`; 7 cases red pre-fix.)

## What changed

- `src/cli/commands/hook-pre-push.ts` — `shouldAttach`: strip redirections per invocation, attach on ≥1 attachable push, veto on any `cd`/`pushd`/`popd`, explicit heredoc guard
- `src/pr/gitWrite.ts` — `stripShellRedirections` (hook-scoped helper; fd-dup, standalone-operator+filename, attached forms)
- `docs/adopt/*.json` + `docs/pr-receipts.md` (+site) — kit commands end `|| true`, with the why
- `specs/SPEC-0073-agent-prepush-hook.md` — R1 amended with the sharpened rule + matrix rows

## What to review, in order

1. `src/cli/commands/hook-pre-push.ts` `shouldAttach` — the riskiest call: `some(attach)` + unordered `cd` veto (chains can't be safely ordered, so any cwd change refuses).
2. `stripShellRedirections` in `src/pr/gitWrite.ts` — used ONLY by the hook; anchors/perCommit consumers untouched.
3. SPEC-0073 amendment vs the previous "&&-chains → no action" reading.

## Evidence

- Gates: tsc 0 / eslint 0 / vitest 2,182 pass / goldens 102 byte-identical / spec-lint 78.
- Red-then-green: 7 new payload cases failed pre-fix for the right reason.
- Mutation on touched files: **71.96%** (≥60% threshold; baseline 68.24% — no decrease).
- Builder: Codex (tests-first); reviewer: Claude Fable — different model families.

## Notes

- Ships as `aireceipts-cli@0.9.1`; org hooks run `@latest` and pick it up with no further org changes (21 repos instrumented + hardened tonight).
- The org-rollout review bots independently confirmed the kit exit-0 gap; addressed both here (templates) and in all 21 org repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
