### PR TITLE
fix: harden PR-receipt attach pipeline (globs, hooksPath self-heal)

### DIFF
--- a/.claude/hooks/ensure-githooks.sh
+++ b/.claude/hooks/ensure-githooks.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SessionStart: keep the receipt pipeline's first link alive. The pre-push hook
+# (.githooks/pre-push) is what pushes refs/aireceipts/<slug>; it only runs if
+# core.hooksPath resolves to a directory that actually contains it.
+#
+# Failure mode this repairs (2026-07-13 incident): an ABSOLUTE hooksPath welds
+# every worktree to the main checkout's working tree — if that checkout sits on
+# a branch predating .githooks/pre-push, NO worktree runs the hook and receipts
+# silently stop attaching. A RELATIVE value resolves per-worktree, so each
+# checkout uses its own tracked hook.
+#
+# Fail-safe: never blocks the session, always exits 0.
+current=$(git config core.hooksPath 2>/dev/null)
+if [ "$current" != ".githooks" ]; then
+  git config core.hooksPath .githooks 2>/dev/null || true
+  echo "aireceipts: repaired core.hooksPath ('${current:-unset}' -> '.githooks')"
+fi
+hook_dir=$(git rev-parse --git-path hooks 2>/dev/null)
+if [ -n "$hook_dir" ] && [ ! -x "$hook_dir/pre-push" ]; then
+  echo "aireceipts: WARNING — no executable pre-push at '$hook_dir'; branch pushes will not attach receipt refs (this checkout may predate .githooks/pre-push)"
+fi
+exit 0

--- a/.claude/hooks/ensure-githooks.sh
+++ b/.claude/hooks/ensure-githooks.sh
@@ -4,19 +4,45 @@
 # core.hooksPath resolves to a directory that actually contains it.
 #
 # Failure mode this repairs (2026-07-13 incident): an ABSOLUTE hooksPath welds
-# every worktree to the main checkout's working tree — if that checkout sits on
-# a branch predating .githooks/pre-push, NO worktree runs the hook and receipts
-# silently stop attaching. A RELATIVE value resolves per-worktree, so each
-# checkout uses its own tracked hook.
+# every worktree to one checkout's working tree. If that checkout sits on a
+# branch predating .githooks/pre-push, NO worktree runs the hook and receipts
+# silently stop attaching. A RELATIVE value resolves per-worktree.
 #
-# Fail-safe: never blocks the session, always exits 0.
-current=$(git config core.hooksPath 2>/dev/null)
-if [ "$current" != ".githooks" ]; then
-  git config core.hooksPath .githooks 2>/dev/null || true
-  echo "aireceipts: repaired core.hooksPath ('${current:-unset}' -> '.githooks')"
-fi
-hook_dir=$(git rev-parse --git-path hooks 2>/dev/null)
-if [ -n "$hook_dir" ] && [ ! -x "$hook_dir/pre-push" ]; then
-  echo "aireceipts: WARNING — no executable pre-push at '$hook_dir'; branch pushes will not attach receipt refs (this checkout may predate .githooks/pre-push)"
+# Safety (Codex review, 2026-07-13): every git call is bound to
+# $CLAUDE_PROJECT_DIR, never the session cwd, so this can only ever touch the
+# repo that ships this script. Only two values are repaired: unset, and an
+# absolute ".githooks" variant (our own convention gone stale). Any other
+# value is a deliberate hooks manager (husky, a central dispatcher): warn,
+# never overwrite. Fail-safe: never blocks the session, always exits 0.
+root="${CLAUDE_PROJECT_DIR:-}"
+[ -n "$root" ] || exit 0
+# Operate only on a checkout of this repo: the tracked hook must be present.
+[ -f "$root/.githooks/pre-push" ] || exit 0
+git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+current=$(git -C "$root" config core.hooksPath 2>/dev/null)
+case "$current" in
+  ".githooks") ;; # healthy
+  "" | */.githooks)
+    git -C "$root" config core.hooksPath .githooks 2>/dev/null || true
+    if [ "$(git -C "$root" config core.hooksPath 2>/dev/null)" = ".githooks" ]; then
+      echo "aireceipts: repaired core.hooksPath ('${current:-unset}' -> '.githooks')"
+    else
+      echo "aireceipts: WARNING: could not repair core.hooksPath (still '${current:-unset}'); branch pushes may not attach receipt refs"
+    fi
+    ;;
+  *)
+    echo "aireceipts: NOTE: core.hooksPath is '$current' (a custom hooks setup, left untouched); the receipt pre-push hook in .githooks will not run"
+    ;;
+esac
+
+hooks_dir=$(git -C "$root" rev-parse --git-path hooks 2>/dev/null)
+case "$hooks_dir" in
+  "") ;;
+  /*) ;;
+  *) hooks_dir="$root/$hooks_dir" ;;
+esac
+if [ -n "$hooks_dir" ] && [ ! -x "$hooks_dir/pre-push" ]; then
+  echo "aireceipts: WARNING: no executable pre-push at '$hooks_dir'; branch pushes will not attach receipt refs"
 fi
 exit 0

--- a/.claude/hooks/ensure-githooks.sh
+++ b/.claude/hooks/ensure-githooks.sh
@@ -23,7 +23,10 @@ git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 current=$(git -C "$root" config core.hooksPath 2>/dev/null)
 case "$current" in
   ".githooks") ;; # healthy
-  "" | */.githooks)
+  "" | /*/.githooks)
+    # Unset, or an ABSOLUTE ".githooks" (our own convention gone stale, the
+    # 2026-07-13 poison). A relative custom path like "tools/.githooks" is a
+    # deliberate setup and falls through to the NOTE branch below.
     git -C "$root" config core.hooksPath .githooks 2>/dev/null || true
     if [ "$(git -C "$root" config core.hooksPath 2>/dev/null)" = ".githooks" ]; then
       echo "aireceipts: repaired core.hooksPath ('${current:-unset}' -> '.githooks')"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/ensure-githooks.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write|MultiEdit",

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,7 +4,7 @@
 # (run `npm run setup:hooks`; SPEC-0065 R3).
 #
 # RECURSION GUARD: this hook runs `aireceipts pr --store ref --push-ref`, which
-# does a nested `git push` of `refs/receipts/<slug>` (see `pushReceiptRef` in
+# does a nested `git push` of `refs/aireceipts/<slug>` (see `pushReceiptRef` in
 # src/pr/store.ts). That nested push re-invokes this same hook. We act only when
 # the ORIGINAL push targets a branch — a stdin line whose LOCAL or REMOTE ref is
 # `refs/heads/*` (a refspec like `HEAD^:refs/heads/main` names the branch only on

--- a/.github/workflows/pr-receipt-check.yml
+++ b/.github/workflows/pr-receipt-check.yml
@@ -1,9 +1,11 @@
 # SPEC-0019 R5 + SPEC-0066 — the PR receipt check. A receipt is GENERATED on the
 # developer's machine (transcripts never reach the runner, I1/I4). This workflow only
-# transports it: if the branch carries a git-ref receipt (refs/receipts/<slug>, written by
+# transports it: if the branch carries a git-ref receipt (refs/aireceipts/<slug>, written by
 # the local store=ref producer / pre-push hook), CI fetches + SANITIZES + renders it, then
 # posts the comment. A receipt posted locally (`pr --post`) is honored as-is. Notice-only
 # by default; opt into same-repo enforcement with AIRECEIPTS_REQUIRE_PR_RECEIPT=true.
+# Enforcement skips branches matching AIRECEIPTS_RECEIPT_EXEMPT_GLOBS (default `release/*`):
+# release checkouts have no capturable agent session, so no receipt is expected there.
 #
 # TRUST BOUNDARY (Codex review). The untrusted, mutable `@latest` npm package renders in a
 # SEPARATE JOB (`render`) that has NO write token and only `contents: read`; its output
@@ -91,7 +93,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           REQUIRE_PR_RECEIPT: ${{ vars.AIRECEIPTS_REQUIRE_PR_RECEIPT }}
+          RECEIPT_EXEMPT_GLOBS: ${{ vars.AIRECEIPTS_RECEIPT_EXEMPT_GLOBS }}
         run: |
           set -uo pipefail
           MARKER='<!-- aireceipts-dogfood -->'
@@ -100,7 +104,9 @@ jobs:
           receipt_verdict() {
             gh api --paginate "repos/${BASE_REPO}/issues/${PR_NUMBER}/comments" > comments.json || echo "[]" > comments.json
             args=(comments.json --head-repo "$HEAD_REPO" --base-repo "$BASE_REPO")
-            if [ "${REQUIRE_PR_RECEIPT:-}" = "true" ]; then args+=(--require-same-repo); fi
+            if [ "${REQUIRE_PR_RECEIPT:-}" = "true" ]; then
+              args+=(--require-same-repo --head-ref "$HEAD_REF" --exempt-globs "${RECEIPT_EXEMPT_GLOBS:-release/*}")
+            fi
             node scripts/check-pr-receipt.mjs "${args[@]}"
           }
 

--- a/scripts/check-pr-receipt.mjs
+++ b/scripts/check-pr-receipt.mjs
@@ -41,7 +41,13 @@ export function isExemptRef(headRef, exemptGlobs) {
   return exemptGlobs
     .split(/\s+/)
     .filter(Boolean)
-    .some((glob) => new RegExp(`^${glob.split("*").map(escapeRegExp).join(".*")}$`).test(headRef));
+    .some((glob) => {
+      // Collapse `*` runs: `a**b` and `a*b` match the same strings, and the
+      // collapsed form can't compile to adjacent `.*.*` (catastrophic
+      // backtracking on long non-matching refs).
+      const pattern = glob.replace(/\*+/g, "*").split("*").map(escapeRegExp).join(".*");
+      return new RegExp(`^${pattern}$`).test(headRef);
+    });
 }
 
 /**

--- a/scripts/check-pr-receipt.mjs
+++ b/scripts/check-pr-receipt.mjs
@@ -23,18 +23,43 @@ export function hasReceiptComment(commentsJson) {
   return parsed.some((c) => c && typeof c.body === "string" && c.body.startsWith(DOGFOOD_MARKER));
 }
 
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * True iff `headRef` matches one of the space-separated shell-style globs
+ * (`*` wildcards only, e.g. `release/* chore/release-*`). Exempt branches are
+ * authored without a capturable agent session (release checkouts, CI chores),
+ * so enforcement must not block them. Keep patterns narrow: feature work must
+ * not be able to slip through.
+ */
+export function isExemptRef(headRef, exemptGlobs) {
+  if (!headRef || !exemptGlobs) {
+    return false;
+  }
+  return exemptGlobs
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((glob) => new RegExp(`^${glob.split("*").map(escapeRegExp).join(".*")}$`).test(headRef));
+}
+
 /**
  * Returns a workflow-friendly verdict.
  *
  * `found`: a marked aireceipts comment is present.
  * `missing-required`: same-repo PR missing a receipt and enforcement is enabled.
- * `missing-notice`: missing receipt in the default/advisory mode, or on a fork PR.
+ * `missing-notice`: missing receipt in the default/advisory mode, on a fork PR,
+ *   or on an exempt branch (`exemptGlobs` matched `headRef`).
  */
-export function receiptCheckVerdict(commentsJson, { headRepo = "", baseRepo = "", requireSameRepo = false } = {}) {
+export function receiptCheckVerdict(
+  commentsJson,
+  { headRepo = "", baseRepo = "", requireSameRepo = false, headRef = "", exemptGlobs = "" } = {},
+) {
   if (hasReceiptComment(commentsJson)) {
     return "found";
   }
-  if (requireSameRepo && headRepo && baseRepo && headRepo === baseRepo) {
+  if (requireSameRepo && headRepo && baseRepo && headRepo === baseRepo && !isExemptRef(headRef, exemptGlobs)) {
     return "missing-required";
   }
   return "missing-notice";
@@ -45,6 +70,8 @@ function parseArgs(argv) {
   let headRepo = "";
   let baseRepo = "";
   let requireSameRepo = false;
+  let headRef = "";
+  let exemptGlobs = "";
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--head-repo") {
@@ -61,15 +88,25 @@ function parseArgs(argv) {
       requireSameRepo = true;
       continue;
     }
+    if (arg === "--head-ref") {
+      headRef = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    if (arg === "--exempt-globs") {
+      exemptGlobs = argv[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
     if (!file) {
       file = arg;
     }
   }
-  return { file, headRepo, baseRepo, requireSameRepo };
+  return { file, headRepo, baseRepo, requireSameRepo, headRef, exemptGlobs };
 }
 
 function main(argv) {
-  const { file, headRepo, baseRepo, requireSameRepo } = parseArgs(argv);
+  const { file, headRepo, baseRepo, requireSameRepo, headRef, exemptGlobs } = parseArgs(argv);
   let json = "[]";
   try {
     json = file && file !== "-" ? readFileSync(file, "utf8") : readFileSync(0, "utf8");
@@ -77,7 +114,7 @@ function main(argv) {
     json = "[]";
   }
   if (headRepo || baseRepo) {
-    process.stdout.write(`${receiptCheckVerdict(json, { headRepo, baseRepo, requireSameRepo })}\n`);
+    process.stdout.write(`${receiptCheckVerdict(json, { headRepo, baseRepo, requireSameRepo, headRef, exemptGlobs })}\n`);
     return 0;
   }
   process.stdout.write(hasReceiptComment(json) ? "found\n" : "missing\n");

--- a/scripts/check-pr-receipt.mjs
+++ b/scripts/check-pr-receipt.mjs
@@ -23,8 +23,37 @@ export function hasReceiptComment(commentsJson) {
   return parsed.some((c) => c && typeof c.body === "string" && c.body.startsWith(DOGFOOD_MARKER));
 }
 
-function escapeRegExp(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+/**
+ * Anchored shell-style glob match (`*` wildcards only). Two-pointer scan with
+ * single backtrack-point, so worst case is O(text * glob): no RegExp, no
+ * catastrophic backtracking on pathological patterns like `release/*a*a*a*Z`
+ * (Codex review, 2026-07-13).
+ */
+function globMatch(text, glob) {
+  let t = 0;
+  let g = 0;
+  let star = -1;
+  let mark = 0;
+  while (t < text.length) {
+    if (g < glob.length && glob[g] === "*") {
+      star = g;
+      mark = t;
+      g += 1;
+    } else if (g < glob.length && glob[g] === text[t]) {
+      t += 1;
+      g += 1;
+    } else if (star !== -1) {
+      mark += 1;
+      t = mark;
+      g = star + 1;
+    } else {
+      return false;
+    }
+  }
+  while (g < glob.length && glob[g] === "*") {
+    g += 1;
+  }
+  return g === glob.length;
 }
 
 /**
@@ -41,13 +70,7 @@ export function isExemptRef(headRef, exemptGlobs) {
   return exemptGlobs
     .split(/\s+/)
     .filter(Boolean)
-    .some((glob) => {
-      // Collapse `*` runs: `a**b` and `a*b` match the same strings, and the
-      // collapsed form can't compile to adjacent `.*.*` (catastrophic
-      // backtracking on long non-matching refs).
-      const pattern = glob.replace(/\*+/g, "*").split("*").map(escapeRegExp).join(".*");
-      return new RegExp(`^${pattern}$`).test(headRef);
-    });
+    .some((glob) => globMatch(headRef, glob));
 }
 
 /**

--- a/specs/SPEC-0036-pr-receipt-presence-policy.md
+++ b/specs/SPEC-0036-pr-receipt-presence-policy.md
@@ -39,6 +39,13 @@ approval converted that implementation from provisional to accepted.
   (`head.repo.full_name == github.repository`) becomes `missing-required`; the workflow
   emits `::error::` and exits 1. The failure message must tell the author to run
   `npx aireceipts pr --post` locally and rerun the check.
+  Amendment (maintainer-directed, 2026-07-13): branches matching repository variable
+  `AIRECEIPTS_RECEIPT_EXEMPT_GLOBS` (space-separated anchored globs, `*` wildcards only;
+  the workflow defaults to `release/*` when the variable is unset) stay notice-only even
+  under enforcement. Release checkouts are authored without a capturable agent session,
+  so no receipt can exist for them; a hard requirement there would block every release
+  PR. Keep patterns narrow so feature work cannot slip through. The verdict logic lives
+  in `scripts/check-pr-receipt.mjs` (`isExemptRef`), gated by unit tests.
 - **R3 - Fork PRs remain notice-only.** Fork PRs never fail this check, even when R2 is
   enabled. The workflow may not assume a fork contributor has local agent sessions for
   the base repo, and it may not pressure them to upload transcripts.

--- a/specs/SPEC-0066-ci-post-from-ref.md
+++ b/specs/SPEC-0066-ci-post-from-ref.md
@@ -113,7 +113,8 @@ transports what the local hook produced.
 payload (injection-corpus golden), renders via `renderPrBody`, and upserts via
 `GITHUB_TOKEN` from a separate `post` job; the comment-marker back-compat path is unchanged.
 **Deferred (spec stays `building`):** R5's agent-built vs hand-written discrimination is not
-implemented. `scripts/check-pr-receipt.mjs` distinguishes only same-repo vs fork, so opt-in
-enforcement currently fails **any** same-repo PR missing a receipt — it does not yet skip a
-hand-written PR. Enforcement is opt-in and default-off, so this is a refinement, not a
-regression; the spec flips to `shipped` when the agent-evidence gate lands.
+implemented. `scripts/check-pr-receipt.mjs` distinguishes same-repo vs fork plus the
+SPEC-0036 R2 exempt-glob carve-out (maintainer-directed 2026-07-13, default `release/*`),
+so opt-in enforcement fails any non-exempt same-repo PR missing a receipt — it does not yet
+skip a hand-written PR. Enforcement is opt-in and default-off, so this is a refinement, not
+a regression; the spec flips to `shipped` when the agent-evidence gate lands.

--- a/src/pr/store.ts
+++ b/src/pr/store.ts
@@ -76,7 +76,7 @@ function git(args: string[], opts: GitOpts = {}): GitResult {
 export type WriteReceiptRefOutcome = { ok: true; ref: string; commit: string } | { ok: false; reason: string };
 
 /**
- * Write `json` as `receipt.json` on `refs/receipts/<slug>`, wrapped in a
+ * Write `json` as `receipt.json` on `refs/aireceipts/<slug>`, wrapped in a
  * commit dated `<epochSeconds> +0000` derived from `endedAtMs` (never
  * wall-clock) under a fixed identity — so the same `(slug, branch, json,
  * endedAtMs)` always produces the same commit SHA (SPEC-0065 R1/R6).
@@ -121,7 +121,7 @@ export function writeReceiptRef(slug: string, branch: string, json: string, ende
   return { ok: true, ref, commit: commitSha };
 }
 
-/** Read back `receipt.json` from `refs/receipts/<slug>`, or `null` when the ref or blob doesn't exist. */
+/** Read back `receipt.json` from `refs/aireceipts/<slug>`, or `null` when the ref or blob doesn't exist. */
 export function readReceiptRef(slug: string, cwd?: string): string | null {
   const result = git(["cat-file", "blob", `${receiptRef(slug)}:receipt.json`], { cwd });
   return result.ok ? result.out : null;

--- a/test/pr/check-pr-receipt.test.ts
+++ b/test/pr/check-pr-receipt.test.ts
@@ -90,6 +90,14 @@ describe("isExemptRef", () => {
     expect(isExemptRef("releaseXv1", "release.v*")).toBe(false);
     expect(isExemptRef("release.v1", "release.v*")).toBe(true);
   });
+
+  it("collapses `*` runs so pathological globs stay linear-time", () => {
+    const ref = `release/${"a".repeat(300)}`;
+    const started = performance.now();
+    expect(isExemptRef(ref, `release/${"*".repeat(8)}Z`)).toBe(false);
+    expect(performance.now() - started).toBeLessThan(200);
+    expect(isExemptRef("release/v1", "release/**")).toBe(true);
+  });
 });
 
 describe("marker parity", () => {

--- a/test/pr/check-pr-receipt.test.ts
+++ b/test/pr/check-pr-receipt.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   DOGFOOD_MARKER as SCRIPT_MARKER,
   hasReceiptComment,
+  isExemptRef,
   receiptCheckVerdict,
 } from "../../scripts/check-pr-receipt.mjs";
 import { DOGFOOD_MARKER as BODY_MARKER } from "../../src/pr/body.js";
@@ -54,6 +55,40 @@ describe("receiptCheckVerdict", () => {
       "missing-notice",
     );
     expect(receiptCheckVerdict("[]")).toBe("missing-notice");
+  });
+
+  it("keeps exempt branches notice-only under enforcement", () => {
+    const opts = { headRepo: "owner/repo", baseRepo: "owner/repo", requireSameRepo: true };
+    expect(receiptCheckVerdict("[]", { ...opts, headRef: "release/v0.10.0", exemptGlobs: "release/*" })).toBe(
+      "missing-notice",
+    );
+    expect(
+      receiptCheckVerdict("[]", { ...opts, headRef: "chore/release-v1", exemptGlobs: "release/* chore/release-*" }),
+    ).toBe("missing-notice");
+  });
+
+  it("still requires non-exempt branches under enforcement", () => {
+    const opts = { headRepo: "owner/repo", baseRepo: "owner/repo", requireSameRepo: true };
+    expect(receiptCheckVerdict("[]", { ...opts, headRef: "feat/x", exemptGlobs: "release/*" })).toBe(
+      "missing-required",
+    );
+    // No globs configured, or no head ref supplied: enforcement is unchanged.
+    expect(receiptCheckVerdict("[]", { ...opts, headRef: "release/v0.10.0" })).toBe("missing-required");
+    expect(receiptCheckVerdict("[]", { ...opts, exemptGlobs: "release/*" })).toBe("missing-required");
+  });
+});
+
+describe("isExemptRef", () => {
+  it("matches shell-style globs, anchored", () => {
+    expect(isExemptRef("release/v0.10.0", "release/*")).toBe(true);
+    expect(isExemptRef("feat/release/x", "release/*")).toBe(false);
+    expect(isExemptRef("release", "release/*")).toBe(false);
+    expect(isExemptRef("ci/nightly", "release/* ci/*")).toBe(true);
+  });
+
+  it("treats regex metacharacters in globs literally", () => {
+    expect(isExemptRef("releaseXv1", "release.v*")).toBe(false);
+    expect(isExemptRef("release.v1", "release.v*")).toBe(true);
   });
 });
 

--- a/test/pr/check-pr-receipt.test.ts
+++ b/test/pr/check-pr-receipt.test.ts
@@ -91,12 +91,14 @@ describe("isExemptRef", () => {
     expect(isExemptRef("release.v1", "release.v*")).toBe(true);
   });
 
-  it("collapses `*` runs so pathological globs stay linear-time", () => {
+  it("stays fast on pathological globs (no regex backtracking)", () => {
     const ref = `release/${"a".repeat(300)}`;
     const started = performance.now();
     expect(isExemptRef(ref, `release/${"*".repeat(8)}Z`)).toBe(false);
+    expect(isExemptRef(ref, "release/*a*a*a*a*Z")).toBe(false);
     expect(performance.now() - started).toBeLessThan(200);
     expect(isExemptRef("release/v1", "release/**")).toBe(true);
+    expect(isExemptRef("release/a1a2a3Z", "release/*a*a*a*Z")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Hardens the PR-receipt attach pipeline after a week-long silent outage (PRs #254/#255 shipped with no receipt).

Root cause: `core.hooksPath` was stored as an absolute path into the main checkout, and that checkout sat on a branch predating `.githooks/pre-push`. Every worktree resolved hooks against an empty directory, so no `refs/aireceipts/<slug>` was pushed, and the notice-only check stayed green through all of it.

Changes:

- **Exempt-glob enforcement support** (`scripts/check-pr-receipt.mjs`, workflow): `AIRECEIPTS_REQUIRE_PR_RECEIPT=true` can now be enabled without blocking release PRs. Branches matching `AIRECEIPTS_RECEIPT_EXEMPT_GLOBS` (default `release/*`) stay notice-only. Matching is a linear-time two-pointer glob scan: no RegExp, no backtracking blowup. SPEC-0036 R2 carries the maintainer-directed (2026-07-13) amendment; SPEC-0066's status note updated.
- **hooksPath self-heal** (`.claude/hooks/ensure-githooks.sh`, SessionStart): bound to `$CLAUDE_PROJECT_DIR` only, repairs only unset or stale absolute `.githooks` values, preserves custom hooks managers (husky, dispatchers) with a NOTE, warns when the resolved hooks dir lacks an executable `pre-push`, always exits 0.
- **Comment hygiene**: stale `refs/receipts/<slug>` mentions corrected to `refs/aireceipts/<slug>` in `.githooks/pre-push`, the workflow header, and `src/pr/store.ts` docs.

Codex review: initial BLOCK (1 blocker, 2 majors, 2 minors) plus 1 residual major on re-verify; all six findings fixed and behavior-simulated (poison repaired, husky and relative custom paths preserved, non-repo/unset-var paths silent).

## Evidence

- `npx tsc --noEmit` 0, `npx eslint . --max-warnings 0` 0, `npx vitest run` 2202/2202, `node scripts/verify-goldens.mjs` 102 byte-identical, determinism x10 OK, spec-lint 78 OK, hygiene OK.
- Live proof on this very branch: the push of this PR fired the repaired pre-push hook and `refs/aireceipts/fix-pr-receipt-attach-hardening` reached origin, the first receipt ref since the outage began. Receipt: `npx aireceipts-cli pr --post` (or CI posts from the ref).

## Follow-ups (not in this PR)

- Flip `AIRECEIPTS_REQUIRE_PR_RECEIPT=true` + make the `post` check required after merge.
- Stale-comment head-SHA matching (a pre-existing comment satisfies the check regardless of head).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
