### PR TITLE
chore: prepare v0.9.1 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ No duplicated truths: one renderer, one price schema, one numbering scheme for s
 *Updated only by the `release` skill. Keep this section, and only this section, current
 after each release — don't hand-edit it elsewhere.*
 
-- **Shipped (npm `aireceipts-cli`, v0.9.0):** the receipt engine and its whole surface
+- **Shipped (npm `aireceipts-cli`, v0.9.1):** the receipt engine and its whole surface
   are live — parse adapters (Claude Code, Codex, Cursor, Gemini, opencode), cited price
   tables, per-tool attribution, waste lines (stuck-loop, trivial-spans, context-thrash
   incl. Codex compactions), price-delta + routable-spend (now with `% less`), `compare`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to `aireceipts-cli`. Factual, grouped by conventional-commit
 type (I6: a log, not marketing). Dates are UTC.
 
+## v0.9.1 — 2026-07-13
+
+Patch: **the SPEC-0073 auto-attach hook now fires for the commands coding agents
+actually run** (fixes #241, PR #252). `hook pre-push` previously refused any Bash
+command with more than one tokenized invocation, and a trailing `2>&1` defeated
+even a single plain push — so chained agent pushes (`git add && git commit && git
+push`, `git push 2>&1 | tail`) never attached a receipt ref. The issue's "worktree"
+correlation was an agent-command-style correlation. Now: shell redirections are
+stripped per invocation, the hook attaches once when at least one invocation is an
+unambiguous branch push, any `cd`/`pushd`/`popd` in the command still refuses (the
+push may target a different repo than the hook's cwd), and heredoc payloads keep
+refusing via an explicit guard. SPEC-0073 R1 amended accordingly.
+
+Also hardened the adopter kit (org-rollout review finding): the hook commands in
+`docs/adopt/claude-settings.json`, `docs/adopt/codex-hooks.json`, the
+`docs/pr-receipts.md` snippets, and the `integrations` command's recipes now end
+`|| true` — an `npx`/registry failure can never block a push.
+
 ## v0.9.0 — 2026-07-13
 
 Minor: **receipt dollars are now explicit observable lower bounds — `≥ $X`, never an

--- a/docs/releases/0.9.1-verdict.md
+++ b/docs/releases/0.9.1-verdict.md
@@ -1,0 +1,55 @@
+# Release verdict — v0.9.1
+
+- **Candidate version:** 0.9.1 (patch)
+- **Content SHA:** `b3ee51b` (HEAD of `main` after #252)
+- **Changelog range:** `v0.9.0..b3ee51b` — one squashed fix commit (#252, fixes #241).
+- **Bump rationale:** PATCH — one bug fix in the SPEC-0073 hook's push classification
+  plus adopter-kit hardening (docs + the `integrations` recipe string). Receipt
+  rendering is untouched: all 102 goldens byte-identical; no schema, pricing, or
+  parser change.
+- **Date:** 2026-07-13 (UTC)
+
+## Right-sizing (v0.8.2 precedent — the lenses with signal ran; the rest skipped)
+
+- **PM lens (skipped):** single-fix patch; the changelog entry is the story. The
+  urgency is real, not manufactured: 21 org dogfood repos are instrumented with
+  hooks pinned to `@latest` waiting on exactly this fix.
+- **Designer lens (skipped):** goldens byte-identical; no rendered artifact changed.
+- **QA lens (RAN, inside PR #252):** tests-first battery of real agent payloads —
+  chained (`&&`, `;`), piped, redirected (`2>&1`, `tee`), cwd-changing (`cd`/`pushd`),
+  heredoc, quoted, `--dry-run`-with-redirect, retargeting forms. 7 cases red pre-fix
+  for the right reason; 2,182 tests green post-fix. The failure mode this fixes was
+  reproduced live from a real worktree session before any code changed (empirical
+  root-cause in #241's PR discussion).
+- **EM lens (mechanical, RAN):** zero dependency delta; rollback = pin `0.9.0`
+  (no persisted-state change); CI green on `b3ee51b` for all required checks except
+  `mutation-pr`, which the maintainer explicitly waived for the merge — the same
+  mutation run had already passed locally on identical content: **71.96%** on the
+  two touched files (≥ 60% threshold, no decrease vs the 68.24% full-set baseline).
+  One process finding recorded: the SPEC-0050 parity test caught the kit hardening
+  missing from the `integrations` recipe on the first CI run — fixed in the same PR
+  before merge, which is the gate working as designed.
+- **Builder ≠ critic:** Codex (GPT-5) built the fix tests-first; Claude (Fable)
+  independently reviewed the implementation, verified red-then-green, and ran the
+  mutation gate. Different model families.
+
+## Mechanical checks (on this candidate)
+
+- `node scripts/preflight-release.mjs` (full): PASS — build, tarball shape +
+  install-and-run e2e, goldens, determinism ×10, spec-lint 78 (includes the parked
+  SPEC-0081 with its Validation/Tombstone record), hygiene, tsc, eslint, vitest,
+  cite-check live.
+- Version/manifest: `package.json` 0.9.1 == tag to be minted by the workflow.
+- Changelog section present (Release job reads it).
+
+## Open risks (tracked, non-blocking)
+
+- Substring-`*push*` pre-filter in the org hook wrapper spawns npx on non-push
+  commands containing "push" — cost is one warm npx no-op; accepted trade-off,
+  documented in the org PR replies.
+- PowerShell-native Claude Code installs can't run the `case…esac` wrapper — the
+  plain kit command (no wrapper) works there; cross-shell wrapper tracked as
+  adopter-kit follow-up.
+- Pre-existing: #237, #170, #246–#250 (unchanged by this range).
+
+VERDICT: GO

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aireceipts-cli",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@resvg/resvg-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aireceipts-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Your AI coding agent used millions of tokens. Here is the observable cost floor.",
   "keywords": [
     "ai",

--- a/site/docs/CHANGELOG.html
+++ b/site/docs/CHANGELOG.html
@@ -336,6 +336,12 @@ footer{
 
 <p>All notable changes to <code>aireceipts-cli</code>. Factual, grouped by conventional-commit type (I6: a log, not marketing). Dates are UTC.</p>
 
+<h2 id="v091-2026-07-13">v0.9.1 — 2026-07-13</h2>
+
+<p>Patch: <strong>the SPEC-0073 auto-attach hook now fires for the commands coding agents actually run</strong> (fixes #241, PR #252). <code>hook pre-push</code> previously refused any Bash command with more than one tokenized invocation, and a trailing <code>2&gt;&amp;1</code> defeated even a single plain push — so chained agent pushes (<code>git add &amp;&amp; git commit &amp;&amp; git push</code>, <code>git push 2&gt;&amp;1 | tail</code>) never attached a receipt ref. The issue's &quot;worktree&quot; correlation was an agent-command-style correlation. Now: shell redirections are stripped per invocation, the hook attaches once when at least one invocation is an unambiguous branch push, any <code>cd</code>/<code>pushd</code>/<code>popd</code> in the command still refuses (the push may target a different repo than the hook's cwd), and heredoc payloads keep refusing via an explicit guard. SPEC-0073 R1 amended accordingly.</p>
+
+<p>Also hardened the adopter kit (org-rollout review finding): the hook commands in <code>docs/adopt/claude-settings.json</code>, <code>docs/adopt/codex-hooks.json</code>, the <code>docs/pr-receipts.md</code> snippets, and the <code>integrations</code> command's recipes now end <code>|| true</code> — an <code>npx</code>/registry failure can never block a push.</p>
+
 <h2 id="v090-2026-07-13">v0.9.0 — 2026-07-13</h2>
 
 <p>Minor: <strong>receipt dollars are now explicit observable lower bounds — <code>≥ $X</code>, never an exact-looking bill — and the <code>--json</code> export schema moves to v2 to say so in a machine-readable way.</strong> A second, deeper cost-correctness pass after v0.7.1's #196: PR #242 fixed real undercounting (a commit/amend truncation had sliced a <code>$0.44</code> receipt out of work independently reconstructed at <code>≥ $44.97</code>, issue #239) and made every surface state what the number is and what it excludes.</p>

--- a/specs/SPEC-0081-first-run-conversion.md
+++ b/specs/SPEC-0081-first-run-conversion.md
@@ -1,0 +1,140 @@
+---
+id: SPEC-0081
+title: First-run conversion — the npx moment renders value or a next step, never a dead end
+status: rejected
+milestone: M6
+depends: [SPEC-0043]
+---
+
+# SPEC-0081: First-run conversion — the npx moment
+
+## Purpose
+
+The 2026-07-10/11 announcement cohort (App Insights, content-free events) shows the
+funnel dying at the first command: 22 new installs; 20 `receipt`-class runs of which
+**13 exited non-zero**; 11 `--help` runs; **2** `install-hook` runs; **zero**
+`receipt_generated`. Two product causes and one measurement cause: (a) the
+no-session path prints a five-path directory dump with a `--demo` pointer nobody
+takes (`src/cli/common/session.ts:24`); (b) failures on machines *with* odd agent
+state exit non-zero with no recovery path; (c) `setup` and `integrations` are
+invisible to telemetry — they are absent from `COMMAND_VALUES`
+(`src/telemetry/schemas.ts:19`) and dropped at `src/telemetry/index.ts:69` — so the
+setup step of the funnel cannot be measured at all. This spec makes the first 60
+seconds land and makes the funnel measurable. Serves I2/I6 (a demo must never be
+mistakable for the user's own dollars) and SPEC-0043 (telemetry stays content-free).
+
+## Requirements
+
+- **R1 — no-session TTY path renders the demo receipt, bannered.** When session
+  discovery finds nothing and stdout is a TTY, render the `--demo` receipt directly,
+  topped and tailed by an unmissable banner line (`SAMPLE RECEIPT — not your data`,
+  exact copy in the golden) plus a three-line next-step ladder: run your agent once →
+  re-run `aireceipts` → `aireceipts install-hook` for always-on. Non-TTY (piped/CI)
+  keeps a terse machine-friendly message and exit 0 — never the demo (a script must
+  not ingest sample numbers; I2). The five-path directory dump moves behind
+  `--verbose`; default copy is ≤ 4 lines before the sample.
+- **R2 — every no-match failure carries a next step.** A selector that matches
+  nothing, an unreadable store, or a discovery error must print one actionable line
+  (what was looked for, the closest command that would work: `--list`, `--demo`,
+  `--verbose`) before exiting. No bare non-zero exits on the first-run surface
+  (`receipt`, `--list`, `--mini`, `setup`).
+- **R3 — `setup` and `integrations` join the `cli_run` catalog.** Add both to
+  `COMMAND_VALUES` with the standard content-free dimensions only. This closes the
+  docs-audit finding (docs/telemetry.md currently documents the gap) and makes the
+  install → configure funnel measurable. `docs/telemetry.md` updated in the same PR.
+- **R4 — `--quota` / `--check-budget` say so when there is nothing to report
+  (#248).** On a TTY, one stderr line each (`no Claude Code quota data found` /
+  `no budget.json — see docs/guide/08-budget.md`), exit code unchanged. Hook mode
+  (non-TTY stdout) keeps byte-silence — those surfaces are parsed.
+- **R5 — funnel instrumentation proves the fix.** `activation_milestone` (existing
+  event) gains `first_run_demo_shown` and `first_run_next_step_shown` milestone
+  values (booleans/enums only — no new identifying dimensions, I4). Kill criterion
+  reads from these.
+
+## Scenarios
+
+- **Given** a fresh machine with no agent transcripts and a TTY, **When** the user
+  runs `npx aireceipts-cli`, **Then** they see the bannered sample receipt and the
+  three-line ladder, exit 0.
+- **Given** the same machine but stdout piped, **When** `aireceipts | cat` runs,
+  **Then** output is the terse no-session message only — no sample dollars.
+- **Given** sessions exist but a positional selector matches nothing, **When**
+  `aireceipts zzz` runs, **Then** stderr names the selector, suggests `--list`, and
+  the exit code is non-zero exactly as today.
+- **Given** a TTY and no `budget.json`, **When** `aireceipts --check-budget` runs,
+  **Then** stderr says so in one line and exit is 0; **When** the same command runs
+  with stdout piped, **Then** it is byte-silent.
+
+## Non-goals
+
+- Changing which session "newest" selects (#247) — separate fix, orthogonal.
+- A TUI wizard or interactive prompts — `npx` first runs are frequently in agent
+  shells; prompts would hang them.
+- Auto-installing the hook or writing any file on first run — configuration stays an
+  explicit user action.
+- Docs polish items from #249 — tracked there.
+
+## Test matrix
+
+| Case | Input | Expected |
+|---|---|---|
+| R1 TTY no sessions | bare run, empty sandbox HOME, TTY | bannered demo + ladder, exit 0 |
+| R1 piped no sessions | same, stdout piped | terse message, no `$`, exit 0 |
+| R2 no-match selector | `aireceipts zzz` with sessions present | actionable stderr, non-zero |
+| R3 catalog | `setup` run with telemetry test transport | one `cli_run` with `commandClass: "setup"` |
+| R4 quota TTY empty | `--quota`, no data, TTY | one stderr line, exit 0 |
+| R4 quota hook mode | `--quota`, no data, piped | byte-silent, exit 0 |
+| banner golden | demo-fallback render | golden byte-pins banner top+tail |
+| R5 milestones | demo fallback + ladder shown, test transport | one `activation_milestone` each for `first_run_demo_shown` / `first_run_next_step_shown`; no `receipt_generated` |
+
+## Success criteria
+
+- [ ] R1–R5 implemented with the tests above; new goldens for the bannered fallback.
+- [ ] `docs/telemetry.md`, `docs/guide/01-getting-started.md` updated in the same PR.
+- [ ] Kill criterion recorded at ship time: if <10% of new non-CI installs reach
+      `receipt_generated` or `hook_configured` within 7 days of first_seen over the
+      30 days post-release, this approach is wrong — revisit or revert.
+- [ ] `npx tsc --noEmit`, `npx eslint . --max-warnings 0`, `npx vitest run`,
+      `node scripts/verify-goldens.mjs` all pass unmasked (`echo $?`).
+
+## Validation
+
+- **Date:** 2026-07-13 (same-day as draft).
+- **S1:** initially passed on measurability/I2, but the causal chain was over-claimed —
+  see S2 finding 1.
+- **S2 (Codex, independent context): 7 findings, all accepted.** (1) The 13 non-zero
+  `receipt` runs cannot be the bare no-session path — that path exits 0
+  (`src/cli/commands/receipt.ts:51`); the diagnosis was hypothesis stated as fact.
+  (2) R3 measures "setup report viewed," not "configured" — the funnel claim was
+  inflated. (3) R5's kill criterion has no baseline and a ~22-install denominator —
+  statistically meaningless. (4) Test matrix missed large parts of R1–R5.
+  (5) R2 requires a cross-adapter error taxonomy — a different, bigger spec.
+  (6) `--verbose` doesn't exist — a new flag smuggled in. (7) R4 reverses SPEC-0014's
+  and SPEC-0009's deliberate silence contracts.
+- **S3 worth:** Who/how often — unknown; the cohort's failure cause is unproven and
+  post-hoc `cli_error` query returns zero events for the cohort (the failures were
+  controlled non-zero exits, most plausibly no-match selectors — but that is still a
+  hypothesis). Do-nothing — the current path exits 0, names roots, points to
+  `--demo`; mildly verbose, not a dead end. Smaller fix — (a) add `setup`/
+  `integrations` to `COMMAND_VALUES` (independent 2-enum change, already a docs-audit
+  finding) and (b) instrument controlled non-zero exits with a content-free
+  `exitClass` so the next launch window yields a real diagnosis; optionally (c) a
+  copy-only tightening of the no-session message. Steelman-the-cut: building a
+  conversion feature on an unproven diagnosis with an unmeasurable success criterion
+  is exactly the over-eager-spec failure this gate exists to catch.
+  **Verdict: defer.**
+- **S4:** spec-lint pass.
+
+## Tombstone
+
+Parked 2026-07-13 after S2/S3. What was tried: a guided first-run (TTY demo fallback +
+next-step ladder + funnel telemetry) motivated by the 2026-07-10/11 launch cohort's
+13 failed receipt runs. Why rejected: the failure diagnosis is unproven (the bare
+no-session path exits 0 and no `cli_error` events exist for the cohort), the proposed
+kill criterion is unmeasurable at current install volume, R2 hid a cross-adapter error
+taxonomy, and R4 reversed deliberate SPEC-0014/0009 contracts. What would change the
+answer: instrument controlled non-zero exits first (content-free `exitClass` on
+`cli_run` or a new small spec), collect one more launch window of data, and respec the
+narrow intervention the evidence actually names. The two extracted slices —
+`setup`/`integrations` in `COMMAND_VALUES`, and exit-class instrumentation — are small
+enough to ship without this spec.


### PR DESCRIPTION
## What this adds

The v0.9.1 release preparation: version bump, changelog, the right-sized GO verdict, AGENTS.md version tick, and the parked SPEC-0081 validation record.

## Why it matters to users

- Ships the #241 fix (#252) to npm: agent-style chained/redirected pushes finally auto-attach receipt refs. 21 AltimateAI dogfood repos run the hook pinned to `@latest` and activate the moment this publishes.

## See it

```
## v0.9.1 — 2026-07-13

Patch: **the SPEC-0073 auto-attach hook now fires for the commands coding agents
actually run** (fixes #241, PR #252).
```

(Full section in `docs/CHANGELOG.md`; verdict in `docs/releases/0.9.1-verdict.md`.)

## What changed

- `package.json` / `package-lock.json` → 0.9.1
- `docs/CHANGELOG.md` + regenerated `site/docs/CHANGELOG.html`
- `docs/releases/0.9.1-verdict.md` — right-sized patch verdict (v0.8.2 precedent), `VERDICT: GO` for content SHA `b3ee51b`
- `AGENTS.md` — inventory version tick
- `specs/SPEC-0081-first-run-conversion.md` — NEW, `status: rejected`: the first-run-conversion draft parked with its full S1–S4 Validation + Tombstone (S2 critic proved the launch-cohort failure diagnosis unproven; extracted small slices tracked for a future PR)

## What to review, in order

1. `docs/releases/0.9.1-verdict.md` — including the recorded mutation-check waiver on the #252 merge (local score 71.96% on identical content).
2. The changelog section wording.
3. SPEC-0081's Tombstone — confirm you agree with the defer.

## Evidence

- Preflight on this branch: **RELEASE-READY — 11 checks passed** (spec-lint 78 includes SPEC-0081).
- CI green on content SHA `b3ee51b` (all required checks; mutation waived at merge by the maintainer with the local run recorded).

## Notes

- After merge: dispatch `release-publish.yml` on `main` — publishes `aireceipts-cli@0.9.1` with OIDC provenance, mints the tag + Release. Dispatch is pre-authorized this session ("release the fix also").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
